### PR TITLE
Add a callbackObject to the SoundFont player

### DIFF
--- a/music/demos/player.html
+++ b/music/demos/player.html
@@ -25,7 +25,7 @@
   <section>
     <b>Base player (with or without click)</b>
     <div id="q-player"></div>
-    <b>SoundFont player (with or without click)</b>
+    <b>SoundFont player</b>
     <div id="q-soundfont"></div>
   </section>
 
@@ -56,10 +56,13 @@
   <h2>NoteSequences with velocities</h2>
   <p>They work!</p>
   <section>
+    <b>SoundFont player</b>
+    <div id="s-v-player"></div>
     <b>Base player (with or without click)</b>
     <div id="v-player"></div>
     <b>Drum player (with or without click)</b>
     <div id="d-v-player"></div>
+
   </section>
 
   <script src="player_bundle.js"></script>

--- a/music/demos/player.ts
+++ b/music/demos/player.ts
@@ -59,6 +59,7 @@ function generateTempoPlayer() {
 function generateVelocityPlayers() {
   writeNoteSeqs('v-player', [MEL_TWINKLE_WITH_VELOCITIES], false);
   writeNoteSeqs('d-v-player', [DRUM_SEQ_WITH_VELOCITIES], false);
+  writeNoteSeqs('s-v-player', [MEL_TWINKLE_WITH_VELOCITIES], true);
 }
 
 try {

--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -392,8 +392,9 @@ export class SoundFontPlayer extends BasePlayer {
   constructor(
       soundFontURL: string, output = Tone.Master,
       programOutputs?: Map<number, any>,  // tslint:disable-line:no-any
-      drumOutputs?: Map<number, any>) {   // tslint:disable-line:no-any
-    super();
+      drumOutputs?: Map<number, any>,
+      callbackObject?: BasePlayerCallback) {  // tslint:disable-line:no-any
+    super(false, callbackObject);
     this.soundFont = new soundfont.SoundFont(soundFontURL);
     this.output = output;
     this.programOutputs = programOutputs;
@@ -401,12 +402,13 @@ export class SoundFontPlayer extends BasePlayer {
   }
 
   async loadSamples(seq: INoteSequence): Promise<void> {
-    await this.soundFont.loadSamples(seq.notes.map((note) => ({
-                                                     pitch: note.pitch,
-                                                     velocity: note.velocity,
-                                                     program: note.program,
-                                                     isDrum: note.isDrum
-                                                   })));
+    await this.soundFont.loadSamples(
+        seq.notes.map((note) => ({
+                        pitch: note.pitch,
+                        velocity: note.velocity,
+                        program: note.program || 0,
+                        isDrum: note.isDrum || false
+                      })));
   }
 
   start(seq: INoteSequence, qpm?: number): Promise<void> {

--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -391,8 +391,8 @@ export class SoundFontPlayer extends BasePlayer {
 
   constructor(
       soundFontURL: string, output = Tone.Master,
-      programOutputs?: Map<number, any>,  // tslint:disable-line:no-any
-      drumOutputs?: Map<number, any>,
+      programOutputs?: Map<number, any>,      // tslint:disable-line:no-any
+      drumOutputs?: Map<number, any>,         // tslint:disable-line:no-any
       callbackObject?: BasePlayerCallback) {  // tslint:disable-line:no-any
     super(false, callbackObject);
     this.soundFont = new soundfont.SoundFont(soundFontURL);


### PR DESCRIPTION
Oooo boy this a good 'un.
- adds a callbackObject to a SoundFont player so that (among other things) it can be used with the visualizer
- cleans up the common demo code
-  fixes `loadSamples` which tended to panic if the NoteSequences wasn't perfect 

Discovered: the SoundFont we use doesn't do velocities even though the code [tries to use them](https://github.com/tensorflow/magenta-js/blob/master/music/src/core/player.ts#L432)