### PR TITLE
Fix canvas

### DIFF
--- a/music/demos/transcription.html
+++ b/music/demos/transcription.html
@@ -34,7 +34,7 @@ limitations under the License.
   </p>
 
   <h2>From an uploaded audio file</h2>
-  <p>You can use your own piano music file for transcription:</p>
+  <p>You can use your own piano music file (i.e. actual audio, not midi) for transcription:</p>
   <section>
     <label class="button">
       Load audio file

--- a/music/demos/transcription.ts
+++ b/music/demos/transcription.ts
@@ -21,10 +21,7 @@ import * as MediaRecorder from 'audio-recorder-polyfill';
 import * as mm from '../src/index';
 import {INoteSequence} from '../src/index';
 // tslint:disable:max-line-length
-import {loadAudioFromFile, loadAudioFromUrl} from '../src/transcription/audio_utils';
-
 import {CHECKPOINTS_DIR, notesMatch, writeMemory, writeNoteSeqs, writeTimer} from './common';
-
 // tslint:enable:max-line-length
 
 mm.logging.verbosity = mm.logging.Level.DEBUG;
@@ -133,9 +130,8 @@ async function transcribe(oaf: mm.OnsetsAndFrames, batchLength: number) {
 }
 
 async function transcribeFromAudio(oaf: mm.OnsetsAndFrames) {
-  const audio = await loadAudioFromUrl(ORIGINAL_AUDIO_URL);
   const start = performance.now();
-  const ns = await oaf.transcribeFromAudio(audio);
+  const ns = await oaf.transcribeFromAudioURL(ORIGINAL_AUDIO_URL);
   writeTimer('audio-time', start);
   writeNoteSeqs('audio-results', [ns], undefined, true);
 
@@ -147,8 +143,6 @@ async function transcribeFromAudio(oaf: mm.OnsetsAndFrames) {
 
 async function transcribeFromFile(blob: Blob, prefix = 'file') {
   setLoadingMessage(prefix);
-  const audio = await loadAudioFromFile(blob);
-
   const audioEl =
       document.getElementById(`${prefix}Player`) as HTMLAudioElement;
   audioEl.hidden = false;
@@ -158,7 +152,7 @@ async function transcribeFromFile(blob: Blob, prefix = 'file') {
   oafA.initialize()
       .then(async () => {
         const start = performance.now();
-        const ns = await oafA.transcribeFromAudio(audio);
+        const ns = await oafA.transcribeFromAudioFile(blob);
         writeTimer(`${prefix}-time`, start);
         writeNoteSeqs(`${prefix}-results`, [ns], undefined, true);
       })

--- a/music/demos/transcription.ts
+++ b/music/demos/transcription.ts
@@ -20,9 +20,8 @@ import * as MediaRecorder from 'audio-recorder-polyfill';
 
 import * as mm from '../src/index';
 import {INoteSequence} from '../src/index';
-// tslint:disable:max-line-length
+// tslint:disable-next-line:max-line-length
 import {CHECKPOINTS_DIR, notesMatch, writeMemory, writeNoteSeqs, writeTimer} from './common';
-// tslint:enable:max-line-length
 
 mm.logging.verbosity = mm.logging.Level.DEBUG;
 

--- a/music/demos/visualizer.html
+++ b/music/demos/visualizer.html
@@ -9,6 +9,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================-->
+<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">

--- a/music/package.json
+++ b/music/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magenta/music",
-  "version": "1.1.11",
+  "version": "1.1.14",
   "description": "Make music with machine learning, in the browser.",
   "main": "es5/index.js",
   "types": "es5/index.d.ts",

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -98,8 +98,8 @@ export class Visualizer {
 
     // If we don't do this, then the canvas will look 2x bigger than we
     // want to.
-    canvas.style.width = `${size.width}`;
-    canvas.style.height = `${size.height}`;
+    canvas.style.width = `${size.width}px`;
+    canvas.style.height = `${size.height}px`;
 
     this.ctx.scale(dpr, dpr);
 

--- a/music/src/transcription/model.ts
+++ b/music/src/transcription/model.ts
@@ -23,7 +23,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import * as logging from '../core/logging';
-
+// tslint:disable-next-line:max-line-length
 import {loadAudioFromFile, loadAudioFromUrl, preprocessAudio} from './audio_utils';
 import {MEL_SPEC_BINS, MIDI_PITCHES} from './constants';
 // tslint:disable-next-line:max-line-length

--- a/music/src/transcription/model.ts
+++ b/music/src/transcription/model.ts
@@ -21,9 +21,10 @@
  * Imports
  */
 import * as tf from '@tensorflow/tfjs';
+
 import * as logging from '../core/logging';
 
-import {preprocessAudio} from './audio_utils';
+import {loadAudioFromFile, loadAudioFromUrl, preprocessAudio} from './audio_utils';
 import {MEL_SPEC_BINS, MIDI_PITCHES} from './constants';
 // tslint:disable-next-line:max-line-length
 import {batchInput, pianorollToNoteSequence, unbatchOutput} from './transcription_utils';
@@ -136,14 +137,14 @@ export class OnsetsAndFrames {
   }
 
   /**
-   * Transcribes a piano performance from audio.
+   * Transcribes a piano performance from audio buffer.
    *
    * @param audioBuffer An audio buffer to transcribe.
    * @param batchSize The number of chunks to compute in parallel. May
    * need to be reduced if hitting a timeout in the browser.
    * @returns A `NoteSequence` containing the transcribed piano performance.
    */
-  async transcribeFromAudio(audioBuffer: AudioBuffer, batchSize = 4) {
+  async transcribeFromAudioBuffer(audioBuffer: AudioBuffer, batchSize = 4) {
     const startTime = performance.now();
     const melSpec = preprocessAudio(audioBuffer);
     melSpec.then(
@@ -153,6 +154,28 @@ export class OnsetsAndFrames {
     return melSpec.then(
         (spec) => this.transcribeFromMelSpec(
             spec.map(a => Array.from(a), batchSize)));
+  }
+
+  /**
+   * Transcribes a piano performance from an audio file.
+   *
+   * @param blob An audio file blob to transcribe.
+   * @returns A `NoteSequence` containing the transcribed piano performance.
+   */
+  async transcribeFromAudioFile(blob: Blob) {
+    const audio = await loadAudioFromFile(blob);
+    return this.transcribeFromAudioBuffer(audio);
+  }
+
+  /**
+   * Transcribes a piano performance from an audio file ULR.
+   *
+   * @param url The url of the file to transcribe.
+   * @returns A `NoteSequence` containing the transcribed piano performance.
+   */
+  async transcribeFromAudioURL(url: string) {
+    const audio = await loadAudioFromUrl(url);
+    return this.transcribeFromAudioBuffer(audio);
   }
 
   private processBatches(


### PR DESCRIPTION
This actually fixes 2 things:
- a weird canvas bug (if your `index.html` had a `doctype` tag then the canvas was 2x the size because it wasn't scaled correctly)
- adds useful methods to oaf so that you can transcribe a file/url. Not super convinced the names are ok.