### PR TITLE
create control signals from JSON spec (besides actual chords)

### DIFF
--- a/core/src/chords.ts
+++ b/core/src/chords.ts
@@ -114,9 +114,8 @@ export abstract class ChordEncoder {
   abstract encode(chord: string): tf.Tensor1D;
 }
 
-export type ChordEncoderType = 'MajorMinorChordEncoder' |
-                               'TriadChordEncoder' |
-                               'PitchChordEncoder';
+export type ChordEncoderType =
+    'MajorMinorChordEncoder' | 'TriadChordEncoder' | 'PitchChordEncoder';
 
 /**
  * Creates a `ChordEncoder` based on the given `ChordEncoderType`.
@@ -126,10 +125,14 @@ export type ChordEncoderType = 'MajorMinorChordEncoder' |
  */
 export function chordEncoderFromType(type: ChordEncoderType) {
   switch (type) {
-    case 'MajorMinorChordEncoder': return new MajorMinorChordEncoder();
-    case 'TriadChordEncoder': return new TriadChordEncoder();
-    case 'PitchChordEncoder': return new PitchChordEncoder();
-    default: throw new Error(`Unknown chord encoder type: ${type}`);
+    case 'MajorMinorChordEncoder':
+      return new MajorMinorChordEncoder();
+    case 'TriadChordEncoder':
+      return new TriadChordEncoder();
+    case 'PitchChordEncoder':
+      return new PitchChordEncoder();
+    default:
+      throw new Error(`Unknown chord encoder type: ${type}`);
   }
 }
 

--- a/core/src/chords.ts
+++ b/core/src/chords.ts
@@ -114,6 +114,25 @@ export abstract class ChordEncoder {
   abstract encode(chord: string): tf.Tensor1D;
 }
 
+export type ChordEncoderType = 'MajorMinorChordEncoder' |
+                               'TriadChordEncoder' |
+                               'PitchChordEncoder';
+
+/**
+ * Creates a `ChordEncoder` based on the given `ChordEncoderType`.
+ *
+ * @param type Specifies the `ChordEncoder` to create.
+ * @returns A new `ChordEncoder` object based on `type`.
+ */
+export function chordEncoderFromType(type: ChordEncoderType) {
+  switch (type) {
+    case 'MajorMinorChordEncoder': return new MajorMinorChordEncoder();
+    case 'TriadChordEncoder': return new TriadChordEncoder();
+    case 'PitchChordEncoder': return new PitchChordEncoder();
+    default: throw new Error(`Unknown chord encoder type: ${type}`);
+  }
+}
+
 /**
  * ChordEncoder that outputs a one-hot encoding over major and minor triads.
  */

