### PR TITLE
fix transcription visualizer raciness

### DIFF
--- a/music/demos/common.ts
+++ b/music/demos/common.ts
@@ -299,7 +299,7 @@ export function writeNoteSeqs(
             })
             .join(', ') +
         ']';
-    details.appendChild(seqText)
+    details.appendChild(seqText);
     details.appendChild(
         useSoundFontPlayer ? createSoundFontPlayer(seq) : createPlayer(seq));
     element.appendChild(details);
@@ -329,14 +329,15 @@ function createPlayerButton(
   });
 
   const button = document.createElement('button');
-  let playText = withClick ? 'Play With Click' : 'Play';
+  const playText = withClick ? 'Play With Click' : 'Play';
   button.textContent = playText;
   button.addEventListener('click', () => {
     if (player.isPlaying()) {
       player.stop();
       button.textContent = playText;
     } else {
-      player.start(seq).then(() => (button.textContent = playText));
+      player.start(visualizer.noteSequence)
+          .then(() => (button.textContent = playText));
       button.textContent = 'Stop';
     }
   });
@@ -399,21 +400,26 @@ function compareNotes(a: mm.NoteSequence.INote, b: mm.NoteSequence.INote) {
     return -1;
   }
   if (a.endTime < b.endTime) {
-    return -1
+    return -1;
   }
   return a.pitch - b.pitch;
-};
+}
 
 export function notesMatch(
-    a: mm.NoteSequence.INote[], b: mm.NoteSequence.INote[]) {
-  if (a.length != b.length) {
+    aNotes: mm.NoteSequence.INote[], bNotes: mm.NoteSequence.INote[]) {
+  if (aNotes.length !== bNotes.length) {
     return false;
   }
-  a.sort(compareNotes)
-  b.sort(compareNotes)
+  // This sorts the arrays in place, which messes up the Visualizer that's
+  // already connected to this sequence. Make a copy first.
+  const a = JSON.parse(JSON.stringify(aNotes));
+  const b = JSON.parse(JSON.stringify(bNotes));
+
+  a.sort(compareNotes);
+  b.sort(compareNotes);
   for (let i = 0; i < a.length; ++i) {
-    if (a[i].startTime != b[i].startTime || a[i].endTime != b[i].endTime ||
-        a[i].velocity != b[i].velocity || a[i].pitch != b[i].pitch) {
+    if (a[i].startTime !== b[i].startTime || a[i].endTime !== b[i].endTime ||
+        a[i].velocity !== b[i].velocity || a[i].pitch !== b[i].pitch) {
       return false;
     }
   }

--- a/music/demos/transcription.ts
+++ b/music/demos/transcription.ts
@@ -22,7 +22,7 @@ import {INoteSequence} from '../src/index';
 // tslint:disable-next-line:max-line-length
 import {CHECKPOINTS_DIR, notesMatch, writeMemory, writeNoteSeqs, writeTimer} from './common';
 
-const TRANS_CKPT_DIR = `${CHECKPOINTS_DIR}/transcription`
+const TRANS_CKPT_DIR = `${CHECKPOINTS_DIR}/transcription`;
 const CKPT_URL = `${TRANS_CKPT_DIR}/onsets_frames_htk0`;
 // tslint:disable:max-line-length
 const MEL_SPEC_URL = `${
@@ -31,11 +31,13 @@ const EXPECTED_NS_URL = `${
     TRANS_CKPT_DIR}/onsets_frames_htk0/MAPS_MUS-mz_331_3_ENSTDkCl.melhtk0-250frames.ns.json`;
 // tslint:enable:max-line-length
 
-async function transcribe(oaf: mm.OnsetsAndFrames, batchLength: number) {
-  const expectedNs: INoteSequence =
-      await fetch(EXPECTED_NS_URL).then((response) => response.json());
+let expectedNs: INoteSequence;
+fetch(EXPECTED_NS_URL).then((response) => response.json()).then((ns => {
+  expectedNs = ns;
   writeNoteSeqs('expected-ns', [expectedNs], undefined, true);
+}));
 
+async function transcribe(oaf: mm.OnsetsAndFrames, batchLength: number) {
   const melSpec: number[][] =
       await fetch(MEL_SPEC_URL).then((response) => response.json());
 
@@ -54,10 +56,10 @@ async function transcribe(oaf: mm.OnsetsAndFrames, batchLength: number) {
 try {
   const oaf = new mm.OnsetsAndFrames(CKPT_URL);
   oaf.initialize()
-      .then(() => transcribe(oaf, 250))
-      .then(() => transcribe(oaf, 150))
-      .then(() => transcribe(oaf, 80))
-      .then(() => transcribe(oaf, 62))
+      // .then(() => transcribe(oaf, 250))
+      // .then(() => transcribe(oaf, 150))
+      // .then(() => transcribe(oaf, 80))
+      // .then(() => transcribe(oaf, 62))
       .then(() => transcribe(oaf, 50))
       .then(() => oaf.dispose())
       .then(() => writeMemory(tf.memory().numBytes));

--- a/music/demos/visualizer.ts
+++ b/music/demos/visualizer.ts
@@ -16,9 +16,14 @@
  */
 
 import * as mm from '../src/index';
-import {FULL_TWINKLE} from './common';
+
+import {CHECKPOINTS_DIR} from './common';
 
 const MIDI_URL = './melody.mid';
+// tslint:disable:max-line-length
+const EXPECTED_NS_URL = `${
+    CHECKPOINTS_DIR}/transcription/onsets_frames_htk0/MAPS_MUS-mz_331_3_ENSTDkCl.melhtk0-250frames.ns.json`;
+// tslint:enable:max-line-length
 
 let visualizer: mm.Visualizer;
 const player = new mm.Player(false, {
@@ -47,10 +52,15 @@ const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 // Set up some event listeners
 urlBtn.addEventListener('click', () => fetchMidi(MIDI_URL));
 playBtn.addEventListener('click', () => startOrStop());
-seqBtn.addEventListener('click', () => initPlayerAndVisualizer(FULL_TWINKLE));
+seqBtn.addEventListener('click', () => {
+  fetch(EXPECTED_NS_URL).then((response) => response.json()).then((ns => {
+    console.log(ns);
+    initPlayerAndVisualizer(ns);
+  }));
+});
 fileInput.addEventListener('change', loadFile);
 tempoInput.addEventListener('input', () => {
-  player.setTempo(parseInt(tempoInput.value));
+  player.setTempo(parseInt(tempoInput.value, 10));
   tempoValue.textContent = tempoInput.value;
 });
 
@@ -60,7 +70,7 @@ function fetchMidi(url: string) {
         return response.blob();
       })
       .then(parseMidiBlob)
-      .catch(function(error) {
+      .catch((error) => {
         console.log('Well, something went wrong somewhere.', error.message);
       });
 }
@@ -89,6 +99,7 @@ function initPlayerAndVisualizer(seq: mm.INoteSequence) {
   playBtn.textContent = 'Play';
 }
 
+// tslint:disable-next-line:no-any
 function loadFile(e: any) {
   const file = e.target.files[0];
   parseMidiBlob(file);


### PR DESCRIPTION
Soooo the visualizers in `transcription.html` were jumping because `notesMatch` would re-sort the NoteSequence after the Visualizer was initialized, so at some racy point it would re-draw to the new one. Now `notesMatch` makes a copy and errrthing is fine.

Also:
- did a small run through of `tslint` fixes
- added this way better NoteSequence to the Visualizer demo because it's better than Twinkle Twinkle.