### PR TITLE
Add explicit type to transcribeFromMelSpec

### DIFF
--- a/music/src/transcription/model.ts
+++ b/music/src/transcription/model.ts
@@ -28,6 +28,7 @@ import {loadAudioFromFile, loadAudioFromUrl, preprocessAudio} from './audio_util
 import {MEL_SPEC_BINS, MIDI_PITCHES} from './constants';
 // tslint:disable-next-line:max-line-length
 import {batchInput, pianorollToNoteSequence, unbatchOutput} from './transcription_utils';
+import { INoteSequence } from '../protobuf';
 
 /**
  * Main "Onsets And Frames" piano transcription model class.
@@ -108,7 +109,8 @@ class OnsetsAndFrames {
    * @returns A `NoteSequence` containing the transcribed piano performance.
    */
   // tslint:enable:max-line-length
-  async transcribeFromMelSpec(melSpec: number[][], parallelBatches = 4) {
+  async transcribeFromMelSpec(melSpec: number[][], parallelBatches = 4)
+      : Promise<INoteSequence> {
     if (!this.isInitialized()) {
       this.initialize();
     }


### PR DESCRIPTION
Fies #186.

After this change, the types look right in the build:
<img width="816" alt="screen shot 2018-10-26 at 10 47 32 am" src="https://user-images.githubusercontent.com/1369170/47583549-b0921a00-d90c-11e8-8a39-e00eb697f281.png">
