### PR TITLE
DrumsOneHotConverter

### DIFF
--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -220,8 +220,8 @@ export class DrumRollConverter extends DrumsConverter {
  * The `Tensor` output by `toTensor` is a 2D one-hot encoding. Each
  * row is a time step, and each column is a one-hot vector where each drum
  * combination is mapped to a single bit of a binary integer representation,
- * where the bit has value 0 if the drum type is not present, and 1 if it is
- * present.
+ * where the bit has value 0 if the drum combination is not present, and 1 if
+ * it is present.
  *
  * The expected `Tensor` in `toNoteSequence` is the same kind of one-hot
  * encoding as the `Tensor` output by `toTensor`.
@@ -229,13 +229,6 @@ export class DrumRollConverter extends DrumsConverter {
  * The output `NoteSequence` uses quantized time and only the first pitch in
  * pitch class are used.
  *
- * @param numSteps The length of each sequence.
- * @param numSegments (Optional) The number of conductor segments, if
- * applicable.
- * @param pitchClasses (Optional) An array of arrays, grouping together MIDI
- * pitches to treat as the same drum. The first pitch in each class will be used
- * in the `NoteSequence` returned by `toNoteSequence`. A default mapping to 9
- * classes is used if not provided.
  */
 export class DrumsOneHotConverter extends DrumsConverter {
   readonly depth: number;
@@ -277,12 +270,12 @@ export class DrumsOneHotConverter extends DrumsConverter {
       const bin = (labels[s] >>> 0).toString(2);
       for (let i = bin.length - 1; i >= 0; i--) {
         if (bin[i] === '1') {
-          noteSequence.notes.push(
-            NoteSequence.Note.create({
-              pitch: this.pitchClasses[bin.length - i - 1][0],
-              quantizedStartStep: s,
-              quantizedEndStep: s + 1,
-            isDrum: true}));
+          noteSequence.notes.push(NoteSequence.Note.create({
+            pitch: this.pitchClasses[bin.length - i - 1][0],
+            quantizedStartStep: s,
+            quantizedEndStep: s + 1,
+            isDrum: true
+          }));
         }
       }
     }

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -280,7 +280,8 @@ export class DrumsOneHotConverter extends DrumsConverter {
             NoteSequence.Note.create({
               pitch: this.pitchClasses[bin.length - i - 1][0],
               quantizedStartStep: s,
-              quantizedEndStep: s + 1}));
+              quantizedEndStep: s + 1,
+            isDrum: true}));
         }
       }
     }

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -247,11 +247,11 @@ export class DrumsOneHotConverter extends DrumsConverter {
   toTensor(noteSequence: INoteSequence) {
     const numSteps = this.numSteps || noteSequence.totalQuantizedSteps;
     const indexes = this.toOneHotIndexes(noteSequence);
-    const drumRoll = tf.buffer([numSteps, 2 ** this.pitchClasses.length]);
+    const buffer = tf.buffer([numSteps, 2 ** this.pitchClasses.length]);
     indexes.forEach((index, quantizedStartStep) => {
-      drumRoll.set(1, quantizedStartStep, index);
+      buffer.set(1, quantizedStartStep, index);
     });
-    return drumRoll.toTensor() as tf.Tensor2D;
+    return buffer.toTensor() as tf.Tensor2D;
   }
 
   private toOneHotIndexes(noteSequence: INoteSequence): Map<number, number> {

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -217,9 +217,10 @@ export class DrumRollConverter extends DrumsConverter {
  * and the `Tensor` objects used by `MusicRNN`.
  *
  * The `Tensor` output by `toTensor` is a 2D one-hot encoding. Each
- * row is a time step, and each column is a one-hot vector where each drum type
- * is mapped to a single bit of a binary integer representation, where the
- * bit has value 0 if the drum type is not present, and 1 if it is present.
+ * row is a time step, and each column is a one-hot vector where each drum
+ * combination is mapped to a single bit of a binary integer representation,
+ * where the bit has value 0 if the drum type is not present, and 1 if it is
+ * present.
  *
  * The expected `Tensor` in `toNoteSequence` is the same kind of one-hot
  * encoding as the `Tensor` output by `toTensor`.

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -237,9 +237,11 @@ export class DrumRollConverter extends DrumsConverter {
  * classes is used if not provided.
  */
 export class DrumsOneHotConverter extends DrumsConverter {
+  readonly depth: number;
 
   constructor(args: DrumsConverterArgs) {
     super(args);
+    this.depth = 2 ** this.pitchClasses.length;
   }
 
   toTensor(noteSequence: INoteSequence) {

--- a/music_rnn/src/model.ts
+++ b/music_rnn/src/model.ts
@@ -36,15 +36,6 @@ export class MusicRNN {
   forgetBias: tf.Scalar;
   biasShapes: number[];
 
-  attnInputMatrix?: tf.Tensor2D;
-  attnInputBias?: tf.Tensor1D;
-  attnW?:  tf.Tensor4D;
-  attnV?: tf.Tensor2D;
-  attnMatrix?: tf.Tensor2D;
-  attnBias?: tf.Tensor1D;
-  attnOutputMatrix?: tf.Tensor2D;
-  attnOutputBias?: tf.Tensor1D;
-
   rawVars: {[varName: string]: tf.Tensor};  // Store for disposal.
 
   initialized: boolean;
@@ -84,8 +75,7 @@ export class MusicRNN {
 
     const reader = new magenta.CheckpointLoader(this.checkpointURL);
     const vars = await reader.getAllVariables();
-    const hasAttention = 'rnn/attention_cell_wrapper/kernel' in vars;
-    const rnnPrefix = hasAttention ? 'rnn/attention_cell_wrapper/' : 'rnn/';
+    const rnnPrefix = 'rnn/';
 
     this.forgetBias = tf.scalar(1.0);
 
@@ -108,19 +98,6 @@ export class MusicRNN {
 
     this.lstmFcW = vars['fully_connected/weights'] as tf.Tensor2D;
     this.lstmFcB = vars['fully_connected/biases'] as tf.Tensor1D;
-
-    if (hasAttention) {
-      this.attnInputMatrix = vars[rnnPrefix + 'kernel'] as tf.Tensor2D;
-      this.attnInputBias = vars[rnnPrefix + 'bias'] as tf.Tensor1D;
-      this.attnW = vars[rnnPrefix + 'attention/attn_w'] as tf.Tensor4D;
-      this.attnV = vars[rnnPrefix + 'attention/attn_v'] as tf.Tensor2D;
-      this.attnMatrix = vars[rnnPrefix + 'attention/kernel'] as tf.Tensor2D;
-      this.attnBias = vars[rnnPrefix + 'attention/bias'] as tf.Tensor1D;
-      this.attnOutputMatrix =
-        vars[rnnPrefix + 'attention_output_projection/kernel'] as tf.Tensor2D;
-      this.attnOutputBias =
-        vars[rnnPrefix + 'attention_output_projection/bias'] as tf.Tensor1D;
-    }
 
     this.rawVars = vars;
     this.initialized = true;
@@ -156,9 +133,7 @@ export class MusicRNN {
     const oh = tf.tidy(() => {
       const inputs = this.dataConverter.toTensor(sequence);
       const outputSize:number = inputs.shape[1];
-      const samples = this.attnMatrix ?
-        this.sampleRnnWithAttention(inputs, steps, temperature) :
-        this.sampleRnn(inputs, steps, temperature);
+      const samples = this.sampleRnn(inputs, steps, temperature);
       return tf.stack(samples).as2D(samples.length, outputSize);
     });
 
@@ -196,117 +171,6 @@ export class MusicRNN {
           samples.push(nextInput.as1D().toBool());
       }
       [c, h] = tf.multiRNNCell(this.lstmCells, nextInput, c, h);
-    }
-    return samples;
-  }
-
-  private sampleRnnWithAttention(inputs: tf.Tensor2D,
-                                 steps: number,
-                                 temperature: number) {
-    const length:number = inputs.shape[0];
-    const outputSize:number = inputs.shape[1];
-
-    let c: tf.Tensor2D[] = [];
-    let h: tf.Tensor2D[] = [];
-    for (let i = 0; i < this.biasShapes.length; i++) {
-      c.push(tf.zeros([1, this.biasShapes[i] / 4]));
-      h.push(tf.zeros([1, this.biasShapes[i] / 4]));
-    }
-    const attnSize = this.biasShapes[0] / 4;
-    const attnLength = 32;
-    const numCounterBits = 6;
-
-    let attention: tf.Tensor1D = tf.zeros([attnSize]);
-    let attentionState: tf.Tensor2D = tf.zeros([1, attnSize * attnLength]);
-    let lastOutput: tf.Tensor2D;
-
-    // Initialize with input.
-    const samples: tf.Tensor1D[] = [];
-    for (let i = 0; i < length + steps; i++) {
-      let nextInput: tf.Tensor2D;
-      if (i < length) {
-        nextInput = inputs.slice([i, 0], [1, outputSize]).as2D(1, outputSize);
-      } else {
-        const logits = lastOutput.matMul(this.lstmFcW).add(this.lstmFcB);
-        const sampledOutput = (
-          temperature ?
-          tf.multinomial(logits.div(tf.scalar(temperature)), 1).as1D():
-          logits.argMax(1).as1D());
-        nextInput = tf.oneHot(sampledOutput, outputSize).toFloat();
-        // Save samples as bool to reduce data sync time.
-        samples.push(nextInput.as1D().toBool());
-      }
-
-      const binaryCounts = tf.buffer([1, numCounterBits]);
-      for (let bit = 0; bit < numCounterBits; bit++) {
-        const counterValue = Math.floor((i + 1) / 2 ** bit) % 2 ? 1.0 : -1.0;
-        binaryCounts.set(counterValue, 0, bit);
-      }
-      nextInput = nextInput.concat(binaryCounts.toTensor(), 1) as tf.Tensor2D;
-
-      const nextAttnInput = tf.concat([nextInput, attention.as2D(1, -1)], 1);
-      const nextRnnInput: tf.Tensor2D = tf.add(
-        tf.matMul(nextAttnInput, this.attnInputMatrix),
-        this.attnInputBias.as2D(1, -1)
-      );
-      [c, h] = tf.multiRNNCell(this.lstmCells, nextRnnInput, c, h);
-
-      const attnHidden: tf.Tensor4D = tf.reshape(
-        attentionState,
-        [-1, attnLength, 1, attnSize]
-      );
-      const attnHiddenFeatures = tf.conv2d(
-        attnHidden,
-        this.attnW,
-        [1, 1],
-        'same'
-      );
-      const attnQueryParts = [];
-      for (let q = 0 ; q < c.length ; q++) {
-        attnQueryParts.push(c[q]);
-        attnQueryParts.push(h[q]);
-      }
-      const attnQuery = tf.concat(attnQueryParts, 1);
-      const attnY = tf
-        .matMul(attnQuery, this.attnMatrix)
-        .reshape([-1, 1, 1, attnSize]);
-      const attnS = tf.sum(
-        tf.mul(this.attnV, tf.tanh(tf.add(attnHiddenFeatures, attnY))),
-        [2, 3]
-      );
-      const attnA = tf.softmax(attnS);
-      const attnD = tf.sum(
-        tf.mul(tf.reshape(attnA, [-1, attnLength, 1, 1]), attnHidden),
-        [1, 2]
-      );
-      const newAttns: tf.Tensor2D = attnD.reshape([-1, attnSize]);
-
-      const attnStates = attentionState.reshape([
-        -1,
-        attnLength,
-        attnSize
-      ]);
-      const newAttnStates = tf.slice(
-        attnStates,
-        [0, 1, 0],
-        [attnStates.shape[0], attnStates.shape[1] - 1, attnStates.shape[2]]
-      );
-
-      lastOutput = tf.add(
-        tf.matMul(tf.concat([h[2], newAttns], 1), this.attnOutputMatrix),
-        this.attnOutputBias
-      );
-
-      attention = newAttns.flatten();
-      attentionState = tf
-        .concat(
-          [
-            newAttnStates,
-            lastOutput.as3D(lastOutput.shape[0], 1, lastOutput.shape[1])
-          ],
-          1
-        )
-        .reshape([-1, attnLength * attnSize]);
     }
     return samples;
   }

--- a/music_rnn/src/model.ts
+++ b/music_rnn/src/model.ts
@@ -19,7 +19,7 @@ import * as magenta from '@magenta/core';
 import tf = magenta.tf;
 import { isNullOrUndefined } from 'util';
 
-const CELL_FORMAT = "rnn/multi_rnn_cell/cell_%d/basic_lstm_cell/";
+const CELL_FORMAT = "multi_rnn_cell/cell_%d/basic_lstm_cell/";
 
 /**
  * Main MusicRNN model class.
@@ -35,6 +35,16 @@ export class MusicRNN {
   lstmFcW: tf.Tensor2D;
   forgetBias: tf.Scalar;
   biasShapes: number[];
+
+  attnInputMatrix?: tf.Tensor2D;
+  attnInputBias?: tf.Tensor1D;
+  attnW?:  tf.Tensor4D;
+  attnV?: tf.Tensor2D;
+  attnMatrix?: tf.Tensor2D;
+  attnBias?: tf.Tensor1D;
+  attnOutputMatrix?: tf.Tensor2D;
+  attnOutputBias?: tf.Tensor1D;
+
   rawVars: {[varName: string]: tf.Tensor};  // Store for disposal.
 
   initialized: boolean;
@@ -74,6 +84,8 @@ export class MusicRNN {
 
     const reader = new magenta.CheckpointLoader(this.checkpointURL);
     const vars = await reader.getAllVariables();
+    const hasAttention = 'rnn/attention_cell_wrapper/kernel' in vars;
+    const rnnPrefix = hasAttention ? 'rnn/attention_cell_wrapper/' : 'rnn/';
 
     this.forgetBias = tf.scalar(1.0);
 
@@ -81,11 +93,10 @@ export class MusicRNN {
     this.biasShapes.length = 0;
     let l = 0;
     while (true) {
-      const cellPrefix = CELL_FORMAT.replace('%d', l.toString());
+      const cellPrefix = rnnPrefix + CELL_FORMAT.replace('%d', l.toString());
       if (!(cellPrefix + 'kernel' in vars)) {
           break;
       }
-      // TODO(fjord): Support attention model.
       this.lstmCells.push(
         (data: tf.Tensor2D, c: tf.Tensor2D, h: tf.Tensor2D) =>
             tf.basicLSTMCell(this.forgetBias,
@@ -97,6 +108,19 @@ export class MusicRNN {
 
     this.lstmFcW = vars['fully_connected/weights'] as tf.Tensor2D;
     this.lstmFcB = vars['fully_connected/biases'] as tf.Tensor1D;
+
+    if (hasAttention) {
+      this.attnInputMatrix = vars[rnnPrefix + 'kernel'] as tf.Tensor2D;
+      this.attnInputBias = vars[rnnPrefix + 'bias'] as tf.Tensor1D;
+      this.attnW = vars[rnnPrefix + 'attention/attn_w'] as tf.Tensor4D;
+      this.attnV = vars[rnnPrefix + 'attention/attn_v'] as tf.Tensor2D;
+      this.attnMatrix = vars[rnnPrefix + 'attention/kernel'] as tf.Tensor2D;
+      this.attnBias = vars[rnnPrefix + 'attention/bias'] as tf.Tensor1D;
+      this.attnOutputMatrix =
+        vars[rnnPrefix + 'attention_output_projection/kernel'] as tf.Tensor2D;
+      this.attnOutputBias =
+        vars[rnnPrefix + 'attention_output_projection/bias'] as tf.Tensor1D;
+    }
 
     this.rawVars = vars;
     this.initialized = true;
@@ -131,36 +155,10 @@ export class MusicRNN {
 
     const oh = tf.tidy(() => {
       const inputs = this.dataConverter.toTensor(sequence);
-
-      const length:number = inputs.shape[0];
       const outputSize:number = inputs.shape[1];
-
-      let c: tf.Tensor2D[] = [];
-      let h: tf.Tensor2D[] = [];
-      for (let i = 0; i < this.biasShapes.length; i++) {
-        c.push(tf.zeros([1, this.biasShapes[i] / 4]));
-        h.push(tf.zeros([1, this.biasShapes[i] / 4]));
-      }
-
-      // Initialize with input.
-      const samples: tf.Tensor1D[] = [];
-      for (let i = 0; i < length + steps; i++) {
-        let nextInput: tf.Tensor2D;
-        if (i < length) {
-          nextInput = inputs.slice([i, 0], [1, outputSize]).as2D(1, outputSize);
-        } else {
-          const logits = h[h.length - 1].matMul(this.lstmFcW).add(this.lstmFcB);
-          const sampledOutput = (
-            temperature ?
-            tf.multinomial(logits.div(tf.scalar(temperature)), 1).as1D():
-            logits.argMax(1).as1D());
-          nextInput = tf.oneHot(sampledOutput, outputSize).toFloat();
-          // Save samples as bool to reduce data sync time.
-          samples.push(nextInput.as1D().toBool());
-        }
-        [c, h] = tf.multiRNNCell(this.lstmCells, nextInput, c, h);
-      }
-
+      const samples = this.attnMatrix ?
+        this.sampleRnnWithAttention(inputs, steps, temperature) :
+        this.sampleRnn(inputs, steps, temperature);
       return tf.stack(samples).as2D(samples.length, outputSize);
     });
 
@@ -168,4 +166,149 @@ export class MusicRNN {
     oh.dispose();
     return result;
   }
+
+  private sampleRnn(inputs: tf.Tensor2D, steps: number, temperature: number) {
+    const length:number = inputs.shape[0];
+    const outputSize:number = inputs.shape[1];
+
+    let c: tf.Tensor2D[] = [];
+    let h: tf.Tensor2D[] = [];
+    for (let i = 0; i < this.biasShapes.length; i++) {
+      c.push(tf.zeros([1, this.biasShapes[i] / 4]));
+      h.push(tf.zeros([1, this.biasShapes[i] / 4]));
+    }
+
+    // Initialize with input.
+    const samples: tf.Tensor1D[] = [];
+    for (let i = 0; i < length + steps; i++) {
+      let nextInput: tf.Tensor2D;
+      if (i < length) {
+        nextInput = inputs.slice([i, 0], [1, outputSize]).as2D(1, outputSize);
+      } else {
+        const logits = h[h.length - 1].matMul(this.lstmFcW).add(this.lstmFcB);
+        const sampledOutput = (
+          temperature ?
+          tf.multinomial(tf.softmax(logits.div(tf.scalar(temperature))), 1)
+            .as1D():
+          logits.argMax(1).as1D());
+        nextInput = tf.oneHot(sampledOutput, outputSize).toFloat();
+        // Save samples as bool to reduce data sync time.
+          samples.push(nextInput.as1D().toBool());
+      }
+      [c, h] = tf.multiRNNCell(this.lstmCells, nextInput, c, h);
+    }
+    return samples;
+  }
+
+  private sampleRnnWithAttention(inputs: tf.Tensor2D,
+                                 steps: number,
+                                 temperature: number) {
+    const length:number = inputs.shape[0];
+    const outputSize:number = inputs.shape[1];
+
+    let c: tf.Tensor2D[] = [];
+    let h: tf.Tensor2D[] = [];
+    for (let i = 0; i < this.biasShapes.length; i++) {
+      c.push(tf.zeros([1, this.biasShapes[i] / 4]));
+      h.push(tf.zeros([1, this.biasShapes[i] / 4]));
+    }
+    const attnSize = this.biasShapes[0] / 4;
+    const attnLength = 32;
+    const numCounterBits = 6;
+
+    let attention: tf.Tensor1D = tf.zeros([attnSize]);
+    let attentionState: tf.Tensor2D = tf.zeros([1, attnSize * attnLength]);
+    let lastOutput: tf.Tensor2D;
+
+    // Initialize with input.
+    const samples: tf.Tensor1D[] = [];
+    for (let i = 0; i < length + steps; i++) {
+      let nextInput: tf.Tensor2D;
+      if (i < length) {
+        nextInput = inputs.slice([i, 0], [1, outputSize]).as2D(1, outputSize);
+      } else {
+        const logits = lastOutput.matMul(this.lstmFcW).add(this.lstmFcB);
+        const sampledOutput = (
+          temperature ?
+          tf.multinomial(logits.div(tf.scalar(temperature)), 1).as1D():
+          logits.argMax(1).as1D());
+        nextInput = tf.oneHot(sampledOutput, outputSize).toFloat();
+        // Save samples as bool to reduce data sync time.
+        samples.push(nextInput.as1D().toBool());
+      }
+
+      const binaryCounts = tf.buffer([1, numCounterBits]);
+      for (let bit = 0; bit < numCounterBits; bit++) {
+        const counterValue = Math.floor((i + 1) / 2 ** bit) % 2 ? 1.0 : -1.0;
+        binaryCounts.set(counterValue, 0, bit);
+      }
+      nextInput = nextInput.concat(binaryCounts.toTensor(), 1) as tf.Tensor2D;
+
+      const nextAttnInput = tf.concat([nextInput, attention.as2D(1, -1)], 1);
+      const nextRnnInput: tf.Tensor2D = tf.add(
+        tf.matMul(nextAttnInput, this.attnInputMatrix),
+        this.attnInputBias.as2D(1, -1)
+      );
+      [c, h] = tf.multiRNNCell(this.lstmCells, nextRnnInput, c, h);
+
+      const attnHidden: tf.Tensor4D = tf.reshape(
+        attentionState,
+        [-1, attnLength, 1, attnSize]
+      );
+      const attnHiddenFeatures = tf.conv2d(
+        attnHidden,
+        this.attnW,
+        [1, 1],
+        'same'
+      );
+      const attnQueryParts = [];
+      for (let q = 0 ; q < c.length ; q++) {
+        attnQueryParts.push(c[q]);
+        attnQueryParts.push(h[q]);
+      }
+      const attnQuery = tf.concat(attnQueryParts, 1);
+      const attnY = tf
+        .matMul(attnQuery, this.attnMatrix)
+        .reshape([-1, 1, 1, attnSize]);
+      const attnS = tf.sum(
+        tf.mul(this.attnV, tf.tanh(tf.add(attnHiddenFeatures, attnY))),
+        [2, 3]
+      );
+      const attnA = tf.softmax(attnS);
+      const attnD = tf.sum(
+        tf.mul(tf.reshape(attnA, [-1, attnLength, 1, 1]), attnHidden),
+        [1, 2]
+      );
+      const newAttns: tf.Tensor2D = attnD.reshape([-1, attnSize]);
+
+      const attnStates = attentionState.reshape([
+        -1,
+        attnLength,
+        attnSize
+      ]);
+      const newAttnStates = tf.slice(
+        attnStates,
+        [0, 1, 0],
+        [attnStates.shape[0], attnStates.shape[1] - 1, attnStates.shape[2]]
+      );
+
+      lastOutput = tf.add(
+        tf.matMul(tf.concat([h[2], newAttns], 1), this.attnOutputMatrix),
+        this.attnOutputBias
+      );
+
+      attention = newAttns.flatten();
+      attentionState = tf
+        .concat(
+          [
+            newAttnStates,
+            lastOutput.as3D(lastOutput.shape[0], 1, lastOutput.shape[1])
+          ],
+          1
+        )
+        .reshape([-1, attnLength * attnSize]);
+    }
+    return samples;
+  }
+
 }


### PR DESCRIPTION
Add a `DrumsOneHotConverter` for the one-hot encoding used by drums-rnn.

Expects `converter.json` for drums-rnn to specify the new one-hot multidrum encoding, like:

```
{
  "type": "DrumsOneHotConverter",
  "args": {
    "pitchClasses": null,
    "numSteps": null
  }
}
````

Related to #10, #14 