--- a/core/src/chords_test.ts
+++ b/core/src/chords_test.ts
@@ -87,7 +87,7 @@ test('Test Chord Quality', (t: test.Test) => {
 });
 
 test('Test Major/Minor Chord Encoder', (t: test.Test) => {
-  const e = new chords.MajorMinorChordEncoder();
+  const e = chords.chordEncoderFromType('MajorMinorChordEncoder');
   t.equal(e.depth, 25);
   t.deepEqual(e.encode('G').shape, [25]);
   t.equal(tf.argMax(e.encode('N.C.')).dataSync()[0], 0);
@@ -101,7 +101,7 @@ test('Test Major/Minor Chord Encoder', (t: test.Test) => {
 });
 
 test('Test Triad Chord Encoder', (t: test.Test) => {
-  const e = new chords.TriadChordEncoder();
+  const e = chords.chordEncoderFromType('TriadChordEncoder');
   t.equal(e.depth, 49);
   t.deepEqual(e.encode('G').shape, [49]);
   t.equal(tf.argMax(e.encode('N.C.')).dataSync()[0], 0);
@@ -115,7 +115,7 @@ test('Test Triad Chord Encoder', (t: test.Test) => {
 });
 
 test('Test Pitch Chord Encoder', (t: test.Test) => {
-  const e = new chords.PitchChordEncoder();
+  const e = chords.chordEncoderFromType('PitchChordEncoder');
   t.equal(e.depth, 37);
   t.deepEqual(e.encode('G').shape, [37]);
   t.deepEqual(e.encode('N.C.').dataSync(), [

--- a/core/src/controls.ts
+++ b/core/src/controls.ts
@@ -97,7 +97,6 @@ export class BinaryCounter extends ControlSignal<BinaryCounterUserArgs> {
 /**
  * Chord progression control signal.
  *
- * @param numSteps The length of the control signal.
  * @param encoderType The chord encoder type to use.
  */
 export class ChordProgression extends ControlSignal<ChordProgressionUserArgs> {

--- a/core/src/controls.ts
+++ b/core/src/controls.ts
@@ -25,7 +25,7 @@ export interface BinaryCounterSpec {
   type: 'BinaryCounter';
   args: BinaryCounterArgs;
 }
-export type BinaryCounterUserArgs = {};
+export type BinaryCounterUserArgs = void;
 
 export type ChordProgressionArgs = {
   encoderType: ChordEncoderType
@@ -67,9 +67,9 @@ export function controlSignalFromSpec(spec: ControlSignalSpec) {
  *
  * @param depth The size of the control tensor at each step.
  */
-export abstract class ControlSignal<T> {
+export abstract class ControlSignal<A extends ControlSignalUserArgs> {
   readonly depth: number;  // Size of final output dimension.
-  abstract getTensors(numSteps: number, args: T): tf.Tensor2D;
+  abstract getTensors(numSteps: number, args: A): tf.Tensor2D;
 
   constructor(depth: number) { this.depth = depth; }
 }

--- a/core/src/controls.ts
+++ b/core/src/controls.ts
@@ -18,23 +18,29 @@
 import * as tf from '@tensorflow/tfjs';
 import {ChordEncoder, ChordEncoderType, chordEncoderFromType} from './chords';
 
-export type BinaryCounterArgs = {numBits: number};
+export type BinaryCounterArgs = {
+  numBits: number
+};
 export interface BinaryCounterSpec {
   type: 'BinaryCounter';
   args: BinaryCounterArgs;
 }
 export type BinaryCounterUserArgs = {};
 
-export type ChordProgressionArgs = {encoderType: ChordEncoderType};
+export type ChordProgressionArgs = {
+  encoderType: ChordEncoderType
+};
 export interface ChordProgressionSpec {
   type: 'ChordProgression';
   args: ChordProgressionArgs;
 }
-export type ChordProgressionUserArgs = {chords:string[]};
+export type ChordProgressionUserArgs = {
+  chords: string[]
+};
 
 export type ControlSignalSpec = BinaryCounterSpec | ChordProgressionSpec;
-export type ControlSignalUserArgs = BinaryCounterUserArgs |
-                                    ChordProgressionUserArgs;
+export type ControlSignalUserArgs =
+    BinaryCounterUserArgs | ChordProgressionUserArgs;
 
 /**
  * Creates a `ControlSignal` based on the given `ControlSignalSpec`.
@@ -42,15 +48,17 @@ export type ControlSignalUserArgs = BinaryCounterUserArgs |
  * @param type Specifies the `ControlSignal` to create.
  * @returns A new `ControlSignal` object based on `spec`.
  */
-export function controlSignalFromSpec(
-    spec: BinaryCounterSpec) : BinaryCounter;
-export function controlSignalFromSpec(
-    spec: ChordProgressionSpec) : ChordProgression;
+export function controlSignalFromSpec(spec: BinaryCounterSpec): BinaryCounter;
+export function controlSignalFromSpec(spec: ChordProgressionSpec):
+    ChordProgression;
 export function controlSignalFromSpec(spec: ControlSignalSpec) {
   switch (spec.type) {
-    case 'BinaryCounter': return new BinaryCounter(spec.args);
-    case 'ChordProgression': return new ChordProgression(spec.args);
-    default: throw new Error(`Unknown control signal: ${spec}`);
+    case 'BinaryCounter':
+      return new BinaryCounter(spec.args);
+    case 'ChordProgression':
+      return new ChordProgression(spec.args);
+    default:
+      throw new Error(`Unknown control signal: ${spec}`);
   }
 }
 
@@ -60,12 +68,10 @@ export function controlSignalFromSpec(spec: ControlSignalSpec) {
  * @param depth The size of the control tensor at each step.
  */
 export abstract class ControlSignal<T> {
-  readonly depth: number;     // Size of final output dimension.
+  readonly depth: number;  // Size of final output dimension.
   abstract getTensors(numSteps: number, args: T): tf.Tensor2D;
 
-  constructor(depth: number) {
-    this.depth = depth;
-  }
+  constructor(depth: number) { this.depth = depth; }
 }
 
 /**
@@ -118,9 +124,10 @@ export class ChordProgression extends ControlSignal<ChordProgressionUserArgs> {
    */
   getTensors(numSteps: number, args: ChordProgressionUserArgs) {
     const encodedChords = args.chords.map(chord => this.encoder.encode(chord));
-    const indices = Array.from(Array(numSteps).keys()).map(
-        step => Math.floor(step * encodedChords.length / numSteps));
-    return tf.stack(
-        indices.map(i => encodedChords[i])).as2D(numSteps, this.depth);
+    const indices =
+        Array.from(Array(numSteps).keys())
+            .map(step => Math.floor(step * encodedChords.length / numSteps));
+    return tf.stack(indices.map(i => encodedChords[i]))
+        .as2D(numSteps, this.depth);
   }
 }

--- a/core/src/controls_test.ts
+++ b/core/src/controls_test.ts
@@ -21,10 +21,8 @@ import * as chords from './chords';
 import * as controls from './controls';
 
 test('Test Binary Counter', (t: test.Test) => {
-  const spec : controls.BinaryCounterSpec = {
-    type: 'BinaryCounter',
-    args: {numBits: 2}
-  };
+  const spec:
+      controls.BinaryCounterSpec = {type: 'BinaryCounter', args: {numBits: 2}};
   const bc = controls.controlSignalFromSpec(spec);
   const tensors = bc.getTensors(5, {});
   t.equal(bc.depth, 2);
@@ -38,7 +36,7 @@ test('Test Binary Counter', (t: test.Test) => {
 });
 
 test('Test Chord Progression', (t: test.Test) => {
-  const spec : controls.ChordProgressionSpec = {
+  const spec: controls.ChordProgressionSpec = {
     type: 'ChordProgression',
     args: {encoderType: 'MajorMinorChordEncoder'}
   };

--- a/core/src/controls_test.ts
+++ b/core/src/controls_test.ts
@@ -26,7 +26,7 @@ test('Test Binary Counter', (t: test.Test) => {
     args: {numBits: 2}
   };
   const bc = controls.controlSignalFromSpec(spec);
-  const tensors = bc.getTensors({numSteps: 5});
+  const tensors = bc.getTensors(5, {});
   t.equal(bc.depth, 2);
   t.deepEqual(tensors.shape, [5, 2]);
   t.deepEqual(tf.gather(tensors, tf.tensor([0])).dataSync(), [-1.0, -1.0]);
@@ -43,8 +43,7 @@ test('Test Chord Progression', (t: test.Test) => {
     args: {encoderType: 'MajorMinorChordEncoder'}
   };
   const cp = controls.controlSignalFromSpec(spec);
-  const args = {chords: ['C', 'Dm'], stepsPerChord: 2};
-  const tensors = cp.getTensors(args);
+  const tensors = cp.getTensors(4, {chords: ['C', 'Dm']});
   const e = new chords.MajorMinorChordEncoder();
   t.equal(cp.depth, e.depth);
   t.deepEqual(tensors.shape, [4, e.depth]);

--- a/core/src/controls_test.ts
+++ b/core/src/controls_test.ts
@@ -17,10 +17,14 @@
 
 import * as test from 'tape';
 import * as chords from './chords';
-import {BinaryCounter, ChordProgression} from './controls';
+import * as controls from './controls';
 
 test('Test Binary Counter', (t: test.Test) => {
-  const bc = new BinaryCounter(5, 2);
+  const spec : controls.BinaryCounterSpec = {
+    type: 'BinaryCounter',
+    args: {numSteps: 5, numBits: 2}
+  };
+  const bc = controls.controlSignalFromSpec(spec);
   t.equal(bc.numSteps, 5);
   t.equal(bc.depth, 2);
   t.deepEqual(bc.getTensor(0).dataSync(), [-1.0, -1.0]);
@@ -33,14 +37,18 @@ test('Test Binary Counter', (t: test.Test) => {
 });
 
 test('Test Chord Progression', (t: test.Test) => {
+  const spec : controls.ChordProgressionSpec = {
+    type: 'ChordProgression',
+    args: {numSteps: 4, encoderType: 'MajorMinorChordEncoder'}
+  };
+  const cp = controls.controlSignalFromSpec(spec, ['C', 'Dm']);
   const e = new chords.MajorMinorChordEncoder();
-  const bc = new ChordProgression(4, ['C', 'Dm'], e);
-  t.equal(bc.numSteps, 4);
-  t.equal(bc.depth, e.depth);
-  t.deepEqual(bc.getTensor(0).dataSync(), e.encode('C').dataSync());
-  t.deepEqual(bc.getTensor(1).dataSync(), e.encode('C').dataSync());
-  t.deepEqual(bc.getTensor(2).dataSync(), e.encode('Dm').dataSync());
-  t.deepEqual(bc.getTensor(3).dataSync(), e.encode('Dm').dataSync());
-  t.throws(() => bc.getTensor(4), RangeError);
+  t.equal(cp.numSteps, 4);
+  t.equal(cp.depth, e.depth);
+  t.deepEqual(cp.getTensor(0).dataSync(), e.encode('C').dataSync());
+  t.deepEqual(cp.getTensor(1).dataSync(), e.encode('C').dataSync());
+  t.deepEqual(cp.getTensor(2).dataSync(), e.encode('Dm').dataSync());
+  t.deepEqual(cp.getTensor(3).dataSync(), e.encode('Dm').dataSync());
+  t.throws(() => cp.getTensor(4), RangeError);
   t.end();
 });

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -72,11 +72,8 @@ export interface DrumsOneHotConverterSpec {
  * @property args Map containing values for argments to the constructor of the
  * `DataConverter` class specified above.
  */
-export type ConverterSpec = MelodyConverterSpec |
-                            DrumsConverterSpec |
-                            DrumRollConverterSpec |
-                            TrioConverterSpec |
-                            DrumsOneHotConverterSpec;
+export type ConverterSpec = MelodyConverterSpec | DrumsConverterSpec |
+    DrumRollConverterSpec | TrioConverterSpec | DrumsOneHotConverterSpec;
 
 /**
  * Builds a `DataConverter` based on the given `ConverterSpec`.
@@ -86,12 +83,18 @@ export type ConverterSpec = MelodyConverterSpec |
  */
 export function converterFromSpec(spec: ConverterSpec) {
   switch (spec.type) {
-    case 'MelodyConverter': return new MelodyConverter(spec.args);
-    case 'DrumsConverter': return new DrumsConverter(spec.args);
-    case 'DrumRollConverter': return new DrumRollConverter(spec.args);
-    case 'TrioConverter': return new TrioConverter(spec.args);
-    case 'DrumsOneHotConverter': return new DrumsOneHotConverter(spec.args);
-    default: throw new Error(`Unknown DataConverter type: ${spec}`);
+    case 'MelodyConverter':
+      return new MelodyConverter(spec.args);
+    case 'DrumsConverter':
+      return new DrumsConverter(spec.args);
+    case 'DrumRollConverter':
+      return new DrumRollConverter(spec.args);
+    case 'TrioConverter':
+      return new TrioConverter(spec.args);
+    case 'DrumsOneHotConverter':
+      return new DrumsOneHotConverter(spec.args);
+    default:
+      throw new Error(`Unknown DataConverter type: ${spec}`);
   }
 }
 

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -95,14 +95,15 @@ export function converterFromSpec(spec: ConverterSpec) {
   }
 }
 
-/**
- * Abstract DataConverter class for converting between `Tensor` and
- * `NoteSequence` objects.
- */
 export interface BaseConverterArgs {
   numSteps?: number;
   numSegments?: number;
 }
+
+/**
+ * Abstract DataConverter class for converting between `Tensor` and
+ * `NoteSequence` objects.
+ */
 export abstract class DataConverter {
   readonly numSteps: number;             // Total length of sequences.
   readonly numSegments: number;          // Number of steps for conductor.

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -44,6 +44,27 @@ const DEFAULT_DRUM_PITCH_CLASSES: number[][] = [
   [51, 52, 53, 59, 82]
 ];
 
+export interface MelodyConverterSpec {
+  type: 'MelodyConverter';
+  args: MelodyConverterArgs;
+}
+export interface DrumsConverterSpec {
+  type: 'DrumsConverter';
+  args: DrumsConverterArgs;
+}
+export interface DrumRollConverterSpec {
+  type: 'DrumRollConverter';
+  args: DrumsConverterArgs;
+}
+export interface TrioConverterSpec {
+  type: 'TrioConverter';
+  args: TrioConverterArgs;
+}
+export interface DrumsOneHotConverterSpec {
+  type: 'DrumsOneHotConverter';
+  args: DrumsConverterArgs;
+}
+
 /**
  * Interface for JSON specification of a `DataConverter`.
  *
@@ -51,36 +72,26 @@ const DEFAULT_DRUM_PITCH_CLASSES: number[][] = [
  * @property args Map containing values for argments to the constructor of the
  * `DataConverter` class specified above.
  */
-export interface ConverterSpec {
-  type: string;
-  args: BaseConverterArgs;
-}
-
-export interface BaseConverterArgs {
-  numSteps?: number;
-  numSegments?: number;
-}
+export type ConverterSpec = MelodyConverterSpec |
+                            DrumsConverterSpec |
+                            DrumRollConverterSpec |
+                            TrioConverterSpec |
+                            DrumsOneHotConverterSpec;
 
 /**
  * Builds a `DataConverter` based on the given `ConverterSpec`.
  *
  * @param spec Specifies the `DataConverter` to build.
  * @returns A new `DataConverter` object based on `spec`.
- * @throws Error if the specified type is not recognized.
  */
 export function converterFromSpec(spec: ConverterSpec) {
-  if (spec.type === 'MelodyConverter') {
-    return new MelodyConverter(spec.args as MelodyConverterArgs);
-  } else if (spec.type === 'DrumsConverter') {
-    return new DrumsConverter(spec.args as DrumsConverterArgs);
-  } else if (spec.type === 'DrumRollConverter') {
-    return new DrumRollConverter(spec.args as DrumsConverterArgs);
-  } else if (spec.type === 'TrioConverter') {
-    return new TrioConverter(spec.args as TrioConverterArgs);
-  } else if (spec.type === 'DrumsOneHotConverter') {
-    return new DrumsOneHotConverter(spec.args as DrumsConverterArgs);
-  } else {
-    throw new Error('Unknown DataConverter type in spec: ' + spec.type);
+  switch (spec.type) {
+    case 'MelodyConverter': return new MelodyConverter(spec.args);
+    case 'DrumsConverter': return new DrumsConverter(spec.args);
+    case 'DrumRollConverter': return new DrumRollConverter(spec.args);
+    case 'TrioConverter': return new TrioConverter(spec.args);
+    case 'DrumsOneHotConverter': return new DrumsOneHotConverter(spec.args);
+    default: throw new Error(`Unknown DataConverter type: ${spec}`);
   }
 }
 
@@ -88,6 +99,10 @@ export function converterFromSpec(spec: ConverterSpec) {
  * Abstract DataConverter class for converting between `Tensor` and
  * `NoteSequence` objects.
  */
+export interface BaseConverterArgs {
+  numSteps?: number;
+  numSegments?: number;
+}
 export abstract class DataConverter {
   readonly numSteps: number;             // Total length of sequences.
   readonly numSegments: number;          // Number of steps for conductor.

--- a/core/src/data.ts
+++ b/core/src/data.ts
@@ -98,6 +98,13 @@ export function converterFromSpec(spec: ConverterSpec) {
   }
 }
 
+/**
+ * Constructor arguments shared by all `DataConverter`s.
+ *
+ * @param numSteps The length of each sequence.
+ * @param numSegments (Optional) The number of conductor segments, if
+ * applicable.
+ */
 export interface BaseConverterArgs {
   numSteps?: number;
   numSegments?: number;

--- a/music_rnn/demo/index.ts
+++ b/music_rnn/demo/index.ts
@@ -156,11 +156,9 @@ async function runMelodyRnn() {
 
 async function runDrumsRnn() {
   const drumsRnn = new MusicRNN(
-    DRUMS_CHECKPOINT, null, 32,
-    magenta.controls.controlSignalFromSpec({
-      type: 'BinaryCounter',
-      args: {numBits: 6}
-    }));
+      DRUMS_CHECKPOINT, null, 32,
+      magenta.controls.controlSignalFromSpec(
+          {type: 'BinaryCounter', args: {numBits: 6}}));
   await drumsRnn.initialize();
 
   const qns = magenta.Sequences.quantizeNoteSequence(DRUMS_NS, 1);

--- a/music_rnn/demo/index.ts
+++ b/music_rnn/demo/index.ts
@@ -164,7 +164,7 @@ async function runDrumsRnn() {
   const qns = magenta.Sequences.quantizeNoteSequence(DRUMS_NS, 1);
   writeNoteSeqs('drums-cont-inputs', [qns]);
   const start = performance.now();
-  const continuation = await drumsRnn.continueSequence(qns, 20, null, {});
+  const continuation = await drumsRnn.continueSequence(qns, 20, null);
   writeTimer('drums-cont-time', start);
   writeNoteSeqs('drums-cont-results', [continuation]);
   drumsRnn.dispose();

--- a/music_rnn/demo/index.ts
+++ b/music_rnn/demo/index.ts
@@ -155,15 +155,18 @@ async function runMelodyRnn() {
 }
 
 async function runDrumsRnn() {
-  const drumsRnn = new MusicRNN(DRUMS_CHECKPOINT, null, 32);
+  const drumsRnn = new MusicRNN(
+    DRUMS_CHECKPOINT, null, 32,
+    magenta.controls.controlSignalFromSpec({
+      type: 'BinaryCounter',
+      args: {numBits: 6}
+    }));
   await drumsRnn.initialize();
 
   const qns = magenta.Sequences.quantizeNoteSequence(DRUMS_NS, 1);
   writeNoteSeqs('drums-cont-inputs', [qns]);
   const start = performance.now();
-  const continuation = await drumsRnn.continueSequence(
-      qns, 20, null,
-      new magenta.controls.BinaryCounter(qns.notes.length + 20, 6));
+  const continuation = await drumsRnn.continueSequence(qns, 20, null, {});
   writeTimer('drums-cont-time', start);
   writeNoteSeqs('drums-cont-results', [continuation]);
   drumsRnn.dispose();
@@ -171,7 +174,6 @@ async function runDrumsRnn() {
   console.log(tf.getBackend());
   console.log(tf.memory());
 }
-
 
 runMelodyRnn();
 runDrumsRnn();

--- a/music_rnn/demo/index.ts
+++ b/music_rnn/demo/index.ts
@@ -164,7 +164,7 @@ async function runDrumsRnn() {
   const qns = magenta.Sequences.quantizeNoteSequence(DRUMS_NS, 1);
   writeNoteSeqs('drums-cont-inputs', [qns]);
   const start = performance.now();
-  const continuation = await drumsRnn.continueSequence(qns, 20, null);
+  const continuation = await drumsRnn.continueSequence(qns, 20);
   writeTimer('drums-cont-time', start);
   writeNoteSeqs('drums-cont-results', [continuation]);
   drumsRnn.dispose();

--- a/music_rnn/src/model.ts
+++ b/music_rnn/src/model.ts
@@ -135,8 +135,8 @@ export class MusicRNN<A extends magenta.controls.ControlSignalUserArgs> {
    *
    * @param sequence The sequence to continue. Must be quantized.
    * @param steps How many steps to continue.
-   * @param temperature The softmax temperature to use when sampling from the
-   *   logits. Argmax is used if not provided.
+   * @param temperature (Optional) The softmax temperature to use when sampling
+   * from the logits. Argmax is used if not provided.
    * @param controlSignalArgs (Optional) Arguments for creating control tensors.
    */
   async continueSequence(

--- a/music_rnn/src/model.ts
+++ b/music_rnn/src/model.ts
@@ -27,11 +27,11 @@ const CELL_FORMAT = 'multi_rnn_cell/cell_%d/basic_lstm_cell/';
  *
  * A MusicRNN is an LSTM-based language model for musical notes.
  */
-export class MusicRNN<T extends magenta.controls.ControlSignalUserArgs> {
+export class MusicRNN<A extends magenta.controls.ControlSignalUserArgs> {
   checkpointURL: string;
   dataConverter: magenta.data.DataConverter;
   attentionLength?: number;
-  controlSignal: magenta.controls.ControlSignal<T>;
+  controlSignal: magenta.controls.ControlSignal<A>;
 
   lstmCells: tf.LSTMCellFunc[];
   lstmFcB: tf.Tensor1D;
@@ -56,7 +56,7 @@ export class MusicRNN<T extends magenta.controls.ControlSignalUserArgs> {
   constructor(
       checkpointURL: string, dataConverter?: magenta.data.DataConverter,
       attentionLength?: number,
-      controlSignal?: magenta.controls.ControlSignal<T>) {
+      controlSignal?: magenta.controls.ControlSignal<A>) {
     this.checkpointURL = checkpointURL;
     this.initialized = false;
     this.rawVars = {};
@@ -137,10 +137,11 @@ export class MusicRNN<T extends magenta.controls.ControlSignalUserArgs> {
    * @param steps How many steps to continue.
    * @param temperature The softmax temperature to use when sampling from the
    *   logits. Argmax is used if not provided.
+   * @param controlSignalArgs (Optional) Arguments for creating control tensors.
    */
   async continueSequence(
       sequence: magenta.INoteSequence, steps: number, temperature?: number,
-      controlSignalArgs?: T): Promise<magenta.INoteSequence> {
+      controlSignalArgs?: A): Promise<magenta.INoteSequence> {
     magenta.Sequences.assertIsQuantizedSequence(sequence);
 
     if (!this.initialized) {

--- a/music_rnn/src/model.ts
+++ b/music_rnn/src/model.ts
@@ -152,9 +152,8 @@ export class MusicRNN<T extends magenta.controls.ControlSignalUserArgs> {
       const length: number = inputs.shape[0];
       const outputSize: number = inputs.shape[1];
       const controls = this.controlSignal ?
-                       this.controlSignal.getTensors(
-                          length + steps, controlSignalArgs) :
-                       undefined;
+          this.controlSignal.getTensors(length + steps, controlSignalArgs) :
+          undefined;
       const samples = this.sampleRnn(inputs, steps, temperature, controls);
       return tf.stack(samples).as2D(samples.length, outputSize);
     });
@@ -200,8 +199,8 @@ export class MusicRNN<T extends magenta.controls.ControlSignalUserArgs> {
       }
 
       if (controls) {
-        const control = controls.slice(
-            [i, 0], [1, controlSize]).as2D(1, controlSize);
+        const control =
+            controls.slice([i, 0], [1, controlSize]).as2D(1, controlSize);
         nextInput = nextInput.concat(control.as2D(1, -1), 1);
       }
 

--- a/music_rnn/src/model.ts
+++ b/music_rnn/src/model.ts
@@ -149,9 +149,11 @@ export class MusicRNN<T extends magenta.controls.ControlSignalUserArgs> {
 
     const oh = tf.tidy(() => {
       const inputs = this.dataConverter.toTensor(sequence);
+      const length: number = inputs.shape[0];
       const outputSize: number = inputs.shape[1];
       const controls = this.controlSignal ?
-                       this.controlSignal.getTensors(controlSignalArgs) :
+                       this.controlSignal.getTensors(
+                          length + steps, controlSignalArgs) :
                        undefined;
       const samples = this.sampleRnn(inputs, steps, temperature, controls);
       return tf.stack(samples).as2D(samples.length, outputSize);

--- a/music_rnn/src/model.ts
+++ b/music_rnn/src/model.ts
@@ -199,9 +199,14 @@ export class MusicRNN<A extends magenta.controls.ControlSignalUserArgs> {
         samples.push(nextInput.as1D().toBool());
       }
 
+      // No need to run an RNN step once we have all our samples.
+      if (i === length + steps - 1) {
+        break;
+      }
+
       if (controls) {
         const control =
-            controls.slice([i, 0], [1, controlSize]).as2D(1, controlSize);
+            controls.slice([i + 1, 0], [1, controlSize]).as2D(1, controlSize);
         nextInput = nextInput.concat(control.as2D(1, -1), 1);
       }
 


### PR DESCRIPTION
How's this?  Creating control signals from JSON spec is a little awkward because we need the actual chords for a chord progression.