### PR TITLE
Resume tonejs context on play, and make it publicly accessible.

### DIFF
--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -96,6 +96,7 @@ export class Player {
   private currentPart: any;
   private scheduledStop: number;
   private synths = new Map<number, any>();
+  static context = Tone.context;
   /* tslint:enable */
 
   /**
@@ -103,6 +104,7 @@ export class Player {
    * that resolves when it is done playing.
    */
   start(seq: INoteSequence): Promise<void> {
+    Tone.context.resume();
     const events =
         seq.notes.map(note => [note.quantizedStartStep * EIGHTH, note]);
     this.currentPart = new Tone.Part(


### PR DESCRIPTION
This helps with playback on mobile, which is blocked until a user interaction occurs. Tone will not play until the context is resumed after the interaction.