### PR TITLE
Fix quantization asserts to be more accurate

### DIFF
--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -109,7 +109,8 @@ export class Player {
    * of 120.
    */
   start(seq: INoteSequence, qpm?: number): Promise<void> {
-    sequences.assertIsQuantizedSequence(seq);
+    // TODO(fjord): support absolute quantized sequences.
+    sequences.assertIsRelativeQuantizedSequence(seq);
 
     Tone.context.resume();
 

--- a/music/src/core/sequences.ts
+++ b/music/src/core/sequences.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import {NoteSequence, INoteSequence} from '../protobuf/index';
+import {INoteSequence, NoteSequence} from '../protobuf/index';
+
 import * as constants from './constants';
 
 // Set the quantization cutoff.
@@ -113,8 +114,7 @@ export function quantizeToStep(
 function quantizeNotes(ns: INoteSequence, stepsPerSecond: number) {
   for (const note of ns.notes) {
     // Quantize the start and end times of the note.
-    note.quantizedStartStep =
-        quantizeToStep(note.startTime, stepsPerSecond);
+    note.quantizedStartStep = quantizeToStep(note.startTime, stepsPerSecond);
     note.quantizedEndStep = quantizeToStep(note.endTime, stepsPerSecond);
     if (note.quantizedEndStep === note.quantizedStartStep) {
       note.quantizedEndStep += 1;
@@ -263,11 +263,10 @@ export function quantizeNoteSequence(
   }
 
   // Compute quantization steps per second.
-  const stepsPerSecond = stepsPerQuarterToStepsPerSecond(
-      stepsPerQuarter, qns.tempos[0].qpm);
+  const stepsPerSecond =
+      stepsPerQuarterToStepsPerSecond(stepsPerQuarter, qns.tempos[0].qpm);
 
-  qns.totalQuantizedSteps =
-      quantizeToStep(qns.totalTime, stepsPerSecond);
+  qns.totalQuantizedSteps = quantizeToStep(qns.totalTime, stepsPerSecond);
   quantizeNotes(qns, stepsPerSecond);
 
   // return qns
@@ -278,13 +277,36 @@ export function quantizeNoteSequence(
  * Returns whether or not a NoteSequence proto has been quantized.
  */
 export function isQuantizedSequence(ns: INoteSequence) {
-  return ns.quantizationInfo && (ns.quantizationInfo.stepsPerQuarter > 0 ||
-                                  ns.quantizationInfo.stepsPerSecond > 0);
+  return ns.quantizationInfo &&
+      (ns.quantizationInfo.stepsPerQuarter > 0 ||
+       ns.quantizationInfo.stepsPerSecond > 0);
 }
 
 export function assertIsQuantizedSequence(ns: INoteSequence) {
   if (!isQuantizedSequence(ns)) {
     throw new QuantizationStatusException(
         `NoteSequence ${ns.id} is not quantized (missing quantizationInfo)`);
+  }
+}
+
+export function isRelativeQuantizedSequence(ns: INoteSequence) {
+  return ns.quantizationInfo && ns.quantizationInfo.stepsPerQuarter > 0;
+}
+
+export function assertIsRelativeQuantizedSequence(ns: INoteSequence) {
+  if (!isRelativeQuantizedSequence(ns)) {
+    throw new QuantizationStatusException(`NoteSequence ${
+        ns.id} is not quantized or is quantized based on absolute timing`);
+  }
+}
+
+export function isAbsoluteQuantizedSequence(ns: INoteSequence) {
+  return ns.quantizationInfo && ns.quantizationInfo.stepsPerSecond > 0;
+}
+
+export function assertIsAbsoluteQuantizedSequence(ns: INoteSequence) {
+  if (!isAbsoluteQuantizedSequence(ns)) {
+    throw new QuantizationStatusException(`NoteSequence ${
+        ns.id} is not quantized or is quantized based on relative timing`);
   }
 }

--- a/music/src/core/sequences.ts
+++ b/music/src/core/sequences.ts
@@ -282,6 +282,9 @@ export function isQuantizedSequence(ns: INoteSequence) {
        ns.quantizationInfo.stepsPerSecond > 0);
 }
 
+/**
+ * Confirms that the given NoteSequence has been quantized.
+ */
 export function assertIsQuantizedSequence(ns: INoteSequence) {
   if (!isQuantizedSequence(ns)) {
     throw new QuantizationStatusException(
@@ -289,10 +292,16 @@ export function assertIsQuantizedSequence(ns: INoteSequence) {
   }
 }
 
+/**
+ * Returns whether the given NoteSequence has been quantized relative to tempo.
+ */
 export function isRelativeQuantizedSequence(ns: INoteSequence) {
   return ns.quantizationInfo && ns.quantizationInfo.stepsPerQuarter > 0;
 }
 
+/**
+ * Confirms that the given NoteSequence has been quantized relative to tempo.
+ */
 export function assertIsRelativeQuantizedSequence(ns: INoteSequence) {
   if (!isRelativeQuantizedSequence(ns)) {
     throw new QuantizationStatusException(`NoteSequence ${
@@ -300,10 +309,16 @@ export function assertIsRelativeQuantizedSequence(ns: INoteSequence) {
   }
 }
 
+/**
+ * Returns whether the given NoteSequence has been quantized by absolute time.
+ */
 export function isAbsoluteQuantizedSequence(ns: INoteSequence) {
   return ns.quantizationInfo && ns.quantizationInfo.stepsPerSecond > 0;
 }
 
+/**
+ * Confirms that the given NoteSequence has been quantized by absolute time.
+ */
 export function assertIsAbsoluteQuantizedSequence(ns: INoteSequence) {
   if (!isAbsoluteQuantizedSequence(ns)) {
     throw new QuantizationStatusException(`NoteSequence ${

--- a/music/src/core/sequences_test.ts
+++ b/music/src/core/sequences_test.ts
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
-import * as sequences from './sequences';
 import * as test from 'tape';
+
 import {NoteSequence} from '../protobuf/index';
+
+import * as sequences from './sequences';
 
 const STEPS_PER_QUARTER = 4;
 
@@ -70,7 +72,8 @@ function addControlChangesToSequence(
     const cc = NoteSequence.ControlChange.create({
       time: ccParams[0],
       controlNumber: ccParams[1],
-      controlValue: ccParams[2], instrument
+      controlValue: ccParams[2],
+      instrument
     });
     ns.controlChanges.push(cc);
   }
@@ -376,6 +379,24 @@ test('Assert isQuantizedNoteSequence', (t: test.Test) => {
 
   const qns = sequences.quantizeNoteSequence(ns, STEPS_PER_QUARTER);
   sequences.assertIsQuantizedSequence(qns);
+
+  t.end();
+});
+
+test('Assert isRelativeQuantizedNoteSequence', (t: test.Test) => {
+  const ns = createTestNS();
+
+  addTrackToSequence(ns, 0, [
+    [12, 100, 0.01, 10.0], [11, 55, 0.22, 0.50], [40, 45, 2.50, 3.50],
+    [55, 120, 4.0, 4.01], [52, 99, 4.75, 5.0]
+  ]);
+
+  t.throws(
+      () => sequences.assertIsRelativeQuantizedSequence(ns),
+      sequences.QuantizationStatusException);
+
+  const qns = sequences.quantizeNoteSequence(ns, STEPS_PER_QUARTER);
+  sequences.assertIsRelativeQuantizedSequence(qns);
 
   t.end();
 });

--- a/music/src/music_rnn/model.ts
+++ b/music/src/music_rnn/model.ts
@@ -197,7 +197,7 @@ export class MusicRNN {
   async continueSequence(
       sequence: INoteSequence, steps: number, temperature?: number,
       chordProgression?: string[]): Promise<INoteSequence> {
-    sequences.assertIsQuantizedSequence(sequence);
+    sequences.assertIsRelativeQuantizedSequence(sequence);
 
     if (this.chordEncoder && !chordProgression) {
       throw new Error('Chord progression expected but not provided.');


### PR DESCRIPTION
In most cases, we specifically care that the sequence is quantized to relative timings.