### PR TITLE
previous tfjs update didn't stick for the demos

### DIFF
--- a/docs/music/demos/callback_player_bundle.js
+++ b/docs/music/demos/callback_player_bundle.js
@@ -252,7 +252,7 @@ catch (err) {
     console.error(err);
 }
 
-},{"../src/index":314,"./common":2}],2:[function(require,module,exports){
+},{"../src/index":338,"./common":2}],2:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var file_saver_1 = require("file-saver");
@@ -672,7 +672,7 @@ function notesMatch(aNotes, bNotes) {
 }
 exports.notesMatch = notesMatch;
 
-},{"../src/index":314,"file-saver":258}],3:[function(require,module,exports){
+},{"../src/index":338,"file-saver":282}],3:[function(require,module,exports){
 "use strict";
 module.exports = asPromise;
 
@@ -3422,7 +3422,7 @@ var FrozenModel = (function () {
         });
     };
     FrozenModel.prototype.predict = function (inputs, config) {
-        return this.execute(inputs, this.outputNodes);
+        return this.execute_(inputs, true, this.outputNodes);
     };
     FrozenModel.prototype.constructTensorMap = function (inputs) {
         var inputArray = inputs instanceof tfc.Tensor ? [inputs] : inputs;
@@ -3437,6 +3437,10 @@ var FrozenModel = (function () {
         }, {});
     };
     FrozenModel.prototype.execute = function (inputs, outputs) {
+        return this.execute_(inputs, false, outputs);
+    };
+    FrozenModel.prototype.execute_ = function (inputs, strictInputCheck, outputs) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         outputs = outputs || this.outputNodes;
         if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
             inputs = this.constructTensorMap(inputs);
@@ -3445,7 +3449,7 @@ var FrozenModel = (function () {
             throw new Error('The model contains control flow or dynamic shape ops, ' +
                 'please use executeAsync method');
         }
-        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), outputs);
+        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
         var keys = Object.keys(result);
         return (Array.isArray(outputs) && outputs.length > 1) ?
             outputs.map(function (node) { return result[node]; }) :
@@ -3559,8 +3563,9 @@ var execution_context_1 = require("./execution_context");
 var GraphExecutor = (function () {
     function GraphExecutor(graph) {
         this.graph = graph;
-        this.compiledOrder = [];
+        this.compiledMap = new Map();
         this._weightMap = {};
+        this.SEPERATOR = ',';
         this.placeholders = graph.placeholders;
         this._outputs = graph.outputs;
         this.compile();
@@ -3635,16 +3640,23 @@ var GraphExecutor = (function () {
         enumerable: true,
         configurable: true
     });
-    GraphExecutor.prototype.compile = function () {
+    GraphExecutor.prototype.compile = function (startNodes) {
         if (this.graph.withControlFlow || this.graph.withDynamicShape) {
             return;
         }
-        var stack = this.graph.inputs.slice();
+        var compiledOrder = [];
+        var inputs = startNodes || this.graph.placeholders;
+        var sortedNodeNames = inputs.map(function (node) { return node.name; }).sort();
+        var nameKey = sortedNodeNames.join(this.SEPERATOR);
+        if (this.compiledMap.get(nameKey)) {
+            return;
+        }
+        var stack = inputs.concat(this.graph.weights);
         var visited = {};
         while (stack.length > 0) {
             var node = stack.pop();
             visited[node.name] = true;
-            this.compiledOrder.push(node);
+            compiledOrder.push(node);
             node.children.forEach(function (childNode) {
                 if (!visited[childNode.name] && childNode.inputNames.every(function (name) {
                     var nodeName = utils_1.getNodeNameAndIndex(name)[0];
@@ -3654,19 +3666,33 @@ var GraphExecutor = (function () {
                 }
             });
         }
+        this.compiledMap.set(nameKey, compiledOrder);
     };
-    GraphExecutor.prototype.execute = function (inputs, outputs) {
+    GraphExecutor.prototype.execute = function (inputs, strictInputCheck, outputs) {
         var _this = this;
-        this.checkInput(inputs);
-        this.checkInputShapeAndType(inputs);
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
+        var names = Object.keys(inputs).sort();
+        this.checkInput(inputs, strictInputCheck);
+        this.checkInputShapeAndType(inputs, strictInputCheck);
+        this.compile(names.map(function (name) { return _this.graph.nodes[name]; }));
+        var outputNames = this.calculateOutputs(outputs);
+        this.checkOutput(this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
         var tensorArrayMap = {};
         var result = tfjs_core_1.tidy(function () {
             var context = new execution_context_1.ExecutionContext(_this._weightMap, tensorArrayMap);
-            var tensors = _this.compiledOrder.reduce(function (map, node) {
-                map[node.name] = operation_executor_1.executeOp(node, map, context);
-                return map;
-            }, __assign({}, _this.weightMap, inputs));
-            return _this.findOutputs(tensors, context, outputs);
+            var tensorMap = __assign({}, _this.weightMap, inputs);
+            var compiledNodes = _this.compiledMap.get(names.join(_this.SEPERATOR));
+            for (var i = 0; i < compiledNodes.length; i++) {
+                var node = compiledNodes[i];
+                if (!tensorMap[node.name]) {
+                    tensorMap[node.name] =
+                        operation_executor_1.executeOp(node, tensorMap, context);
+                }
+                if (outputNames.every(function (name) { return !!tensorMap[name]; })) {
+                    break;
+                }
+            }
+            return _this.findOutputs(tensorMap, context, outputNames);
         });
         return result;
     };
@@ -3677,8 +3703,8 @@ var GraphExecutor = (function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        this.checkInput(inputs);
-                        this.checkInputShapeAndType(inputs);
+                        this.checkInput(inputs, false);
+                        this.checkInputShapeAndType(inputs, false);
                         tensorArrayMap = {};
                         context = new execution_context_1.ExecutionContext(this._weightMap, tensorArrayMap);
                         return [4, this.executeWithControlFlow(inputs, context)];
@@ -3705,11 +3731,14 @@ var GraphExecutor = (function () {
     };
     GraphExecutor.prototype.executeWithControlFlow = function (inputs, context) {
         return __awaiter(this, void 0, void 0, function () {
-            var stack, tensorMap, added, promises;
+            var _this = this;
+            var names, inputNodes, stack, tensorMap, added, promises;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        stack = this.graph.inputs.map(function (node) {
+                        names = Object.keys(inputs);
+                        inputNodes = names.map(function (name) { return _this.graph.nodes[name]; });
+                        stack = inputNodes.concat(this.graph.weights).map(function (node) {
                             return { node: node, contexts: context.currentContext };
                         });
                         tensorMap = __assign({}, this.weightMap, inputs);
@@ -3717,7 +3746,7 @@ var GraphExecutor = (function () {
                         _a.label = 1;
                     case 1:
                         if (!(stack.length > 0)) return [3, 3];
-                        promises = this.processStack(stack, context, tensorMap, added);
+                        promises = this.processStack(inputNodes, stack, context, tensorMap, added);
                         return [4, Promise.all(promises)];
                     case 2:
                         _a.sent();
@@ -3727,7 +3756,7 @@ var GraphExecutor = (function () {
             });
         });
     };
-    GraphExecutor.prototype.processStack = function (stack, context, tensorMap, added) {
+    GraphExecutor.prototype.processStack = function (inputNodes, stack, context, tensorMap, added) {
         var _this = this;
         var promises = [];
         var _loop_1 = function () {
@@ -3738,21 +3767,26 @@ var GraphExecutor = (function () {
                 utils_1.getParamValue('isConstant', item.node, tensorMap, context)) {
                 nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
             }
-            var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
-            if (!nodeName) {
-                nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
-            }
-            var currentContext = context.currentContext;
-            if (tensors instanceof Promise) {
-                promises.push(tensors.then(function (t) {
-                    tensorMap[nodeName] = t;
-                    context.currentContext = currentContext;
-                    _this.processChildNodes(item.node, stack, context, tensorMap, added);
-                    return t;
-                }));
+            if (inputNodes.indexOf(item.node) === -1) {
+                var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
+                if (!nodeName) {
+                    nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
+                }
+                var currentContext_1 = context.currentContext;
+                if (tensors instanceof Promise) {
+                    promises.push(tensors.then(function (t) {
+                        tensorMap[nodeName] = t;
+                        context.currentContext = currentContext_1;
+                        _this.processChildNodes(item.node, stack, context, tensorMap, added);
+                        return t;
+                    }));
+                }
+                else {
+                    tensorMap[nodeName] = tensors;
+                    this_1.processChildNodes(item.node, stack, context, tensorMap, added);
+                }
             }
             else {
-                tensorMap[nodeName] = tensors;
                 this_1.processChildNodes(item.node, stack, context, tensorMap, added);
             }
         };
@@ -3783,11 +3817,14 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+    GraphExecutor.prototype.calculateOutputs = function (outputs) {
         if (outputs && !(outputs instanceof Array)) {
             outputs = [outputs];
         }
-        var requestedOutputs = (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+        return (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+    };
+    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+        var requestedOutputs = this.calculateOutputs(outputs);
         return requestedOutputs.reduce(function (map, name) {
             map[name] = utils_1.getTensor(name, tensorMap, context);
             return map;
@@ -3798,9 +3835,14 @@ var GraphExecutor = (function () {
         Object.keys(this.weightMap)
             .forEach(function (key) { return _this.weightMap[key].forEach(function (tensor) { return tensor.dispose(); }); });
     };
-    GraphExecutor.prototype.checkInputShapeAndType = function (inputs) {
+    GraphExecutor.prototype.checkInputShapeAndType = function (inputs, strictInputCheck) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         this.placeholders.forEach(function (node) {
-            var input = inputs[node.name][0];
+            var inputTensors = inputs[node.name];
+            if (!strictInputCheck && !inputTensors) {
+                return;
+            }
+            var input = inputTensors[0];
             if (node.params['shape'] && node.params['shape'].value) {
                 var shape_1 = node.params['shape'].value;
                 var match = shape_1.length === input.shape.length &&
@@ -3812,8 +3854,9 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.checkInput = function (inputs) {
+    GraphExecutor.prototype.checkInput = function (inputs, strictInputCheck) {
         var _this = this;
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         var inputKeys = Object.keys(inputs);
         var missing = [];
         var extra = [];
@@ -3825,14 +3868,31 @@ var GraphExecutor = (function () {
             if (_this.inputNodes.indexOf(name) === -1)
                 extra.push(name);
         });
-        if (missing.length > 0) {
+        var notInGraph = extra.filter(function (name) { return !_this.graph.nodes[name]; });
+        if (missing.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has the keys " +
                 ("[" + inputKeys + "], but is missing the required keys: [" + missing + "]."));
         }
-        if (extra.length > 0) {
+        if (extra.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has " +
                 ("unused keys: [" + extra + "]. Please provide only the following keys: ") +
                 ("[" + this.inputNodes + "]."));
+        }
+        if (notInGraph.length > 0) {
+            throw new Error("The dict provided in model.execute(dict) has " +
+                ("keys: [" + notInGraph + "] not part of model graph."));
+        }
+    };
+    GraphExecutor.prototype.checkOutput = function (compiledNodes, outputs) {
+        var compiledNodeNames = compiledNodes.map(function (node) { return node.name; });
+        var extra = [];
+        outputs.forEach(function (name) {
+            if (compiledNodeNames.indexOf(name) === -1)
+                extra.push(name);
+        });
+        if (extra.length > 0) {
+            throw new Error("The following outputs are not be generated by the execution: " +
+                ("[" + extra + "]."));
         }
     };
     return GraphExecutor;
@@ -4548,6 +4608,9 @@ exports.executeOp = function (node, tensorMap, context) {
             return [snapshot.clone()];
         case 'shape':
             return [tfc.tensor1d(utils_1.getParamValue('x', node, tensorMap, context).shape, 'int32')];
+        case 'shapeN':
+            return utils_1.getParamValue('x', node, tensorMap, context)
+                .map(function (t) { return tfc.tensor1d(t.shape); });
         case 'size':
             return [tfc.scalar(utils_1.getParamValue('x', node, tensorMap, context).size, 'int32')];
         case 'rank':
@@ -4590,6 +4653,15 @@ exports.executeOp = function (node, tensorMap, context) {
             var size = utils_1.getParamValue('size', node, tensorMap, context);
             var alignCorners = utils_1.getParamValue('alignCorners', node, tensorMap, context);
             return [tfc.image.resizeNearestNeighbor(images, [size[0], size[1]], alignCorners)];
+        }
+        case 'cropAndResize': {
+            var image = utils_1.getParamValue('image', node, tensorMap, context);
+            var boxes = utils_1.getParamValue('boxes', node, tensorMap, context);
+            var boxInd = utils_1.getParamValue('boxInd', node, tensorMap, context);
+            var cropSize = utils_1.getParamValue('cropSize', node, tensorMap, context);
+            var method = utils_1.getParamValue('method', node, tensorMap, context);
+            var extrapolationValue = utils_1.getParamValue('extrapolationValue', node, tensorMap, context);
+            return [tfc.image.cropAndResize(image, boxes, boxInd, cropSize, method, extrapolationValue)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4723,6 +4795,11 @@ exports.executeOp = function (node, tensorMap, context) {
         case 'argMin': {
             var axis = utils_1.getParamValue('axis', node, tensorMap, context);
             return [tfc.argMin(utils_1.getParamValue('x', node, tensorMap, context), axis)];
+        }
+        case 'prod': {
+            var axis = utils_1.getParamValue('axis', node, tensorMap, context);
+            var keepDims = utils_1.getParamValue('keepDims', node, tensorMap, context);
+            return [tfc.prod(utils_1.getParamValue('x', node, tensorMap, context), axis, keepDims)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -5079,6 +5156,20 @@ exports.json = [
     },
     {
         'tfOpName': 'Mod',
+        'dlOpName': 'mod',
+        'category': 'arithmetic',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'FloorMod',
         'dlOpName': 'mod',
         'category': 'arithmetic',
         'params': [
@@ -6238,6 +6329,17 @@ exports.json = [
         'params': [{ 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' }]
     },
     {
+        'tfOpName': 'ShapeN',
+        'dlOpName': 'shapeN',
+        'category': 'graph',
+        'params': [{
+                'tfInputIndex': 0,
+                'tfInputParamLength': 0,
+                'dlParamName': 'x',
+                'type': 'tensors'
+            }]
+    },
+    {
         'tfOpName': 'Print',
         'dlOpName': 'print',
         'category': 'graph',
@@ -6319,6 +6421,22 @@ exports.json = [
                 'dlParamName': 'dtype',
                 'type': 'dtype',
                 'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'CropAndResize',
+        'dlOpName': 'cropAndResize',
+        'category': 'image',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'image', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'boxes', 'type': 'tensor' },
+            { 'tfInputIndex': 2, 'dlParamName': 'boxInd', 'type': 'tensor' },
+            { 'tfInputIndex': 3, 'dlParamName': 'cropSize', 'type': 'number[]' },
+            { 'tfParamName': 'method', 'dlParamName': 'method', 'type': 'string' }, {
+                'tfParamName': 'extrapolation_value',
+                'dlParamName': 'extrapolationValue',
+                'type': 'number'
             }
         ]
     }
@@ -6488,6 +6606,32 @@ exports.json = [
             },
             {
                 'tfParamName': 'transpose_b',
+                'dlParamName': 'transposeB',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'BatchMatMul',
+        'dlOpName': 'matMul',
+        'category': 'matrices',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'adj_x',
+                'dlParamName': 'transposeA',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'adj_y',
                 'dlParamName': 'transposeB',
                 'type': 'bool',
                 'defaultValue': false
@@ -6685,6 +6829,19 @@ exports.json = [
         'params': [
             { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
             { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number' }
+        ]
+    },
+    {
+        'tfOpName': 'Prod',
+        'dlOpName': 'prod',
+        'category': 'reduction',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number[]' }, {
+                'tfParamName': 'keep_dims',
+                'dlParamName': 'keepDims',
+                'type': 'bool'
+            }
         ]
     }
 ];
@@ -6893,6 +7050,21 @@ exports.json = [
                 'dlParamName': 'numOrSizeSplits',
                 'type': 'number',
                 'defaultValue': 1
+            }
+        ]
+    },
+    {
+        'tfOpName': 'SplitV',
+        'dlOpName': 'split',
+        'category': 'slice_join',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'numOrSizeSplits', 'type': 'number[]' },
+            {
+                'tfInputIndex': 2,
+                'dlParamName': 'axis',
+                'type': 'number',
+                'defaultValue': 0
             }
         ]
     }
@@ -7111,6 +7283,7 @@ var OperationMapper = (function () {
         var withControlFlow = false;
         var withDynamicShape = false;
         var placeholders = [];
+        var weights = [];
         var nodes = tfNodes.reduce(function (map, node) {
             map[node.name] = _this.mapNode(node);
             if (_this.isControlFlow(node))
@@ -7119,6 +7292,8 @@ var OperationMapper = (function () {
                 withDynamicShape = true;
             if (node.op === 'Placeholder')
                 placeholders.push(map[node.name]);
+            if (node.op === 'Const')
+                weights.push(map[node.name]);
             return map;
         }, {});
         var inputs = [];
@@ -7142,6 +7317,7 @@ var OperationMapper = (function () {
             nodes: nodes,
             inputs: inputs,
             outputs: outputs,
+            weights: weights,
             placeholders: placeholders,
             withControlFlow: withControlFlow,
             withDynamicShape: withDynamicShape
@@ -7279,7 +7455,7 @@ exports.OperationMapper = OperationMapper;
 },{"../data/compiled_api":10,"./executors/utils":31,"./op_list/arithmetic":32,"./op_list/basic_math":33,"./op_list/control":34,"./op_list/convolution":35,"./op_list/creation":36,"./op_list/dynamic":37,"./op_list/evaluation":38,"./op_list/graph":39,"./op_list/image":40,"./op_list/logical":41,"./op_list/matrices":42,"./op_list/normalization":43,"./op_list/reduction":44,"./op_list/slice_join":45,"./op_list/transformation":46}],49:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.5.9';
+var version = '0.6.5';
 exports.version = version;
 
 },{}],50:[function(require,module,exports){
@@ -9218,18 +9394,24 @@ var Engine = (function () {
         this.safeMode = safeMode;
         this.debugMode = debugMode;
         this.registeredVariables = {};
-        this.refCounter = new WeakMap();
         this.nextTapeNodeId = 0;
         this.numBytes = 0;
         this.numTensors = 0;
         this.numDataBuffers = 0;
+        this.profiling = false;
         this.gradientScopeCount = 0;
         this.customGradientDepth = 0;
         this.keepTensors = new Set();
+        this.tensorInfo = new WeakMap();
         this.activeScope = { track: [], name: 'default scope' };
         this.scopeStack = [this.activeScope];
         this.profiler = new profiler_1.Profiler(backend);
+        this.activeProfile =
+            { newBytes: 0, newTensors: 0, peakBytes: 0, kernels: [], result: null };
     }
+    Engine.prototype.moveData = function (dataId) {
+        this.write(dataId, this.readSync(dataId));
+    };
     Engine.prototype.tidy = function (nameOrFn, fn, gradMode) {
         var _this = this;
         if (gradMode === void 0) { gradMode = false; }
@@ -9281,6 +9463,8 @@ var Engine = (function () {
             return x;
         };
         var scopeName = this.activeScope.name;
+        var startingBytecount = this.numBytes;
+        var startingNumTensors = this.numTensors;
         this.scopedRun(function () { return _this.customGradientDepth++; }, function () { return _this.customGradientDepth--; }, function () {
             if (!_this.debugMode()) {
                 result = forwardFunc(_this.backend, saveFunc);
@@ -9302,10 +9486,25 @@ var Engine = (function () {
             }
             this.activeTape.push(tapeNode);
         }
+        if (this.profiling) {
+            this.activeProfile.kernels.push({
+                name: scopeName,
+                bytesAdded: this.numBytes - startingBytecount,
+                totalBytesSnapshot: this.numBytes,
+                tensorsAdded: this.numTensors - startingNumTensors,
+                totalTensorsSnapshot: this.numTensors,
+                inputShapes: Object.keys(inputs).map(function (key) { return inputs[key].shape; }),
+                outputShape: Array.isArray(result) ?
+                    result.map(function (item) { return item.shape; }) :
+                    result.shape
+            });
+        }
         return result;
     };
     Engine.prototype.registerTensor = function (a) {
-        var refCount = this.refCounter.has(a.dataId) ? this.refCounter.get(a.dataId) : 0;
+        var refCount = this.tensorInfo.has(a.dataId) ?
+            this.tensorInfo.get(a.dataId).refCount :
+            0;
         this.numTensors++;
         if (refCount === 0) {
             this.numDataBuffers++;
@@ -9313,9 +9512,10 @@ var Engine = (function () {
                 this.numBytes +=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.set(a.dataId, { backend: this.backend, dtype: a.dtype, shape: a.shape, refCount: 0 });
             this.backend.register(a.dataId, a.shape, a.dtype);
         }
-        this.refCounter.set(a.dataId, refCount + 1);
+        this.tensorInfo.get(a.dataId).refCount++;
         if (!(a instanceof tensor_1.Variable)) {
             this.track(a);
         }
@@ -9327,25 +9527,26 @@ var Engine = (function () {
         this.registeredVariables[v.name] = v;
     };
     Engine.prototype.disposeTensor = function (a) {
-        if (!this.refCounter.has(a.dataId)) {
+        if (!this.tensorInfo.has(a.dataId)) {
             return;
         }
         if (this.keepTensors.has(a.id)) {
             this.keepTensors.delete(a.id);
         }
         this.numTensors--;
-        var refCount = this.refCounter.get(a.dataId);
+        var refCount = this.tensorInfo.get(a.dataId).refCount;
         if (refCount <= 1) {
-            this.refCounter.delete(a.dataId);
-            this.backend.disposeData(a.dataId);
+            var info = this.tensorInfo.get(a.dataId);
+            info.backend.disposeData(a.dataId);
             this.numDataBuffers--;
             if (a.dtype !== 'complex64') {
                 this.numBytes -=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.delete(a.dataId);
         }
         else {
-            this.refCounter.set(a.dataId, refCount - 1);
+            this.tensorInfo.get(a.dataId).refCount--;
         }
     };
     Engine.prototype.disposeVariables = function () {
@@ -9361,6 +9562,23 @@ var Engine = (function () {
         info.numDataBuffers = this.numDataBuffers;
         info.numBytes = this.numBytes;
         return info;
+    };
+    Engine.prototype.profile = function (query) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startBytes, startNumTensors;
+            return __generator(this, function (_a) {
+                this.profiling = true;
+                startBytes = this.numBytes;
+                startNumTensors = this.numTensors;
+                this.activeProfile.kernels = [];
+                this.activeProfile.result = query();
+                this.profiling = false;
+                this.activeProfile.peakBytes = Math.max.apply(Math, this.activeProfile.kernels.map(function (d) { return d.totalBytesSnapshot; }));
+                this.activeProfile.newBytes = this.numBytes - startBytes;
+                this.activeProfile.newTensors = this.numTensors - startNumTensors;
+                return [2, this.activeProfile];
+            });
+        });
     };
     Engine.prototype.shouldRecord = function () {
         return this.activeTape != null && this.customGradientDepth === 0;
@@ -9506,13 +9724,21 @@ var Engine = (function () {
         };
     };
     Engine.prototype.write = function (dataId, values) {
+        var info = this.tensorInfo.get(dataId);
+        if (this.backend !== info.backend) {
+            info.backend.disposeData(dataId);
+            info.backend = this.backend;
+            this.backend.register(dataId, info.shape, info.dtype);
+        }
         this.backend.write(dataId, values);
     };
     Engine.prototype.readSync = function (dataId) {
-        return this.backend.readSync(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.readSync(dataId);
     };
     Engine.prototype.read = function (dataId) {
-        return this.backend.read(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.read(dataId);
     };
     Engine.prototype.fromPixels = function (pixels, numChannels) {
         return this.backend.fromPixels(pixels, numChannels);
@@ -9549,7 +9775,7 @@ function ones(shape) {
     return tensor_1.Tensor.make(shape, { values: values });
 }
 
-},{"./profiler":184,"./tape":186,"./tensor":187,"./tensor_util":189,"./util":194}],64:[function(require,module,exports){
+},{"./profiler":204,"./tape":206,"./tensor":207,"./tensor_util":209,"./util":214}],64:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -9565,7 +9791,6 @@ var TEST_EPSILON_FLOAT32 = 1e-3;
 var Environment = (function () {
     function Environment(features) {
         this.features = {};
-        this.engines = {};
         this.registry = {};
         if (features != null) {
             this.features = features;
@@ -9581,10 +9806,11 @@ var Environment = (function () {
         if (!(backendName in exports.ENV.registry)) {
             throw new Error("Backend name '" + backendName + "' not found in registry");
         }
-        exports.ENV.initBackend(backendName, safeMode);
+        exports.ENV.engine.backend = exports.ENV.findBackend(backendName);
+        exports.ENV.backendName = backendName;
     };
     Environment.getBackend = function () {
-        exports.ENV.initDefaultBackend();
+        exports.ENV.initEngine();
         return exports.ENV.backendName;
     };
     Environment.disposeVariables = function () {
@@ -9592,6 +9818,9 @@ var Environment = (function () {
     };
     Environment.memory = function () {
         return exports.ENV.engine.memory();
+    };
+    Environment.profile = function (f) {
+        return exports.ENV.engine.profile(f);
     };
     Environment.tidy = function (nameOrFn, fn, gradMode) {
         if (gradMode === void 0) { gradMode = false; }
@@ -9648,6 +9877,18 @@ var Environment = (function () {
         else if (feature === 'IS_CHROME') {
             return environment_util_1.isChrome();
         }
+        else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+            return false;
+        }
+        else if (feature === 'WEBGL_CONV_IM2COL') {
+            return false;
+        }
+        else if (feature === 'WEBGL_PAGING_ENABLED') {
+            return this.get('IS_BROWSER') && !this.get('PROD');
+        }
+        else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
+            return environment_util_1.getWebGLMaxTextureSize(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+        }
         else if (feature === 'IS_TEST') {
             return false;
         }
@@ -9657,9 +9898,6 @@ var Environment = (function () {
         else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
             var webGLVersion = this.get('WEBGL_VERSION');
             if (webGLVersion === 0) {
-                return 0;
-            }
-            if (webGLVersion > 0) {
                 return 0;
             }
             return environment_util_1.getWebGLDisjointQueryTimerVersion(webGLVersion, this.get('IS_BROWSER'));
@@ -9689,6 +9927,10 @@ var Environment = (function () {
         else if (feature === 'WEBGL_FENCE_API_ENABLED') {
             return environment_util_1.isWebGLFenceEnabled(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
         }
+        else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
+            var useUniforms = this.get('WEBGL_RENDER_FLOAT32_ENABLED');
+            return useUniforms ? 4 : 0;
+        }
         else if (feature === 'TEST_EPSILON') {
             return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
                 TEST_EPSILON_FLOAT16;
@@ -9696,6 +9938,12 @@ var Environment = (function () {
         else if (feature === 'EPSILON') {
             return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
                 EPSILON_FLOAT16;
+        }
+        else if (feature === 'PROD') {
+            return false;
+        }
+        else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
+            return !this.get('PROD');
         }
         throw new Error("Unknown feature " + feature + ".");
     };
@@ -9706,20 +9954,6 @@ var Environment = (function () {
         this.features = environment_util_1.getFeaturesFromURL();
         if (this.globalEngine != null) {
             this.globalEngine = null;
-        }
-    };
-    Environment.prototype.initBackend = function (backendName, safeMode) {
-        var _this = this;
-        if (safeMode === void 0) { safeMode = false; }
-        this.backendName = backendName;
-        if (this.engines[backendName]) {
-            this.globalEngine = this.engines[backendName];
-        }
-        else {
-            var backend = this.findBackend(backendName);
-            this.globalEngine =
-                new engine_1.Engine(backend, safeMode, function () { return _this.get('DEBUG'); });
-            this.engines[backendName] = this.globalEngine;
         }
     };
     Object.defineProperty(Environment.prototype, "backend", {
@@ -9747,6 +9981,7 @@ var Environment = (function () {
         }
         try {
             var backend = factory();
+            backend.setDataMover({ moveData: function (dataId) { return _this.engine.moveData(dataId); } });
             this.registry[name] = { backend: backend, priority: priority };
             return true;
         }
@@ -9762,21 +9997,22 @@ var Environment = (function () {
         }
         this.registry[name].backend.dispose();
         delete this.registry[name];
-        if (name in this.engines) {
-            delete this.engines[name];
-        }
     };
     Object.defineProperty(Environment.prototype, "engine", {
         get: function () {
-            this.initDefaultBackend();
+            this.initEngine();
             return this.globalEngine;
         },
         enumerable: true,
         configurable: true
     });
-    Environment.prototype.initDefaultBackend = function () {
+    Environment.prototype.initEngine = function () {
+        var _this = this;
         if (this.globalEngine == null) {
-            this.initBackend(this.get('BACKEND'), false);
+            this.backendName = this.get('BACKEND');
+            var backend = this.findBackend(this.backendName);
+            this.globalEngine =
+                new engine_1.Engine(backend, false, function () { return _this.get('DEBUG'); });
         }
     };
     return Environment;
@@ -9806,7 +10042,7 @@ function getOrMakeEnvironment() {
 exports.ENV = getOrMakeEnvironment();
 
 }).call(this,require('_process'))
-},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":187,"./tensor_util":189,"_process":269}],65:[function(require,module,exports){
+},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":207,"./tensor_util":209,"_process":293}],65:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Type;
@@ -9816,14 +10052,23 @@ var Type;
     Type[Type["STRING"] = 2] = "STRING";
 })(Type = exports.Type || (exports.Type = {}));
 exports.URL_PROPERTIES = [
-    { name: 'DEBUG', type: Type.BOOLEAN }, { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'DEBUG', type: Type.BOOLEAN },
+    { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN },
+    { name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN },
+    { name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER },
+    { name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN },
     { name: 'WEBGL_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_RENDER_FLOAT32_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DOWNLOAD_FLOAT_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_FENCE_API_ENABLED', type: Type.BOOLEAN },
-    { name: 'BACKEND', type: Type.STRING }, { name: 'EPSILON', type: Type.NUMBER }
+    { name: 'WEBGL_SIZE_UPLOAD_UNIFORM', type: Type.NUMBER },
+    { name: 'BACKEND', type: Type.STRING },
+    { name: 'EPSILON', type: Type.NUMBER },
+    { name: 'PROD', type: Type.BOOLEAN },
+    { name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN },
 ];
 function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     var gl;
@@ -9840,6 +10085,15 @@ function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     return false;
 }
 exports.isWebGLVersionEnabled = isWebGLVersionEnabled;
+var MAX_TEXTURE_SIZE;
+function getWebGLMaxTextureSize(webGLVersion, isBrowser) {
+    if (MAX_TEXTURE_SIZE == null) {
+        var gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+        MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    }
+    return MAX_TEXTURE_SIZE;
+}
+exports.getWebGLMaxTextureSize = getWebGLMaxTextureSize;
 function getWebGLDisjointQueryTimerVersion(webGLVersion, isBrowser) {
     if (webGLVersion === 0) {
         return 0;
@@ -10028,6 +10282,7 @@ exports.tidy = environment_1.Environment.tidy;
 exports.keep = environment_1.Environment.keep;
 exports.dispose = environment_1.Environment.dispose;
 exports.time = environment_1.Environment.time;
+exports.profile = environment_1.Environment.profile;
 
 },{"./environment":64,"./gradients":67}],67:[function(require,module,exports){
 "use strict";
@@ -10142,7 +10397,7 @@ function checkGrads(grads) {
     }
 }
 
-},{"./environment":64,"./tensor":187,"./util":194}],68:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],68:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -10157,6 +10412,8 @@ exports.environment = environment;
 var environment_1 = require("./environment");
 var io = require("./io/io");
 exports.io = io;
+var math = require("./math");
+exports.math = math;
 var serialization = require("./serialization");
 exports.serialization = serialization;
 var tensor_1 = require("./tensor");
@@ -10203,10 +10460,12 @@ exports.setBackend = environment_1.Environment.setBackend;
 exports.getBackend = environment_1.Environment.getBackend;
 exports.disposeVariables = environment_1.Environment.disposeVariables;
 exports.memory = environment_1.Environment.memory;
+var backend_1 = require("./kernels/backend");
+exports.DataStorage = backend_1.DataStorage;
 var ops = require("./ops/ops");
 tensor_1.setOpHandler(ops);
 
-},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend_cpu":80,"./kernels/backend_webgl":82,"./ops/loss_ops":150,"./ops/ops":157,"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer":180,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183,"./serialization":185,"./tensor":187,"./test_util":191,"./train":192,"./types":193,"./util":194,"./version":195,"./webgl":196}],69:[function(require,module,exports){
+},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend":80,"./kernels/backend_cpu":81,"./kernels/backend_webgl":83,"./math":145,"./ops/loss_ops":165,"./ops/ops":172,"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer":200,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203,"./serialization":205,"./tensor":207,"./test_util":211,"./train":212,"./types":213,"./util":214,"./version":215,"./webgl":216}],69:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10698,7 +10957,7 @@ function browserHTTPRequest(path, requestInit) {
 }
 exports.browserHTTPRequest = browserHTTPRequest;
 
-},{"../util":194,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11279,7 +11538,7 @@ function getModelArtifactsInfoForJSON(modelArtifacts) {
 exports.getModelArtifactsInfoForJSON = getModelArtifactsInfoForJSON;
 
 }).call(this,require("buffer").Buffer)
-},{"../ops/tensor_ops":171,"../util":194,"./types":78,"buffer":251}],74:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214,"./types":78,"buffer":275}],74:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11527,7 +11786,7 @@ if (environment_1.ENV.get('IS_BROWSER')) {
     }
 }
 
-},{"../environment":64,"../util":194,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
+},{"../environment":64,"../util":214,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11731,7 +11990,7 @@ function moveModel(sourceURL, destURL) {
 }
 exports.moveModel = moveModel;
 
-},{"../util":194,"./router_registry":77}],76:[function(require,module,exports){
+},{"../util":214,"./router_registry":77}],76:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -12040,7 +12299,34 @@ function loadWeights(manifest, filePathPrefix, weightNames, requestOptions) {
 }
 exports.loadWeights = loadWeights;
 
-},{"../util":194,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var DataStorage = (function () {
+    function DataStorage(dataMover) {
+        this.dataMover = dataMover;
+        this.data = new WeakMap();
+    }
+    DataStorage.prototype.get = function (dataId) {
+        if (!this.data.has(dataId)) {
+            this.dataMover.moveData(dataId);
+        }
+        return this.data.get(dataId);
+    };
+    DataStorage.prototype.set = function (dataId, value) {
+        this.data.set(dataId, value);
+    };
+    DataStorage.prototype.has = function (dataId) {
+        return this.data.has(dataId);
+    };
+    DataStorage.prototype.delete = function (dataId) {
+        return this.data.delete(dataId);
+    };
+    return DataStorage;
+}());
+exports.DataStorage = DataStorage;
+
+},{}],81:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -12086,14 +12372,17 @@ var axis_util = require("../ops/axis_util");
 var broadcast_util = require("../ops/broadcast_util");
 var concat_util = require("../ops/concat_util");
 var erf_util = require("../ops/erf_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var ops = require("../ops/ops");
 var ops_1 = require("../ops/ops");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var selu_util = require("../ops/selu_util");
 var slice_util_1 = require("../ops/slice_util");
 var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -12103,12 +12392,14 @@ var where_impl_1 = require("./where_impl");
 var MathBackendCPU = (function () {
     function MathBackendCPU() {
         this.blockSize = 48;
-        this.data = new WeakMap();
         this.firstUse = true;
         if (environment_1.ENV.get('IS_BROWSER')) {
             this.canvas = document.createElement('canvas');
         }
     }
+    MathBackendCPU.prototype.setDataMover = function (dataMover) {
+        this.data = new backend_1.DataStorage(dataMover);
+    };
     MathBackendCPU.prototype.register = function (dataId, shape, dtype) {
         if (this.firstUse) {
             this.firstUse = false;
@@ -12134,7 +12425,6 @@ var MathBackendCPU = (function () {
         if (values == null) {
             throw new Error('MathBackendCPU.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         this.data.get(dataId).values = values;
     };
     MathBackendCPU.prototype.fromPixels = function (pixels, numChannels) {
@@ -12197,7 +12487,6 @@ var MathBackendCPU = (function () {
         });
     };
     MathBackendCPU.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var _a = this.data.get(dataId), dtype = _a.dtype, complexTensors = _a.complexTensors;
         if (dtype === 'complex64') {
             var realValues = complexTensors.real.dataSync();
@@ -12231,13 +12520,6 @@ var MathBackendCPU = (function () {
         return {
             unreliable: true
         };
-    };
-    MathBackendCPU.prototype.throwIfNoData = function (dataId) {
-        if (!this.data.has(dataId)) {
-            throw new Error("CPU backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
     };
     MathBackendCPU.prototype.complex = function (real, imag) {
         var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
@@ -12458,6 +12740,24 @@ var MathBackendCPU = (function () {
                 sum += aVals[offset + j];
             }
             vals[i] = sum;
+        }
+        return result;
+    };
+    MathBackendCPU.prototype.prod = function (x, axes) {
+        this.assertNotComplex(x, 'sum');
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var resultDtype = types_1.upcastType(x.dtype, 'int32');
+        var result = ops.zeros(outShape, resultDtype);
+        var reduceSize = util.sizeFromShape(reduceShape);
+        var vals = result.dataSync();
+        var aVals = x.dataSync();
+        for (var i = 0; i < vals.length; ++i) {
+            var offset = i * reduceSize;
+            var prod = 1;
+            for (var j = 0; j < reduceSize; ++j) {
+                prod *= aVals[offset + j];
+            }
+            vals[i] = prod;
         }
         return result;
     };
@@ -12954,11 +13254,19 @@ var MathBackendCPU = (function () {
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
     MathBackendCPU.prototype.abs = function (x) {
-        this.assertNotComplex(x, 'abs');
         var resultValues = new Float32Array(x.size);
         var values = x.dataSync();
-        for (var i = 0; i < values.length; ++i) {
-            resultValues[i] = Math.abs(values[i]);
+        if (x.dtype === 'complex64') {
+            for (var i = 0; i < x.size; ++i) {
+                var real = values[i * 2];
+                var imag = values[i * 2 + 1];
+                resultValues[i] = Math.sqrt(real * real + imag * imag);
+            }
+        }
+        else {
+            for (var i = 0; i < values.length; ++i) {
+                resultValues[i] = Math.abs(values[i]);
+            }
         }
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
@@ -13517,8 +13825,10 @@ var MathBackendCPU = (function () {
         this.assertNotComplex(x, 'pool');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var y = ops.buffer(convInfo.outShape, 'float32');
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
@@ -13529,16 +13839,16 @@ var MathBackendCPU = (function () {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
                     var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
                         var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var minMaxValue = initialValue;
                         var avgValue = 0;
                         var count = 0;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var pixel = x.get(b, xR, xC, d);
                                 if ((poolType === 'max' && pixel > minMaxValue)) {
                                     minMaxValue = pixel;
@@ -13566,30 +13876,38 @@ var MathBackendCPU = (function () {
         var maxPositions = ops.buffer(convInfo.outShape, 'int32');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
-                    var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMin = xRCorner;
+                    while (xRMin < 0) {
+                        xRMin += dilationHeight;
+                    }
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
-                        var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMin = xCCorner;
+                        while (xCMin < 0) {
+                            xCMin += dilationWidth;
+                        }
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var maxValue = Number.NEGATIVE_INFINITY;
                         var maxPosition = -1;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
                             var wR = xR - xRCorner;
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var wC = xC - xCCorner;
                                 var pixel = x.get(b, xR, xC, d);
                                 if (pixel > maxValue) {
                                     maxValue = pixel;
-                                    maxPosition = wR * filterWidth + wC;
+                                    maxPosition = wR * effectiveFilterWidth + wC;
                                 }
                             }
                         }
@@ -13605,10 +13923,12 @@ var MathBackendCPU = (function () {
         var maxPositions = this.maxPoolPositions(x, convInfo);
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
@@ -13617,21 +13937,21 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
                                     continue;
                                 }
-                                var maxPos = filterHeight * filterWidth - 1 -
-                                    maxPositions.get(b, dyR, dyC, d);
-                                var curPos = wR * filterWidth + wC;
+                                var maxPos = effectiveFilterHeight * effectiveFilterWidth -
+                                    1 - maxPositions.get(b, dyR, dyC, d);
+                                var curPos = wR * effectiveFilterWidth + wC;
                                 var mask = maxPos === curPos ? 1 : 0;
                                 if (mask === 0) {
                                     continue;
@@ -13653,8 +13973,12 @@ var MathBackendCPU = (function () {
         var strideWidth = convInfo.strideWidth;
         var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         var avgMultiplier = 1 / (filterHeight * filterWidth);
         for (var b = 0; b < convInfo.batchSize; ++b) {
@@ -13664,13 +13988,13 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
@@ -13700,7 +14024,8 @@ var MathBackendCPU = (function () {
     MathBackendCPU.prototype.resizeBilinear = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeBilinear');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var result = new Float32Array(util.sizeFromShape([batch, newHeight, newWidth, numChannels]));
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13709,37 +14034,46 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var outputIdx = 0;
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
         for (var b = 0; b < batch; b++) {
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceRowFloor = Math.floor(sourceFracRow);
+                var rowFrac = sourceFracRow - sourceRowFloor;
+                var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
+                var topRowOffset = b * x.strides[0] + sourceRowFloor * x.strides[1];
+                var botRowOffset = b * x.strides[0] + sourceRowCeil * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceColFloor = Math.floor(sourceFracCol);
+                    var colFrac = sourceFracCol - sourceColFloor;
+                    var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
+                    var topLeftOffest = topRowOffset + sourceColFloor * x.strides[2];
+                    var botLeftOffset = botRowOffset + sourceColFloor * x.strides[2];
+                    var topRightOffset = topRowOffset + +sourceColCeil * x.strides[2];
+                    var botRightOffest = botRowOffset + sourceColCeil * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceRowFloor = Math.floor(sourceFracRow);
-                        var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
-                        var sourceColFloor = Math.floor(sourceFracCol);
-                        var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
-                        var topLeft = x.get(b, sourceRowFloor, sourceColFloor, d);
-                        var bottomLeft = x.get(b, sourceRowCeil, sourceColFloor, d);
-                        var topRight = x.get(b, sourceRowFloor, sourceColCeil, d);
-                        var bottomRight = x.get(b, sourceRowCeil, sourceColCeil, d);
-                        var rowFrac = sourceFracRow - sourceRowFloor;
-                        var colFrac = sourceFracCol - sourceColFloor;
+                        var topLeft = xValues[topLeftOffest + d];
+                        var bottomLeft = xValues[botLeftOffset + d];
+                        var topRight = xValues[topRightOffset + d];
+                        var bottomRight = xValues[botRightOffest + d];
                         var top_1 = topLeft + (topRight - topLeft) * colFrac;
                         var bottom = bottomLeft + (bottomRight - bottomLeft) * colFrac;
                         var newValue = top_1 + (bottom - top_1) * rowFrac;
-                        output.set(newValue, b, r, c, d);
+                        result[outputIdx++] = newValue;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(result, [batch, newHeight, newWidth, numChannels]);
     };
     MathBackendCPU.prototype.resizeBilinearBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeBilinearBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13750,11 +14084,16 @@ var MathBackendCPU = (function () {
         ];
         var heightScale = effectiveXSize[0] / effectiveYSize[0];
         var widthScale = effectiveXSize[1] / effectiveYSize[1];
+        var dyValues = dy.dataSync();
+        var offset = 0;
         for (var b = 0; b < batch; b++) {
+            var bOffset = b * x.strides[0];
             for (var r = 0; r < yHeight; r++) {
                 var dxR = r * heightScale;
                 var topDxRIndex = Math.floor(dxR);
                 var bottomDxRIndex = Math.min(Math.ceil(dxR), xHeight - 1);
+                var topDxROffset = bOffset + topDxRIndex * x.strides[1];
+                var bottomDxROffset = bOffset + bottomDxRIndex * x.strides[1];
                 var dxRLerp = dxR - topDxRIndex;
                 var inverseDxRLerp = 1.0 - dxRLerp;
                 for (var c = 0; c < yWidth; c++) {
@@ -13763,30 +14102,33 @@ var MathBackendCPU = (function () {
                     var rightDxCIndex = Math.min(Math.ceil(dxC), xWidth - 1);
                     var dxCLerp = dxC - leftDxCIndex;
                     var inverseDxCLerp = 1.0 - dxCLerp;
+                    var topLeftRCOffset = topDxROffset + leftDxCIndex * x.strides[2];
+                    var topRightRCOffset = topDxROffset + rightDxCIndex * x.strides[2];
+                    var bottomLeftRCOffset = bottomDxROffset + leftDxCIndex * x.strides[2];
+                    var bottomRightRCOffset = bottomDxROffset + rightDxCIndex * x.strides[2];
+                    var inverseDxRLerpTimesInverseDxCLerp = inverseDxRLerp * inverseDxCLerp;
+                    var inverseDxRLerpTimesDxCLerp = inverseDxRLerp * dxCLerp;
+                    var dxRLerpTimesInverseDxCLerp = dxRLerp * inverseDxCLerp;
+                    var dxRLerpTimesDxCLerp = dxRLerp * dxCLerp;
                     for (var d = 0; d < depth; d++) {
-                        var dyVal = dy.get(b, r, c, d);
-                        var topLeft = output.get(b, topDxRIndex, leftDxCIndex, d);
-                        topLeft += dyVal * inverseDxRLerp * inverseDxCLerp;
-                        output.set(topLeft, b, topDxRIndex, leftDxCIndex, d);
-                        var topRight = output.get(b, topDxRIndex, rightDxCIndex, d);
-                        topRight += dyVal * inverseDxRLerp * dxCLerp;
-                        output.set(topRight, b, topDxRIndex, rightDxCIndex, d);
-                        var bottomLeft = output.get(b, bottomDxRIndex, leftDxCIndex, d);
-                        bottomLeft += dyVal * dxRLerp * inverseDxCLerp;
-                        output.set(bottomLeft, b, bottomDxRIndex, leftDxCIndex, d);
-                        var bottomRight = output.get(b, bottomDxRIndex, rightDxCIndex, d);
-                        bottomRight += dyVal * dxRLerp * dxCLerp;
-                        output.set(bottomRight, b, bottomDxRIndex, rightDxCIndex, d);
+                        var dyVal = dyValues[offset++];
+                        output[topLeftRCOffset + d] +=
+                            dyVal * inverseDxRLerpTimesInverseDxCLerp;
+                        output[topRightRCOffset + d] += dyVal * inverseDxRLerpTimesDxCLerp;
+                        output[bottomLeftRCOffset + d] +=
+                            dyVal * dxRLerpTimesInverseDxCLerp;
+                        output[bottomRightRCOffset + d] += dyVal * dxRLerpTimesDxCLerp;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, [batch, xWidth, xHeight, depth], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighbor = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeNearestNeighbor');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var output = new Float32Array(batch * newHeight * newWidth * numChannels);
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13795,29 +14137,36 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
+        var outputOffset = 0;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                    Math.floor(sourceFracRow));
+                var rowOffset = batchOffset + sourceNearestRow * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
+                        Math.floor(sourceFracCol));
+                    var colOffset = rowOffset + sourceNearestCol * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                            Math.floor(sourceFracRow));
-                        var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
-                            Math.floor(sourceFracCol));
-                        var newValue = x.get(b, sourceNearestRow, sourceNearestCol, d);
-                        output.set(newValue, b, r, c, d);
+                        var newVal = xValues[colOffset + d];
+                        output[outputOffset++] = newVal;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(output, [batch, newHeight, newWidth, numChannels], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighborBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeNearestNeighborBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
+        var dyValues = dy.dataSync();
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13833,41 +14182,49 @@ var MathBackendCPU = (function () {
         var winHeight = (Math.ceil(invHeightScale) * 2) + 2;
         var winWidth = (Math.ceil(invWidthScale) * 2) + 2;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < xHeight; r++) {
+                var rowOffset = batchOffset + r * x.strides[1];
+                var startRLerp = Math.floor(r * invHeightScale);
+                var startDyR = Math.floor(startRLerp - (winHeight / 2));
                 for (var c = 0; c < xWidth; c++) {
-                    var startRLerp = Math.floor(r * invHeightScale);
-                    var startDyR = Math.floor(startRLerp - (winHeight / 2));
+                    var colOffset = rowOffset + c * x.strides[2];
                     var startCLerp = Math.floor(c * invWidthScale);
                     var startDyC = Math.floor(startCLerp - (winWidth / 2));
                     for (var d = 0; d < depth; d++) {
                         var accum = 0;
-                        for (var dyROffset = 0; dyROffset < winHeight; dyROffset++) {
-                            var dyR = dyROffset + startDyR;
+                        for (var dyRIndex = 0; dyRIndex < winHeight; dyRIndex++) {
+                            var dyR = dyRIndex + startDyR;
                             if (dyR < 0 || dyR >= yHeight) {
                                 continue;
                             }
-                            for (var dyCOffSet = 0; dyCOffSet < winWidth; dyCOffSet++) {
-                                var dyC = dyCOffSet + startDyC;
+                            var dyROffset = batchOffset + dyR * dy.strides[1];
+                            var sourceFracRow = dyR * heightScale;
+                            var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                                Math.floor(sourceFracRow));
+                            if (r !== sourceNearestRow) {
+                                continue;
+                            }
+                            for (var dyCIndex = 0; dyCIndex < winWidth; dyCIndex++) {
+                                var dyC = dyCIndex + startDyC;
                                 if (dyC < 0 || dyC >= yWidth) {
                                     continue;
                                 }
-                                var sourceFracRow = effectiveXSize[0] * (dyR / effectiveYSize[0]);
-                                var sourceFracCol = effectiveXSize[1] * (dyC / effectiveYSize[1]);
-                                var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                                    Math.floor(sourceFracRow));
+                                var dyCOffset = dyROffset + dyC * dy.strides[2];
+                                var sourceFracCol = dyC * widthScale;
                                 var sourceNearestCol = Math.min(xWidth - 1, alignCorners ? Math.round(sourceFracCol) :
                                     Math.floor(sourceFracCol));
-                                if (r === sourceNearestRow && c === sourceNearestCol) {
-                                    accum += dy.get(b, dyR, dyC, d);
+                                if (c === sourceNearestCol) {
+                                    accum += dyValues[dyCOffset + d];
                                 }
                             }
                         }
-                        output.set(accum, b, r, c, d);
+                        output[colOffset + d] = accum;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, x.shape, x.dtype);
     };
     MathBackendCPU.prototype.batchNormalization = function (x, mean, variance, varianceEpsilon, scale, offset) {
         this.assertNotComplex([x, mean, variance, scale, offset], 'batchNormalization');
@@ -14007,6 +14364,61 @@ var MathBackendCPU = (function () {
         var scoresVals = scores.dataSync();
         return non_max_suppression_impl_1.nonMaxSuppressionImpl(boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
     };
+    MathBackendCPU.prototype.fft = function (input) {
+        if (input.shape[0] !== 1) {
+            throw new Error("tf.fft() on CPU only supports vectors.");
+        }
+        var input1D = input.as1D();
+        var n = input1D.size;
+        if (this.isExponentOf2(n)) {
+            return this.fftRadix2(input1D, n).as2D(input.shape[0], input.shape[1]);
+        }
+        else {
+            var data = input.dataSync();
+            var rawOutput = this.fourierTransformByMatmul(data, n);
+            var output = complex_util.splitRealAndImagArrays(rawOutput);
+            return ops.complex(output.real, output.imag)
+                .as2D(input.shape[0], input.shape[1]);
+        }
+    };
+    MathBackendCPU.prototype.isExponentOf2 = function (size) {
+        return (size & size - 1) === 0;
+    };
+    MathBackendCPU.prototype.fftRadix2 = function (input, size) {
+        if (size === 1) {
+            return input;
+        }
+        var data = input.dataSync();
+        var half = size / 2;
+        var evenComplex = complex_util.complexWithEvenIndex(data);
+        var evenTensor = ops.complex(evenComplex.real, evenComplex.imag).as1D();
+        var oddComplex = complex_util.complexWithOddIndex(data);
+        var oddTensor = ops.complex(oddComplex.real, oddComplex.imag).as1D();
+        evenTensor = this.fftRadix2(evenTensor, half);
+        oddTensor = this.fftRadix2(oddTensor, half);
+        var e = complex_util.exponents(size);
+        var exponent = ops.complex(e.real, e.imag).mul(oddTensor);
+        var addPart = evenTensor.add(exponent);
+        var subPart = evenTensor.sub(exponent);
+        var realTensor = ops.real(addPart).concat(ops.real(subPart));
+        var imagTensor = ops.imag(addPart).concat(ops.imag(subPart));
+        return ops.complex(realTensor, imagTensor).as1D();
+    };
+    MathBackendCPU.prototype.fourierTransformByMatmul = function (data, size) {
+        var ret = new Float32Array(size * 2);
+        for (var r = 0; r < size; r++) {
+            var real = 0.0;
+            var imag = 0.0;
+            for (var c = 0; c < size; c++) {
+                var e = complex_util.exponent(r * c, size);
+                var term = complex_util.getComplexWithIndex(data, c);
+                real += term.real * e.real - term.imag * e.imag;
+                imag += term.real * e.imag + term.imag * e.real;
+            }
+            complex_util.assignToTypedArray(ret, real, imag, r);
+        }
+        return ret;
+    };
     MathBackendCPU.prototype.depthToSpace = function (x, blockSize, dataFormat) {
         util.assert(dataFormat === 'NHWC', "Only NHWC dataFormat supported on CPU for depthToSpace. Got " + dataFormat);
         util.assert(blockSize > 1, "blockSize should be > 1 for depthToSpace, but was: " + blockSize);
@@ -14140,9 +14552,7 @@ var MathBackendCPU = (function () {
             var heightScale = (cropHeight > 1) ?
                 (y2 - y1) * (imageHeight - 1) / (cropHeight - 1) :
                 0;
-            var widthScale = (cropWidth > 1) ?
-                (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) :
-                0;
+            var widthScale = (cropWidth > 1) ? (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) : 0;
             for (var y = 0; y < cropHeight; y++) {
                 var yInd = (cropHeight > 1) ?
                     y1 * (imageHeight - 1) + y * (heightScale) :
@@ -14150,8 +14560,7 @@ var MathBackendCPU = (function () {
                 if (yInd < 0 || yInd > imageHeight - 1) {
                     for (var x = 0; x < cropWidth; x++) {
                         for (var c = 0; c < numChannels; c++) {
-                            var ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = extrapolationValue;
                         }
                     }
@@ -14167,8 +14576,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14191,8 +14599,7 @@ var MathBackendCPU = (function () {
                             var bottomRight = imageVals[ind];
                             var top_2 = topLeft + (topRight - topLeft) * xLerp;
                             var bottom = bottomLeft + (bottomRight - bottomLeft) * xLerp;
-                            ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = top_2 + ((bottom - top_2) * yLerp);
                         }
                     }
@@ -14204,8 +14611,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14213,10 +14619,9 @@ var MathBackendCPU = (function () {
                         var closestX = Math.round(xInd);
                         var closestY = Math.round(yInd);
                         for (var c = 0; c < numChannels; c++) {
-                            var inInd = c + closestX * inStride[2]
-                                + closestY * inStride[1] + bInd * inStride[0];
-                            var outInd = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var inInd = c + closestX * inStride[2] +
+                                closestY * inStride[1] + bInd * inStride[0];
+                            var outInd = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[outInd] = imageVals[inInd];
                         }
                     }
@@ -14225,12 +14630,84 @@ var MathBackendCPU = (function () {
         }
         return output.toTensor();
     };
+    MathBackendCPU.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        return this.scatter(sparseIndices, sparseValues, outputShape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        if (numSlices === 0) {
+            return ops_1.tensor([], resultShape, x.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer([numSlices, sliceSize], x.dtype);
+        var indicesData = indices.dataSync();
+        var xData = x.dataSync();
+        for (var i = 0; i < numSlices; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                flattenIndex += dim * strides[j];
+                index.push(dim);
+            }
+            if (flattenIndex < 0 || flattenIndex >= x.size / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + x.shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                buffer.values[i * sliceSize + k] = xData[flattenIndex * sliceSize + k];
+            }
+        }
+        return buffer.toTensor().reshape(resultShape);
+    };
+    MathBackendCPU.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var defaultValue = ops_1.scalar(0);
+        var sumDupeIndices = true;
+        return this.scatter(indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.scatter = function (indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices) {
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var indicesData = indices.dataSync();
+        var updatesData = updates.dataSync();
+        if (outputSize === 0) {
+            return ops_1.tensor([], shape, updates.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer(flattenShape, updates.dtype);
+        buffer.values.fill(defaultValue.dataSync()[0]);
+        for (var i = 0; i < numUpdates; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                index.push(dim);
+                flattenIndex += dim * strides[j];
+            }
+            if (flattenIndex < 0 || flattenIndex >= outputSize / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                if (sumDupeIndices) {
+                    buffer.values[flattenIndex * sliceSize + k] +=
+                        updatesData[i * sliceSize + k];
+                }
+                else {
+                    buffer.values[flattenIndex * sliceSize + k] = updates.rank === 0 ?
+                        updatesData[0] :
+                        updatesData[i * sliceSize + k];
+                }
+            }
+        }
+        return buffer.toTensor().reshape(shape);
+    };
     return MathBackendCPU;
 }());
 exports.MathBackendCPU = MathBackendCPU;
 environment_1.ENV.registerBackend('cpu', function () { return new MathBackendCPU(); }, 1, tensor_1.setTensorTracker);
 
-},{"../environment":64,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/broadcast_util":139,"../ops/concat_util":143,"../ops/erf_util":146,"../ops/ops":157,"../ops/selu_util":166,"../ops/slice_util":168,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./where_impl":132,"seedrandom":281}],81:[function(require,module,exports){
+},{"../environment":64,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/broadcast_util":151,"../ops/concat_util":155,"../ops/erf_util":159,"../ops/gather_nd_util":161,"../ops/ops":172,"../ops/scatter_nd_util":180,"../ops/selu_util":183,"../ops/slice_util":185,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./where_impl":143,"seedrandom":305}],82:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -14276,7 +14753,7 @@ function reshapeTensor(x, shape) {
 }
 exports.reshapeTensor = reshapeTensor;
 
-},{"../ops/tensor_ops":171,"../tensor":187,"../util":194}],82:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../tensor":207,"../util":214}],83:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14320,7 +14797,9 @@ var log_1 = require("../log");
 var array_ops_util = require("../ops/array_ops_util");
 var axis_util = require("../ops/axis_util");
 var concat_util_1 = require("../ops/concat_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var reduce_util = require("../ops/reduce_util");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var segment_util = require("../ops/segment_util");
 var slice_util_1 = require("../ops/slice_util");
 var softmax_1 = require("../ops/softmax");
@@ -14329,6 +14808,7 @@ var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util_1 = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -14337,31 +14817,39 @@ var topk_impl_1 = require("./topk_impl");
 var argminmax_gpu_1 = require("./webgl/argminmax_gpu");
 var avg_pool_backprop_gpu_1 = require("./webgl/avg_pool_backprop_gpu");
 var batchnorm_gpu_1 = require("./webgl/batchnorm_gpu");
+var batchnorm_packed_gpu_1 = require("./webgl/batchnorm_packed_gpu");
 var binaryop_complex_gpu = require("./webgl/binaryop_complex_gpu");
 var binaryop_complex_gpu_1 = require("./webgl/binaryop_complex_gpu");
 var binaryop_gpu = require("./webgl/binaryop_gpu");
 var binaryop_gpu_1 = require("./webgl/binaryop_gpu");
 var clip_gpu_1 = require("./webgl/clip_gpu");
+var complex_abs_gpu_1 = require("./webgl/complex_abs_gpu");
 var concat_gpu_1 = require("./webgl/concat_gpu");
 var conv_backprop_gpu_1 = require("./webgl/conv_backprop_gpu");
 var conv_backprop_gpu_depthwise_1 = require("./webgl/conv_backprop_gpu_depthwise");
 var conv_gpu_1 = require("./webgl/conv_gpu");
-var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var conv_gpu_depthwise_1 = require("./webgl/conv_gpu_depthwise");
+var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var cumsum_gpu_1 = require("./webgl/cumsum_gpu");
 var depth_to_space_gpu_1 = require("./webgl/depth_to_space_gpu");
 var encode_float_gpu_1 = require("./webgl/encode_float_gpu");
+var fft_gpu = require("./webgl/fft_gpu");
+var fft_gpu_1 = require("./webgl/fft_gpu");
 var from_pixels_gpu_1 = require("./webgl/from_pixels_gpu");
 var gather_gpu_1 = require("./webgl/gather_gpu");
+var gather_nd_gpu_1 = require("./webgl/gather_nd_gpu");
 var gpgpu_context_1 = require("./webgl/gpgpu_context");
 var gpgpu_math = require("./webgl/gpgpu_math");
 var gpgpu_util = require("./webgl/gpgpu_util");
+var im2col_gpu_1 = require("./webgl/im2col_gpu");
 var lrn_gpu_1 = require("./webgl/lrn_gpu");
 var lrn_grad_gpu_1 = require("./webgl/lrn_grad_gpu");
 var max_pool_backprop_gpu_1 = require("./webgl/max_pool_backprop_gpu");
 var mulmat_gpu_1 = require("./webgl/mulmat_gpu");
+var mulmat_packed_gpu_1 = require("./webgl/mulmat_packed_gpu");
 var multinomial_gpu_1 = require("./webgl/multinomial_gpu");
 var onehot_gpu_1 = require("./webgl/onehot_gpu");
+var pack_gpu_1 = require("./webgl/pack_gpu");
 var pad_gpu_1 = require("./webgl/pad_gpu");
 var pool_gpu_1 = require("./webgl/pool_gpu");
 var reduce_gpu_1 = require("./webgl/reduce_gpu");
@@ -14370,6 +14858,7 @@ var resize_bilinear_gpu_1 = require("./webgl/resize_bilinear_gpu");
 var resize_nearest_neighbor_backprop_gpu_1 = require("./webgl/resize_nearest_neighbor_backprop_gpu");
 var resize_nearest_neighbor_gpu_1 = require("./webgl/resize_nearest_neighbor_gpu");
 var reverse_gpu_1 = require("./webgl/reverse_gpu");
+var scatter_gpu_1 = require("./webgl/scatter_gpu");
 var segment_gpu_1 = require("./webgl/segment_gpu");
 var select_gpu_1 = require("./webgl/select_gpu");
 var slice_gpu_1 = require("./webgl/slice_gpu");
@@ -14380,16 +14869,16 @@ var tile_gpu_1 = require("./webgl/tile_gpu");
 var transpose_gpu_1 = require("./webgl/transpose_gpu");
 var unary_op = require("./webgl/unaryop_gpu");
 var unaryop_gpu_1 = require("./webgl/unaryop_gpu");
+var unpack_gpu_1 = require("./webgl/unpack_gpu");
 var webgl_util = require("./webgl/webgl_util");
 var where_impl_1 = require("./where_impl");
 var BEFORE_PAGING_CONSTANT = 300;
-exports.SIZE_UPLOAD_UNIFORM = 32;
+exports.SIZE_UPLOAD_UNIFORM = 4;
 var MathBackendWebGL = (function () {
     function MathBackendWebGL(gpgpu, delayedStorage) {
         if (delayedStorage === void 0) { delayedStorage = true; }
         this.gpgpu = gpgpu;
         this.delayedStorage = delayedStorage;
-        this.texData = new WeakMap();
         this.pendingRead = new WeakMap();
         this.pendingDisposal = new WeakSet();
         this.lruDataGPU = [];
@@ -14411,9 +14900,12 @@ var MathBackendWebGL = (function () {
         else {
             this.gpgpuCreatedLocally = false;
         }
-        this.NUM_BYTES_BEFORE_PAGING =
-            (window.screen.height * window.screen.width * window.devicePixelRatio) *
-                BEFORE_PAGING_CONSTANT;
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.NUM_BYTES_BEFORE_PAGING =
+                (window.screen.height * window.screen.width *
+                    window.devicePixelRatio) *
+                    BEFORE_PAGING_CONSTANT;
+        }
         this.textureManager = new texture_manager_1.TextureManager(this.gpgpu);
     }
     MathBackendWebGL.prototype.register = function (dataId, shape, dtype) {
@@ -14427,8 +14919,12 @@ var MathBackendWebGL = (function () {
             texture: null,
             complexTensors: null,
             texShape: null,
-            usage: tex_util_1.TextureUsage.RENDER
+            usage: tex_util_1.TextureUsage.RENDER,
+            isPacked: false
         });
+    };
+    MathBackendWebGL.prototype.setDataMover = function (dataMover) {
+        this.texData = new backend_1.DataStorage(dataMover);
     };
     MathBackendWebGL.prototype.fromPixels = function (pixels, numChannels) {
         if (pixels == null) {
@@ -14461,27 +14957,31 @@ var MathBackendWebGL = (function () {
             this.fromPixelsCanvas.getContext('2d').drawImage(pixels, 0, 0, pixels.width, pixels.height);
             pixels = this.fromPixelsCanvas;
         }
-        var tempPixelArray = tensor_1.Tensor.make(texShape, {}, 'int32');
-        this.texData.get(tempPixelArray.dataId).usage = tex_util_1.TextureUsage.PIXELS;
-        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelArray.dataId), pixels);
+        var tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
+        this.texData.get(tempPixelHandle.dataId).usage = tex_util_1.TextureUsage.PIXELS;
+        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelHandle.dataId), pixels);
         var program = new from_pixels_gpu_1.FromPixelsProgram(outShape);
-        var res = this.compileAndRun(program, [tempPixelArray]);
-        tempPixelArray.dispose();
+        var res = this.compileAndRun(program, [tempPixelHandle]);
+        this.disposeData(tempPixelHandle.dataId);
         return res;
+    };
+    MathBackendWebGL.prototype.makeTensorHandle = function (shape, dtype) {
+        var dataId = {};
+        this.register(dataId, shape, dtype);
+        return { dataId: dataId, shape: shape, dtype: dtype };
     };
     MathBackendWebGL.prototype.write = function (dataId, values) {
         if (values == null) {
             throw new Error('MathBackendWebGL.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype;
+        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype, isPacked = texData.isPacked;
         if (dtype === 'complex64') {
             throw new Error("Cannot write to a complex64 dtype. " +
                 "Please use tf.complex(real, imag).");
         }
         if (texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -14492,9 +14992,8 @@ var MathBackendWebGL = (function () {
         }
     };
     MathBackendWebGL.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype, complexTensors = texData.complexTensors;
+        var values = texData.values, dtype = texData.dtype, complexTensors = texData.complexTensors;
         if (values != null) {
             this.cacheOnCPU(dataId);
             return values;
@@ -14511,8 +15010,7 @@ var MathBackendWebGL = (function () {
             result = complex_util_1.mergeRealAndImagArrays(realValues, imagValues);
         }
         else {
-            result =
-                this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+            result = this.getValuesFromTexture(dataId);
         }
         if (shouldTimeProgram) {
             this.downloadWaitMs += performance.now() - start;
@@ -14522,7 +15020,7 @@ var MathBackendWebGL = (function () {
     };
     MathBackendWebGL.prototype.read = function (dataId) {
         return __awaiter(this, void 0, void 0, function () {
-            var subscribers_1, texData, shape, texture, values, texShape, dtype, bufferOrTexture, vals, subscribers;
+            var subscribers_1, texData, texture, values, texShape, bufferOrTexture, vals, subscribers;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14530,9 +15028,8 @@ var MathBackendWebGL = (function () {
                             subscribers_1 = this.pendingRead.get(dataId);
                             return [2, new Promise(function (resolve) { return subscribers_1.push(resolve); })];
                         }
-                        this.throwIfNoData(dataId);
                         texData = this.texData.get(dataId);
-                        shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype;
+                        texture = texData.texture, values = texData.values, texShape = texData.texShape;
                         if (values != null) {
                             this.cacheOnCPU(dataId);
                             return [2, values];
@@ -14548,7 +15045,7 @@ var MathBackendWebGL = (function () {
                     case 1:
                         _a.sent();
                         if (bufferOrTexture instanceof WebGLTexture) {
-                            vals = this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+                            vals = this.getValuesFromTexture(dataId);
                         }
                         else {
                             vals = this.gpgpu.downloadFloat32MatrixFromBuffer(bufferOrTexture, texShape[0], texShape[1]);
@@ -14566,25 +15063,33 @@ var MathBackendWebGL = (function () {
             });
         });
     };
-    MathBackendWebGL.prototype.getValuesFromTexture = function (texture, dataId, dtype, texShape, shape) {
+    MathBackendWebGL.prototype.getValuesFromTexture = function (dataId) {
+        var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype, texture = _a.texture, texShape = _a.texShape;
         if (environment_1.ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
-            return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            if (this.texData.get(dataId).isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                return this.gpgpu.downloadMatrixFromPackedTexture(texture, batch, rows, cols, texShape[0], texShape[1]);
+            }
+            else {
+                return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            }
         }
-        var tmpTarget = tensor_1.Tensor.make(shape, {});
+        var tmpTarget = this.makeTensorHandle(shape, 'float32');
+        tmpTarget.size = util_1.sizeFromShape(shape);
         this.texData.get(tmpTarget.dataId).usage = tex_util_1.TextureUsage.DOWNLOAD;
-        var tmpInput = tensor_1.Tensor.make(shape, { dataId: dataId }, dtype);
         var program = new encode_float_gpu_1.EncodeFloatProgram(shape);
         var pageToCpu = false;
-        this.compileAndRun(program, [tmpInput], tmpTarget, null, pageToCpu);
+        this.compileAndRun(program, [{ shape: shape, dtype: dtype, dataId: dataId }], tmpTarget, null, pageToCpu);
         var tmpData = this.texData.get(tmpTarget.dataId);
         var vals = this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
-        tmpInput.dispose();
-        tmpTarget.dispose();
+        this.disposeData(tmpTarget.dataId);
         return vals;
     };
     MathBackendWebGL.prototype.time = function (f) {
         return __awaiter(this, void 0, void 0, function () {
-            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimers, kernelMs, res;
+            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimerQueries, flattenedActiveTimerNames, kernelMs, res;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14600,22 +15105,26 @@ var MathBackendWebGL = (function () {
                         }
                         this.activeTimers = newActiveTimers;
                         f();
-                        flattenedActiveTimers = util.flatten(this.activeTimers);
+                        flattenedActiveTimerQueries = util.flatten(this.activeTimers.map(function (d) { return d.query; }))
+                            .filter(function (d) { return d != null; });
+                        flattenedActiveTimerNames = util.flatten(this.activeTimers.map(function (d) { return d.name; }))
+                            .filter(function (d) { return d != null; });
                         this.activeTimers = oldActiveTimers;
                         if (outerMostTime) {
                             this.programTimersStack = null;
                         }
-                        return [4, Promise.all(flattenedActiveTimers).then(function (results) {
-                                var sum = 0;
-                                results.forEach(function (result) { return sum += result; });
-                                return sum;
-                            })];
+                        return [4, Promise.all(flattenedActiveTimerQueries)];
                     case 1:
                         kernelMs = _a.sent();
                         res = {
                             uploadWaitMs: this.uploadWaitMs,
                             downloadWaitMs: this.downloadWaitMs,
-                            kernelMs: kernelMs,
+                            kernelMs: util.sum(kernelMs),
+                            getExtraProfileInfo: function () {
+                                return kernelMs.map(function (d, i) { return ({ name: flattenedActiveTimerNames[i], ms: d }); })
+                                    .map(function (d) { return d.name + ": " + d.ms; })
+                                    .join(', ');
+                            },
                             wallMs: null
                         };
                         this.uploadWaitMs = 0;
@@ -14663,9 +15172,9 @@ var MathBackendWebGL = (function () {
             return;
         }
         if (this.texData.has(dataId)) {
-            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors;
+            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors, isPacked = _a.isPacked;
             if (texture != null) {
-                this.releaseTexture(dataId, texture, texShape, usage);
+                this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             }
             if (complexTensors != null) {
                 complexTensors.real.dispose();
@@ -14685,7 +15194,7 @@ var MathBackendWebGL = (function () {
         return this.canvas;
     };
     MathBackendWebGL.prototype.complex = function (real, imag) {
-        var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
+        var result = this.makeOutputArray(real.shape, 'complex64');
         var resultData = this.texData.get(result.dataId);
         resultData.complexTensors = {
             real: environment_1.ENV.engine.keep(real.clone()),
@@ -14742,8 +15251,18 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.batchMatMul = function (a, b, transposeA, transposeB) {
-        var program = new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-        return this.compileAndRun(program, [a, b]);
+        var outerShapeA = transposeA ? a.shape[2] : a.shape[1];
+        var outerShapeB = transposeB ? b.shape[1] : b.shape[2];
+        if (a.shape[0] === 1 && b.shape[0] === 1) {
+            var aSqueezed = a.as2D(a.shape[1], a.shape[2]);
+            var bSqueezed = b.as2D(b.shape[1], b.shape[2]);
+            var program = new mulmat_packed_gpu_1.MatMulPackedProgram(aSqueezed.shape, bSqueezed.shape, [outerShapeA, outerShapeB], transposeA, transposeB);
+            var result = this.unpackTensor(this.compileAndRun(program, [aSqueezed, bSqueezed], this.makePackedTensor(program.outputShape)));
+            return result.reshape([1, result.shape[0], result.shape[1]]);
+        }
+        else {
+            return this.compileAndRun(new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB), [a, b]);
+        }
     };
     MathBackendWebGL.prototype.multiply = function (a, b) {
         if (a.dtype === 'complex64') {
@@ -14780,8 +15299,14 @@ var MathBackendWebGL = (function () {
             scaleShape = scale.shape;
             inputs.push(scale);
         }
-        var program = new batchnorm_gpu_1.BatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
-        return this.compileAndRun(program, inputs);
+        var output = null;
+        var envSpecificBatchNormProgram = batchnorm_gpu_1.BatchNormProgram;
+        if (environment_1.ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
+            output = this.makePackedTensor(x.shape);
+            envSpecificBatchNormProgram = batchnorm_packed_gpu_1.BatchNormPackedProgram;
+        }
+        var program = new envSpecificBatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
+        return this.compileAndRun(program, inputs, output);
     };
     MathBackendWebGL.prototype.localResponseNormalization4D = function (x, radius, bias, alpha, beta) {
         var program = new lrn_gpu_1.LRNProgram(x.shape, radius, bias, alpha, beta);
@@ -14880,6 +15405,13 @@ var MathBackendWebGL = (function () {
         var a2D = x.as2D(-1, inSize);
         var outputDType = types_1.sumOutType(x.dtype);
         return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+    };
+    MathBackendWebGL.prototype.prod = function (x, axes) {
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var inSize = util.sizeFromShape(reduceShape);
+        var a2D = x.as2D(-1, inSize);
+        var outputDType = types_1.sumOutType(x.dtype);
+        return this.reduce(a2D, 'prod', outputDType).reshape(outShape);
     };
     MathBackendWebGL.prototype.unsortedSegmentSum = function (x, segmentIds, numSegments) {
         var axis = 0;
@@ -15188,6 +15720,15 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.abs = function (x) {
+        if (x.dtype === 'complex64') {
+            var xData = this.texData.get(x.dataId);
+            var program_1 = new complex_abs_gpu_1.ComplexAbsProgram(x.shape);
+            var inputs = [
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+            ];
+            return this.compileAndRun(program_1, inputs);
+        }
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.ABS);
         return this.compileAndRun(program, [x]);
     };
@@ -15261,7 +15802,23 @@ var MathBackendWebGL = (function () {
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.STEP(alpha));
         return this.compileAndRun(program, [x]);
     };
+    MathBackendWebGL.prototype.conv2dWithIm2Row = function (x, filter, convInfo) {
+        var filterWidth = convInfo.filterWidth, filterHeight = convInfo.filterHeight, inChannels = convInfo.inChannels, outWidth = convInfo.outWidth, outHeight = convInfo.outHeight;
+        var sharedDim = filterWidth * filterHeight * inChannels;
+        var numCols = outHeight * outWidth;
+        var x2ColShape = [sharedDim, numCols];
+        var xSqueezed = x.squeeze([0]);
+        var w2Row = filter.reshape([sharedDim, -1]);
+        var im2ColProgram = new im2col_gpu_1.Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
+        var im2Col = this.compileAndRun(im2ColProgram, [xSqueezed], this.makePackedTensor(x2ColShape));
+        var matmulProgram = new mulmat_packed_gpu_1.MatMulPackedProgram(im2Col.shape, w2Row.shape, [numCols, convInfo.outChannels], true, false);
+        var product = this.unpackTensor(this.compileAndRun(matmulProgram, [im2Col, w2Row], this.makePackedTensor(matmulProgram.outputShape)));
+        return product.reshape([1, outHeight, outWidth, convInfo.outChannels]);
+    };
     MathBackendWebGL.prototype.conv2d = function (x, filter, convInfo) {
+        if (environment_1.ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
+            return this.conv2dWithIm2Row(x, filter, convInfo);
+        }
         var program = new conv_gpu_1.Conv2DProgram(convInfo);
         return this.compileAndRun(program, [x, filter]);
     };
@@ -15374,14 +15931,69 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.split = function (x, sizeSplits, axis) {
         return split_shared_1.split(x, sizeSplits, axis);
     };
+    MathBackendWebGL.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var flattenIndices = indices.reshape([numUpdates, sliceRank]);
+        var flattenX = updates.reshape([numUpdates, sliceSize]);
+        if (outputSize === 0) {
+            return backend_util.reshapeTensor(tensor_ops_1.tensor([]), shape);
+        }
+        var defaultValue = tensor_ops_1.scalar(0);
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, flattenIndices.rank, flattenX.rank, strides, flattenShape);
+        return this.compileAndRun(program, [flattenX, flattenIndices, defaultValue])
+            .reshape(shape);
+    };
+    MathBackendWebGL.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, sparseIndices.rank, sparseValues.rank, strides, [outputSize, 1], sumDupeIndices);
+        return this.compileAndRun(program, [sparseValues, sparseIndices, defaultValue])
+            .reshape(outputShape);
+    };
+    MathBackendWebGL.prototype.fft = function (x) {
+        var xData = this.texData.get(x.dataId);
+        var realProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
+        var imagProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+        var inputs = [
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+        ];
+        var real = this.compileAndRun(realProgram, inputs);
+        var imag = this.compileAndRun(imagProgram, inputs);
+        var complex = this.complex(real, imag).as2D(x.shape[0], x.shape[1]);
+        real.dispose();
+        imag.dispose();
+        return complex;
+    };
+    MathBackendWebGL.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        var flattenIndices = indices.reshape([numSlices, sliceRank]);
+        var flattenX = x.reshape([x.size / sliceSize, sliceSize]);
+        var program = new gather_nd_gpu_1.GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+        return this.compileAndRun(program, [flattenX, flattenIndices])
+            .reshape(resultShape);
+    };
     MathBackendWebGL.prototype.makeOutputArray = function (shape, dtype) {
         return tensor_1.Tensor.make(shape, {}, dtype);
+    };
+    MathBackendWebGL.prototype.makePackedTensor = function (shape) {
+        var packedTensor = tensor_1.Tensor.make(shape, {});
+        this.texData.get(packedTensor.dataId).isPacked = true;
+        return packedTensor;
+    };
+    MathBackendWebGL.prototype.unpackTensor = function (input) {
+        var program = new unpack_gpu_1.UnpackProgram(input.shape);
+        return this.compileAndRun(program, [input]);
     };
     MathBackendWebGL.prototype.compileAndRun = function (program, inputs, output, customSetup, pageToCpu) {
         var _this = this;
         if (pageToCpu === void 0) { pageToCpu = true; }
         if (output == null) {
-            output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+            output =
+                this.makeOutputArray(program.outputShape, inputs[0].dtype);
         }
         if (output.size === 0) {
             this.texData.get(output.dataId).values =
@@ -15396,13 +16008,29 @@ var MathBackendWebGL = (function () {
             }
             var texData = _this.texData.get(input.dataId);
             if (texData.texture == null &&
-                util.sizeFromShape(input.shape) <= exports.SIZE_UPLOAD_UNIFORM) {
+                !(!texData.isPacked && program.usesPackedTextures) &&
+                util.sizeFromShape(input.shape) <=
+                    environment_1.ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
                 return {
                     shape: input.shape,
                     texData: null,
                     isUniform: true,
                     uniformValues: _this.readSync(input.dataId)
                 };
+            }
+            if (texData.isPacked !== !!program.usesPackedTextures) {
+                var preProcessProgram = void 0;
+                var processedInput = void 0;
+                if (texData.isPacked) {
+                    preProcessProgram = new unpack_gpu_1.UnpackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input]);
+                }
+                else {
+                    preProcessProgram = new pack_gpu_1.PackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input], _this.makePackedTensor(input.shape));
+                }
+                texData = _this.texData.get(processedInput.dataId);
+                input = processedInput;
             }
             _this.uploadToGPU(input.dataId);
             return { shape: input.shape, texData: texData, isUniform: false };
@@ -15423,7 +16051,8 @@ var MathBackendWebGL = (function () {
             query = this.startTimer();
         }
         gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-        if (pageToCpu && this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED') && pageToCpu &&
+            this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
             var numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
             while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
                 var dataId = this.lruDataGPU.shift();
@@ -15434,7 +16063,7 @@ var MathBackendWebGL = (function () {
         }
         if (shouldTimeProgram) {
             query = this.endTimer(query);
-            this.activeTimers.push(this.getQueryTime(query));
+            this.activeTimers.push({ name: program.constructor.name, query: this.getQueryTime(query) });
         }
         return output;
     };
@@ -15473,22 +16102,16 @@ var MathBackendWebGL = (function () {
             return 16;
         });
     };
-    MathBackendWebGL.prototype.throwIfNoData = function (dataId) {
-        if (!this.texData.has(dataId)) {
-            throw new Error("WebGL backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
-    };
     MathBackendWebGL.prototype.uploadToGPU = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage;
+        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (texture != null) {
-            var index = this.lruDataGPU.indexOf(dataId);
-            if (index >= 0) {
-                this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
-                this.lruDataGPU.push(dataId);
+            if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+                var index = this.lruDataGPU.indexOf(dataId);
+                if (index >= 0) {
+                    this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
+                    this.lruDataGPU.push(dataId);
+                }
             }
             return;
         }
@@ -15497,12 +16120,20 @@ var MathBackendWebGL = (function () {
         if (shouldTimeProgram) {
             start = performance.now();
         }
-        var texShape = webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        var texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
         texData.texShape = texShape;
-        var newTexture = this.acquireTexture(dataId, texShape, usage);
+        var newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
         texData.texture = newTexture;
         if (values != null) {
-            this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            if (isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                this.gpgpu.uploadMatrixToPackedTexture(newTexture, batch, rows, cols, typedArrayToFloat32(values, dtype));
+            }
+            else {
+                this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            }
             texData.values = null;
             if (shouldTimeProgram) {
                 this.uploadWaitMs += performance.now() - start;
@@ -15512,9 +16143,9 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.cacheOnCPU = function (dataId, float32Values) {
         var dontKeepCopyOnGPU = this.delayedStorage;
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage;
+        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (dontKeepCopyOnGPU && texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -15523,20 +16154,24 @@ var MathBackendWebGL = (function () {
             texData.values = float32ToTypedArray(float32Values, dtype);
         }
     };
-    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType) {
+    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        var idx = this.lruDataGPU.indexOf(dataId);
-        if (idx >= 0) {
-            this.lruDataGPU.splice(idx, 1);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            var idx = this.lruDataGPU.indexOf(dataId);
+            if (idx >= 0) {
+                this.lruDataGPU.splice(idx, 1);
+            }
         }
         this.numBytesInGPU -= this.computeBytes(shape, dtype);
-        this.textureManager.releaseTexture(texture, texShape, texType);
+        this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
     };
-    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType) {
+    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        this.lruDataGPU.push(dataId);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.lruDataGPU.push(dataId);
+        }
         this.numBytesInGPU += this.computeBytes(shape, dtype);
-        return this.textureManager.acquireTexture(texShape, texType);
+        return this.textureManager.acquireTexture(texShape, texType, isPacked);
     };
     MathBackendWebGL.prototype.computeBytes = function (shape, dtype) {
         return util.sizeFromShape(shape) * util.bytesPerElement(dtype);
@@ -15567,7 +16202,7 @@ function typedArrayToFloat32(a, dtype) {
     return (a instanceof Float32Array) ? a : new Float32Array(a);
 }
 
-},{"../environment":64,"../globals":66,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/concat_util":143,"../ops/reduce_util":160,"../ops/segment_util":165,"../ops/slice_util":168,"../ops/softmax":169,"../ops/tensor_ops":171,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./webgl/argminmax_gpu":87,"./webgl/avg_pool_backprop_gpu":88,"./webgl/batchnorm_gpu":89,"./webgl/binaryop_complex_gpu":90,"./webgl/binaryop_gpu":91,"./webgl/clip_gpu":92,"./webgl/concat_gpu":93,"./webgl/conv_backprop_gpu":94,"./webgl/conv_backprop_gpu_depthwise":95,"./webgl/conv_gpu":96,"./webgl/conv_gpu_depthwise":97,"./webgl/crop_and_resize_gpu":98,"./webgl/cumsum_gpu":99,"./webgl/depth_to_space_gpu":100,"./webgl/encode_float_gpu":101,"./webgl/from_pixels_gpu":102,"./webgl/gather_gpu":103,"./webgl/gpgpu_context":104,"./webgl/gpgpu_math":105,"./webgl/gpgpu_util":106,"./webgl/lrn_gpu":107,"./webgl/lrn_grad_gpu":108,"./webgl/max_pool_backprop_gpu":109,"./webgl/mulmat_gpu":110,"./webgl/multinomial_gpu":111,"./webgl/onehot_gpu":112,"./webgl/pad_gpu":113,"./webgl/pool_gpu":114,"./webgl/reduce_gpu":115,"./webgl/resize_bilinear_backprop_gpu":116,"./webgl/resize_bilinear_gpu":117,"./webgl/resize_nearest_neighbor_backprop_gpu":118,"./webgl/resize_nearest_neighbor_gpu":119,"./webgl/reverse_gpu":120,"./webgl/segment_gpu":121,"./webgl/select_gpu":122,"./webgl/slice_gpu":124,"./webgl/strided_slice_gpu":125,"./webgl/tex_util":126,"./webgl/texture_manager":127,"./webgl/tile_gpu":128,"./webgl/transpose_gpu":129,"./webgl/unaryop_gpu":130,"./webgl/webgl_util":131,"./where_impl":132}],83:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/concat_util":155,"../ops/gather_nd_util":161,"../ops/reduce_util":175,"../ops/scatter_nd_util":180,"../ops/segment_util":182,"../ops/slice_util":185,"../ops/softmax":186,"../ops/tensor_ops":191,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./webgl/argminmax_gpu":89,"./webgl/avg_pool_backprop_gpu":90,"./webgl/batchnorm_gpu":91,"./webgl/batchnorm_packed_gpu":92,"./webgl/binaryop_complex_gpu":93,"./webgl/binaryop_gpu":94,"./webgl/clip_gpu":95,"./webgl/complex_abs_gpu":96,"./webgl/concat_gpu":97,"./webgl/conv_backprop_gpu":98,"./webgl/conv_backprop_gpu_depthwise":99,"./webgl/conv_gpu":100,"./webgl/conv_gpu_depthwise":101,"./webgl/crop_and_resize_gpu":102,"./webgl/cumsum_gpu":103,"./webgl/depth_to_space_gpu":104,"./webgl/encode_float_gpu":105,"./webgl/fft_gpu":106,"./webgl/from_pixels_gpu":107,"./webgl/gather_gpu":108,"./webgl/gather_nd_gpu":109,"./webgl/gpgpu_context":110,"./webgl/gpgpu_math":111,"./webgl/gpgpu_util":112,"./webgl/im2col_gpu":113,"./webgl/lrn_gpu":114,"./webgl/lrn_grad_gpu":115,"./webgl/max_pool_backprop_gpu":116,"./webgl/mulmat_gpu":117,"./webgl/mulmat_packed_gpu":118,"./webgl/multinomial_gpu":119,"./webgl/onehot_gpu":120,"./webgl/pack_gpu":121,"./webgl/pad_gpu":122,"./webgl/pool_gpu":123,"./webgl/reduce_gpu":124,"./webgl/resize_bilinear_backprop_gpu":125,"./webgl/resize_bilinear_gpu":126,"./webgl/resize_nearest_neighbor_backprop_gpu":127,"./webgl/resize_nearest_neighbor_gpu":128,"./webgl/reverse_gpu":129,"./webgl/scatter_gpu":130,"./webgl/segment_gpu":131,"./webgl/select_gpu":132,"./webgl/slice_gpu":134,"./webgl/strided_slice_gpu":135,"./webgl/tex_util":136,"./webgl/texture_manager":137,"./webgl/tile_gpu":138,"./webgl/transpose_gpu":139,"./webgl/unaryop_gpu":140,"./webgl/unpack_gpu":141,"./webgl/webgl_util":142,"./where_impl":143}],84:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function mergeRealAndImagArrays(real, imag) {
@@ -15593,8 +16228,59 @@ function splitRealAndImagArrays(complex) {
     return { real: real, imag: imag };
 }
 exports.splitRealAndImagArrays = splitRealAndImagArrays;
+function complexWithEvenIndex(complex) {
+    var len = Math.ceil(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 0; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithEvenIndex = complexWithEvenIndex;
+function complexWithOddIndex(complex) {
+    var len = Math.floor(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 2; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithOddIndex = complexWithOddIndex;
+function getComplexWithIndex(complex, index) {
+    var real = complex[index * 2];
+    var imag = complex[index * 2 + 1];
+    return { real: real, imag: imag };
+}
+exports.getComplexWithIndex = getComplexWithIndex;
+function assignToTypedArray(data, real, imag, index) {
+    data[index * 2] = real;
+    data[index * 2 + 1] = imag;
+}
+exports.assignToTypedArray = assignToTypedArray;
+function exponents(n) {
+    var real = new Float32Array(n / 2);
+    var imag = new Float32Array(n / 2);
+    for (var i = 0; i < Math.ceil(n / 2); i++) {
+        var x = -2 * Math.PI * (i / n);
+        real[i] = Math.cos(x);
+        imag[i] = Math.sin(x);
+    }
+    return { real: real, imag: imag };
+}
+exports.exponents = exponents;
+function exponent(k, n) {
+    var x = -2 * Math.PI * (k / n);
+    var real = Math.cos(x);
+    var imag = Math.sin(x);
+    return { real: real, imag: imag };
+}
+exports.exponent = exponent;
 
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15652,7 +16338,33 @@ function intersectionOverUnion(boxes, i, j) {
     return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 
-},{"../ops/tensor_ops":171}],85:[function(require,module,exports){
+},{"../ops/tensor_ops":191}],86:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function getChannels(name) {
+    return ['x', 'y', 'z', 'w'].map(function (d) { return name + "." + d; });
+}
+exports.getChannels = getChannels;
+function getInnerDims(rank, dims) {
+    return dims.slice(0, rank).slice(-2);
+}
+exports.getInnerDims = getInnerDims;
+function getSourceCoords(rank, dims) {
+    if (rank === 1) {
+        return 'rc';
+    }
+    var coords = '';
+    for (var i = 0; i < rank; i++) {
+        coords += dims[i];
+        if (i < rank - 1) {
+            coords += ',';
+        }
+    }
+    return coords;
+}
+exports.getSourceCoords = getSourceCoords;
+
+},{}],87:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function split(x, sizeSplits, axis) {
@@ -15667,7 +16379,7 @@ function split(x, sizeSplits, axis) {
 }
 exports.split = split;
 
-},{}],86:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15702,7 +16414,7 @@ function topkImpl(x, xShape, xDtype, k, sorted) {
 }
 exports.topkImpl = topkImpl;
 
-},{"../ops/tensor_ops":171,"../util":194}],87:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214}],89:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ArgMinMaxProgram = (function () {
@@ -15720,13 +16432,13 @@ var ArgMinMaxProgram = (function () {
         var indexSnippet = firstPass ?
             'inOffset + i;' :
             'round(getBestIndicesA(batch, inOffset + i));';
-        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = 0;\n        float bestValue = getA(batch, inOffset);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
+        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = inOffset;\n        float bestValue = getA(batch, bestIndex);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
     }
     return ArgMinMaxProgram;
 }());
 exports.ArgMinMaxProgram = ArgMinMaxProgram;
 
-},{}],88:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var AvgPool2DBackpropProgram = (function () {
@@ -15737,16 +16449,20 @@ var AvgPool2DBackpropProgram = (function () {
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
         var avgMultiplier = 1 / (filterHeight * filterWidth);
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + ";\n            wC+= " + dilationWidth + ") {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return AvgPool2DBackpropProgram;
 }());
 exports.AvgPool2DBackpropProgram = AvgPool2DBackpropProgram;
 
-},{}],89:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15770,13 +16486,52 @@ var BatchNormProgram = (function () {
             scaleSnippet = 'getScaleAtOutCoords()';
         }
         this.outputShape = xShape;
-        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput(dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));\n      }\n    ";
     }
     return BatchNormProgram;
 }());
 exports.BatchNormProgram = BatchNormProgram;
 
-},{"../../ops/broadcast_util":139}],90:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],92:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var broadcast_util = require("../../ops/broadcast_util");
+var BatchNormPackedProgram = (function () {
+    function BatchNormPackedProgram(xShape, meanShape, varianceShape, offsetShape, scaleShape, varianceEpsilon) {
+        this.supportsBroadcasting = true;
+        this.usesPackedTextures = true;
+        this.variableNames = ['x', 'mean', 'variance'];
+        broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+        broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+        var meanSnippet = broadcastSample('mean', meanShape.length);
+        var varianceSnippet = broadcastSample('variance', varianceShape.length);
+        var offsetSnippet = 'vec4 offset = vec4(0.0)';
+        if (offsetShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+            this.variableNames.push('offset');
+            offsetSnippet = broadcastSample('offset', offsetShape.length);
+        }
+        var scaleSnippet = 'vec4 scale = vec4(1.0)';
+        if (scaleShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+            this.variableNames.push('scale');
+            scaleSnippet = broadcastSample('scale', scaleShape.length);
+        }
+        this.outputShape = xShape;
+        this.userCode = "\n      void main() {\n        ivec4 rc = getOutputCoords();\n\n        " + offsetSnippet + ";\n        " + scaleSnippet + ";\n\n        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);\n        " + meanSnippet + ";\n        " + varianceSnippet + ";\n\n        vec4 inv = scale * inversesqrt(variance + vec4(" + varianceEpsilon + "));\n\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+    }
+    return BatchNormPackedProgram;
+}());
+exports.BatchNormPackedProgram = BatchNormPackedProgram;
+function broadcastSample(texName, rank) {
+    var texSampler = "get" + texName.charAt(0).toUpperCase() + texName.slice(1);
+    if (rank === 1) {
+        return "\n      vec4 " + texName + "Sample = " + texSampler + "(rc.w);\n      vec4 " + texName + " = vec4(" + texName + "Sample.xy, " + texName + "Sample.xy);\n    ";
+    }
+    return "vec4 " + texName + " = " + texSampler + "(rc.x, rc.y, rc.z, rc.w)";
+}
+
+},{"../../ops/broadcast_util":151}],93:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15796,7 +16551,7 @@ var BinaryOpComplexProgram = (function () {
 }());
 exports.BinaryOpComplexProgram = BinaryOpComplexProgram;
 
-},{"../../ops/broadcast_util":139}],91:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],94:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15845,7 +16600,7 @@ var BinaryOpProgram = (function () {
 }());
 exports.BinaryOpProgram = BinaryOpProgram;
 
-},{"../../ops/broadcast_util":139}],92:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],95:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ClipProgram = (function () {
@@ -15858,7 +16613,20 @@ var ClipProgram = (function () {
 }());
 exports.ClipProgram = ClipProgram;
 
-},{}],93:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var ComplexAbsProgram = (function () {
+    function ComplexAbsProgram(shape) {
+        this.variableNames = ['real', 'imag'];
+        this.outputShape = shape;
+        this.userCode = "\n      void main() {\n        float real = getRealAtOutCoords();\n        float imag = getImagAtOutCoords();\n        vec2 v = vec2(real, imag);\n\n        setOutput(sqrt(dot(v, v)));\n      }\n    ";
+    }
+    return ComplexAbsProgram;
+}());
+exports.ComplexAbsProgram = ComplexAbsProgram;
+
+},{}],97:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var concat_util = require("../../ops/concat_util");
@@ -15874,7 +16642,7 @@ var ConcatProgram = (function () {
 }());
 exports.ConcatProgram = ConcatProgram;
 
-},{"../../ops/concat_util":143}],94:[function(require,module,exports){
+},{"../../ops/concat_util":155}],98:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DDerFilterProgram = (function () {
@@ -15906,7 +16674,7 @@ var Conv2DDerInputProgram = (function () {
 }());
 exports.Conv2DDerInputProgram = Conv2DDerInputProgram;
 
-},{}],95:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DDerFilterProgram = (function () {
@@ -15940,7 +16708,7 @@ var DepthwiseConv2DDerInputProgram = (function () {
 }());
 exports.DepthwiseConv2DDerInputProgram = DepthwiseConv2DDerInputProgram;
 
-},{}],96:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DProgram = (function () {
@@ -15963,7 +16731,7 @@ var Conv2DProgram = (function () {
 }());
 exports.Conv2DProgram = Conv2DProgram;
 
-},{}],97:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DProgram = (function () {
@@ -15987,7 +16755,7 @@ var DepthwiseConv2DProgram = (function () {
 }());
 exports.DepthwiseConv2DProgram = DepthwiseConv2DProgram;
 
-},{}],98:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var CropAndResizeProgram = (function () {
@@ -16028,7 +16796,7 @@ var CropAndResizeProgram = (function () {
 }());
 exports.CropAndResizeProgram = CropAndResizeProgram;
 
-},{}],99:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16079,7 +16847,7 @@ function getFinalCoord(rank, name) {
     }
 }
 
-},{"./shader_compiler":123}],100:[function(require,module,exports){
+},{"./shader_compiler":133}],104:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthToSpaceProgram = (function () {
@@ -16135,7 +16903,7 @@ var DepthToSpaceProgram = (function () {
 }());
 exports.DepthToSpaceProgram = DepthToSpaceProgram;
 
-},{}],101:[function(require,module,exports){
+},{}],105:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var EncodeFloatProgram = (function () {
@@ -16148,7 +16916,25 @@ var EncodeFloatProgram = (function () {
 }());
 exports.EncodeFloatProgram = EncodeFloatProgram;
 
-},{}],102:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COMPLEX_FFT = {
+    REAL: 'return real * expR - imag * expI;',
+    IMAG: 'return real * expI + imag * expR;'
+};
+var FFTProgram = (function () {
+    function FFTProgram(op, inputShape) {
+        this.variableNames = ['real', 'imag'];
+        var innerDim = inputShape[1];
+        this.outputShape = inputShape;
+        this.userCode = "\n      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;\n\n      float unaryOpComplex(float real, float expR, float imag, float expI) {\n        " + op + "\n      }\n\n      float mulMatDFT(int batch, int index) {\n        float indexRatio = float(index) / float(" + innerDim + ");\n        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;\n\n        float result = 0.0;\n\n        for (int i = 0; i < " + innerDim + "; i++) {\n          // x = (-2 * PI / N) * index * i;\n          float x = negativeTwoPiTimesIndexRatio * float(i);\n          float expR = cos(x);\n          float expI = sin(x);\n          float real = getReal(batch, i);\n          float imag = getImag(batch, i);\n\n          result += unaryOpComplex(real, expR, imag, expI);\n        }\n\n        return result;\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        setOutput(mulMatDFT(coords[0], coords[1]));\n      }\n    ";
+    }
+    return FFTProgram;
+}());
+exports.FFTProgram = FFTProgram;
+
+},{}],107:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var FromPixelsProgram = (function () {
@@ -16162,7 +16948,7 @@ var FromPixelsProgram = (function () {
 }());
 exports.FromPixelsProgram = FromPixelsProgram;
 
-},{}],103:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16201,7 +16987,26 @@ function getSourceCoords(aShape, axis) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],104:[function(require,module,exports){
+},{"./shader_compiler":133}],109:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var GatherNDProgram = (function () {
+    function GatherNDProgram(sliceDim, strides, shape) {
+        this.sliceDim = sliceDim;
+        this.strides = strides;
+        this.variableNames = ['x', 'indices'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + this.strides + ");\n         void main() {\n          " + dtype + " coords = getOutputCoords();\n          int flattenIndex = 0;\n          for (int j = 0; j < " + this.sliceDim + "; j++) {\n            int index = round(getIndices(coords[0], j));\n            flattenIndex += index * " + strideString + ";\n          }\n          setOutput(getX(flattenIndex, coords[1]));\n        }\n      ";
+    }
+    return GatherNDProgram;
+}());
+exports.GatherNDProgram = GatherNDProgram;
+
+},{"./shader_compiler":133}],110:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16329,6 +17134,10 @@ var GPGPUContext = (function () {
         this.throwIfDisposed();
         gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
     };
+    GPGPUContext.prototype.createFloat16PackedMatrixTexture = function (rows, columns) {
+        this.throwIfDisposed();
+        return gpgpu_util.createFloat16PackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
+    };
     GPGPUContext.prototype.createPackedMatrixTexture = function (rows, columns) {
         this.throwIfDisposed();
         return gpgpu_util.createPackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
@@ -16347,9 +17156,9 @@ var GPGPUContext = (function () {
         var numChannels = webgl_util.getNumChannels();
         return gpgpu_util.uploadMatrixToTexture(this.gl, texture, rows, columns, matrix, numChannels, this.textureConfig);
     };
-    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, rows, columns, matrix) {
+    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, batch, rows, columns, matrix) {
         this.throwIfDisposed();
-        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, rows, columns, matrix, this.textureConfig);
+        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, batch, rows, columns, matrix, this.textureConfig);
     };
     GPGPUContext.prototype.downloadFloat32MatrixFromOutputTexture = function (texture, rows, columns) {
         var _this = this;
@@ -16397,9 +17206,9 @@ var GPGPUContext = (function () {
         }
         return { query: query, isFencePassed: isFencePassed };
     };
-    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, rows, columns) {
+    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, batch, rows, columns, physicalRows, physicalCols) {
         var _this = this;
-        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, rows, columns, _this.textureConfig); });
+        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, batch, rows, columns, physicalRows, physicalCols, _this.textureConfig); });
     };
     GPGPUContext.prototype.createProgram = function (fragmentShaderSource) {
         this.throwIfDisposed();
@@ -16681,7 +17490,7 @@ function binSearchLastTrue(arr) {
 }
 exports.binSearchLastTrue = binSearchLastTrue;
 
-},{"../../environment":64,"../../util":194,"./gpgpu_util":106,"./tex_util":126,"./webgl_util":131}],105:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./gpgpu_util":112,"./tex_util":136,"./webgl_util":142}],111:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../../util");
@@ -16692,7 +17501,8 @@ function compileProgram(gpgpu, program, inputs, output) {
         var shapeInfo = {
             logicalShape: input.shape,
             texShape: input.isUniform ? null : input.texData.texShape,
-            isUniform: input.isUniform
+            isUniform: input.isUniform,
+            isPacked: input.isUniform ? false : input.texData.isPacked
         };
         return { name: program.variableNames[i], shapeInfo: shapeInfo };
     });
@@ -16700,7 +17510,8 @@ function compileProgram(gpgpu, program, inputs, output) {
     var outShapeInfo = {
         logicalShape: output.shape,
         texShape: output.texData.texShape,
-        isUniform: false
+        isUniform: false,
+        isPacked: output.texData.isPacked
     };
     var source = shader_compiler.makeShader(inputInfos, outShapeInfo, userCode, program.supportsBroadcasting === true);
     var webGLProgram = gpgpu.createProgram(source);
@@ -16752,7 +17563,12 @@ function runProgram(binary, inputs, output, customSetup) {
     var outTex = output.texData.texture;
     var outTexShape = output.texData.texShape;
     var gpgpu = binary.gpgpu;
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    if (output.texData.isPacked) {
+        gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
+    else {
+        gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
     gpgpu.setProgram(binary.webGLProgram);
     inputs.forEach(function (input, i) {
         var variableName = binary.program.variableNames[i];
@@ -16794,10 +17610,11 @@ function makeShaderKey(program, inputs, output) {
 }
 exports.makeShaderKey = makeShaderKey;
 
-},{"../../util":194,"./shader_compiler":123}],106:[function(require,module,exports){
+},{"../../util":214,"./shader_compiler":133}],112:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 var tex_util = require("./tex_util");
 var webgl_util = require("./webgl_util");
 function getWebGLContextAttributes() {
@@ -16892,7 +17709,7 @@ function getTextureConfig(gl, textureHalfFloatExtension) {
 }
 exports.getTextureConfig = getTextureConfig;
 function createAndConfigureTexture(gl, width, height, internalFormat, textureFormat, textureType) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     var texture = webgl_util.createTexture(gl);
     var tex2d = gl.TEXTURE_2D;
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(tex2d, texture); });
@@ -16924,6 +17741,11 @@ function createPackedMatrixTexture(gl, rows, columns, textureConfig) {
     return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatPackedFloat, gl.RGBA, gl.FLOAT);
 }
 exports.createPackedMatrixTexture = createPackedMatrixTexture;
+function createFloat16PackedMatrixTexture(gl, rows, columns, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), width = _a[0], height = _a[1];
+    return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA, textureConfig.textureTypeHalfFloat);
+}
+exports.createFloat16PackedMatrixTexture = createFloat16PackedMatrixTexture;
 function bindVertexProgramAttributeStreams(gl, program, vertexBuffer) {
     var posOffset = 0;
     var uvOffset = 3 * 4;
@@ -16941,7 +17763,7 @@ function uploadPixelDataToTexture(gl, texture, pixels) {
 }
 exports.uploadPixelDataToTexture = uploadPixelDataToTexture;
 function uploadDataToTexture(gl, texture, width, height, data, textureFormat) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, texture); });
     webgl_util.callAndCheck(gl, function () { return gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, textureFormat, gl.FLOAT, data); });
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, null); });
@@ -16960,10 +17782,10 @@ function uploadMatrixToTexture(gl, texture, rows, columns, matrix, numChannels, 
     uploadDataToTexture(gl, texture, w, h, unpackedArray, textureConfig.textureFormatFloat);
 }
 exports.uploadMatrixToTexture = uploadMatrixToTexture;
-function uploadMatrixToPackedTexture(gl, texture, rows, columns, matrix, textureConfig) {
+function uploadMatrixToPackedTexture(gl, texture, batch, rows, columns, matrix, textureConfig) {
     var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
     var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
-    tex_util.encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA);
+    tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
     uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }
 exports.uploadMatrixToPackedTexture = uploadMatrixToPackedTexture;
@@ -17012,16 +17834,32 @@ function downloadByteEncodedFloatMatrixFromOutputTexture(gl, rows, columns, text
     return new Float32Array(downloadTarget.buffer);
 }
 exports.downloadByteEncodedFloatMatrixFromOutputTexture = downloadByteEncodedFloatMatrixFromOutputTexture;
-function downloadMatrixFromPackedOutputTexture(gl, rows, columns, textureConfig) {
-    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
-    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+function downloadMatrixFromPackedOutputTexture(gl, batch, rows, cols, physicalRows, physicalCols, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(physicalRows, physicalCols), w = _a[0], h = _a[1];
+    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
     webgl_util.callAndCheck(gl, function () { return gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, packedRGBA); });
-    var matrix = new Float32Array(rows * columns);
-    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix);
+    var matrix = new Float32Array(util.sizeFromShape([batch, rows, cols]));
+    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, batch, rows, cols, matrix);
 }
 exports.downloadMatrixFromPackedOutputTexture = downloadMatrixFromPackedOutputTexture;
 
-},{"../../environment":64,"./tex_util":126,"./webgl_util":131}],107:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./tex_util":136,"./webgl_util":142}],113:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Im2ColProgram = (function () {
+    function Im2ColProgram(outputShape, inputShape, convInfo) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var filterWidth = convInfo.filterWidth, inChannels = convInfo.inChannels, strideWidth = convInfo.strideWidth, strideHeight = convInfo.strideHeight, padInfo = convInfo.padInfo, outWidth = convInfo.outWidth, dilationWidth = convInfo.dilationWidth, dilationHeight = convInfo.dilationHeight;
+        var left = padInfo.left, top = padInfo.top;
+        var itemsPerBlockRow = inChannels * filterWidth;
+        this.userCode = "\n      void main() {\n        ivec2 rc = getOutputCoords();\n\n        vec4 result = vec4(0);\n\n        for(int row=0; row<=1; row++) {\n          for(int col=0; col<=1; col++) {\n            int blockIndex = rc.y + col;\n            int pos = rc.x + row;\n\n            if(blockIndex >= " + outputShape[1] + " || pos >= " + outputShape[0] + ") continue;\n\n            int offsetY = int(blockIndex / (" + outWidth + ")) * " + strideHeight + " - " + top + ";\n            int d0 = offsetY + " + dilationHeight + " * (pos / " + itemsPerBlockRow + ");\n\n            if(d0 >= " + inputShape[0] + " || d0 < 0) continue;\n\n            int offsetX = int(mod(float(blockIndex), " + outWidth + ".) * " + strideWidth + ". - " + left + ".);\n            int d1 = offsetX + " + dilationWidth + " * (int(mod(float(pos), " + itemsPerBlockRow + ".) / " + inChannels + ".));\n\n            if(d1 >= " + inputShape[1] + " || d1 < 0) continue;\n\n            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), " + inChannels + ".)));\n          }\n        }\n\n        gl_FragColor = result;\n      }\n    ";
+    }
+    return Im2ColProgram;
+}());
+exports.Im2ColProgram = Im2ColProgram;
+
+},{}],114:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNProgram = (function () {
@@ -17048,7 +17886,7 @@ var LRNProgram = (function () {
 }());
 exports.LRNProgram = LRNProgram;
 
-},{}],108:[function(require,module,exports){
+},{}],115:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNGradProgram = (function () {
@@ -17067,27 +17905,28 @@ var LRNGradProgram = (function () {
 }());
 exports.LRNGradProgram = LRNGradProgram;
 
-},{}],109:[function(require,module,exports){
+},{}],116:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MaxPool2DBackpropProgram = (function () {
     function MaxPool2DBackpropProgram(convInfo) {
         this.variableNames = ['dy', 'maxPos'];
         this.outputShape = convInfo.inShape;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var lastIndex = filterHeight * filterWidth - 1;
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + filterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        var dilationHeight = convInfo.dilationHeight;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var lastIndex = effectiveFilterHeight * effectiveFilterWidth - 1;
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n          wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + effectiveFilterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return MaxPool2DBackpropProgram;
 }());
 exports.MaxPool2DBackpropProgram = MaxPool2DBackpropProgram;
 
-},{}],110:[function(require,module,exports){
+},{}],117:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MatMulProgram = (function () {
@@ -17116,7 +17955,29 @@ var MatMulProgram = (function () {
 }());
 exports.MatMulProgram = MatMulProgram;
 
-},{}],111:[function(require,module,exports){
+},{}],118:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var MatMulPackedProgram = (function () {
+    function MatMulPackedProgram(aShape, bShape, outputShape, transposeA, transposeB) {
+        if (transposeA === void 0) { transposeA = false; }
+        if (transposeB === void 0) { transposeB = false; }
+        this.variableNames = ['matrixA', 'matrixB'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var sharedDim = transposeA ? aShape[0] : aShape[1];
+        var sharedDimensionPacked = Math.ceil(sharedDim / 2);
+        var aSample = transposeA ? 'i * 2, rc.x' : 'rc.x, i * 2';
+        var bSample = transposeB ? 'rc.y, i * 2' : 'i * 2, rc.y';
+        var aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
+        var bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
+        this.userCode = "\n      const float sharedDimension = " + sharedDimensionPacked + ".0;\n\n      vec4 dot2x2ARowBCol(ivec2 rc) {\n        vec4 result = vec4(0);\n        for (int i = 0; i < " + sharedDimensionPacked + "; i++) {\n          vec4 a = getMatrixA(" + aSample + ");\n          vec4 b = getMatrixB(" + bSample + ");\n\n          result += (" + aSwizzle[0] + " * " + bSwizzle[0] + ") + (" + aSwizzle[1] + " * " + bSwizzle[1] + ");\n        }\n        return result;\n      }\n\n      void main() {\n        ivec2 rc = getOutputCoords();\n        setOutput(dot2x2ARowBCol(rc));\n      }\n    ";
+    }
+    return MatMulPackedProgram;
+}());
+exports.MatMulPackedProgram = MatMulPackedProgram;
+
+},{}],119:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MultinomialProgram = (function () {
@@ -17138,7 +17999,7 @@ var MultinomialProgram = (function () {
 }());
 exports.MultinomialProgram = MultinomialProgram;
 
-},{}],112:[function(require,module,exports){
+},{}],120:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var OneHotProgram = (function () {
@@ -17151,7 +18012,69 @@ var OneHotProgram = (function () {
 }());
 exports.OneHotProgram = OneHotProgram;
 
-},{}],113:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var PackProgram = (function () {
+    function PackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var outOfBoundsCondition = getOutOfBoundsCondition(rank, outputShape, channels);
+        var setup = getSetup(rank, outputShape[outputShape.length - 1], outputShape[outputShape.length - 2], channels);
+        var output = getOutput(outputShape, channels);
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n\n        if(" + outOfBoundsCondition + ") {\n          gl_FragColor = vec4(0);\n        } else {\n          " + setup + "\n\n          setOutput(vec4(" + output + "));\n        }\n      }\n    ";
+    }
+    return PackProgram;
+}());
+exports.PackProgram = PackProgram;
+function getSourceCoordsArr(rank, dims) {
+    var coords = [];
+    for (var row = 0; row <= 1; row++) {
+        for (var col = 0; col <= 1; col++) {
+            var coord = (row === 0 ? 'r' : 'rp1') + ", " + (col === 0 ? 'c' : 'cp1');
+            for (var d = 2; d < rank; d++) {
+                coord = dims[dims.length - 1 - d] + "," + coord;
+            }
+            coords.push(coord);
+        }
+    }
+    return coords;
+}
+function getOutOfBoundsCondition(rank, shape, dims) {
+    if (rank === 1) {
+        return "rc > " + shape[0];
+    }
+    var cond = '';
+    for (var i = 0; i < rank; i++) {
+        cond += dims[i] + " >= " + shape[i];
+        if (i < rank - 1) {
+            cond += '||';
+        }
+    }
+    return cond;
+}
+function getSetup(rank, cols, rows, dims) {
+    if (rank === 1) {
+        return '';
+    }
+    var innerDims = packing_util_1.getInnerDims(rank, dims);
+    return "\n    int r = " + innerDims[0] + ";\n    int c = " + innerDims[1] + ";\n    int rp1 = r + 1;\n    int cp1 = c + 1;\n\n    bool cEdge = cp1 >= " + cols + ";\n    bool rEdge = rp1 >= " + rows + ";\n  ";
+}
+function getOutput(shape, dims) {
+    var rank = shape.length;
+    var sourceCoords = getSourceCoordsArr(rank, dims);
+    if (rank === 1) {
+        return "getA(rc),\n            rc + 1 >= " + shape[0] + " ? 0. : getA(rc + 1),\n            0, 0";
+    }
+    return "getA(" + sourceCoords[0] + "),\n          cEdge ? 0. : getA(" + sourceCoords[1] + "),\n          rEdge ? 0. : getA(" + sourceCoords[2] + "),\n          rEdge || cEdge ? 0. : getA(" + sourceCoords[3] + ")";
+}
+
+},{"../packing_util":86,"./shader_compiler":133}],122:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17174,7 +18097,7 @@ var PadProgram = (function () {
 }());
 exports.PadProgram = PadProgram;
 
-},{"./shader_compiler":123}],114:[function(require,module,exports){
+},{"./shader_compiler":133}],123:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Pool2DProgram = (function () {
@@ -17183,10 +18106,13 @@ var Pool2DProgram = (function () {
         if (poolType === 'avg' && computePositions) {
             throw new Error('Cannot compute positions for average pool.');
         }
-        var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         this.outputShape = convInfo.outShape;
@@ -17197,7 +18123,7 @@ var Pool2DProgram = (function () {
         }
         if (computePositions) {
             var compareOp_1 = '>=';
-            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + filterHeight + "; wR++) {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + filterWidth + "; wC++) {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + filterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
+            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + effectiveFilterHeight + ";\n              wR += " + dilationHeight + ") {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + effectiveFilterWidth + ";\n                wC += " + dilationWidth + ") {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + effectiveFilterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
             return;
         }
         var compareOp = 'max';
@@ -17209,13 +18135,13 @@ var Pool2DProgram = (function () {
         var filterWidthNearestVec4 = Math.floor(filterWidth / 4) * 4;
         var filterWidthVec4Remainder = filterWidth % 4;
         var updateSnippet = "\n      if (" + isAvgPool + ") {\n        avgValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
-        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC;\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              getValue(batch, xR, xC + 3, d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC * " + dilationWidth + ";\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 3 * " + dilationWidth + ", d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return Pool2DProgram;
 }());
 exports.Pool2DProgram = Pool2DProgram;
 
-},{}],115:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ReduceProgram = (function () {
@@ -17228,7 +18154,10 @@ var ReduceProgram = (function () {
         this.outputShape = [batchSize, outSize];
         var initializationValue = '0.0';
         var compareOp = "";
-        if (reduceType === 'min') {
+        if (reduceType === 'prod') {
+            initializationValue = '1.0';
+        }
+        else if (reduceType === 'min') {
             initializationValue = '1.0 / 0.0';
             compareOp = "min";
         }
@@ -17241,6 +18170,9 @@ var ReduceProgram = (function () {
         if (reduceType === 'sum') {
             returnValue = "sumValue";
         }
+        else if (reduceType === 'prod') {
+            returnValue = "prodValue";
+        }
         else if (reduceType === 'all') {
             returnValue = "allValue";
         }
@@ -17249,7 +18181,7 @@ var ReduceProgram = (function () {
         }
         var windowSizeNearestVec4 = Math.floor(windowSize / 4) * 4;
         var windowSizeVec4Remainder = windowSize % 4;
-        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
+        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else if (" + (reduceType === 'prod') + ") {\n        vec2 tmp = vec2(values[0], values[1]) * vec2(values[2], values[3]);\n        prodValue *= tmp[0] * tmp[1];\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
         var vecType = "vec4";
         if (reduceType === 'all') {
             initializationValue = '1.0';
@@ -17265,13 +18197,13 @@ var ReduceProgram = (function () {
         if (inSize % windowSize > 0) {
             checkOutOfBounds = "\n        if (inIdx < 0 || inIdx >= " + inSize + ") {\n          return initializationValue;\n        }\n      ";
         }
-        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float prodValue = 1.0;\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return ReduceProgram;
 }());
 exports.ReduceProgram = ReduceProgram;
 
-},{}],116:[function(require,module,exports){
+},{}],125:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearBackpropProgram = (function () {
@@ -17301,7 +18233,7 @@ var ResizeBilinearBackpropProgram = (function () {
 }());
 exports.ResizeBilinearBackpropProgram = ResizeBilinearBackpropProgram;
 
-},{}],117:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearProgram = (function () {
@@ -17324,7 +18256,7 @@ var ResizeBilinearProgram = (function () {
 }());
 exports.ResizeBilinearProgram = ResizeBilinearProgram;
 
-},{}],118:[function(require,module,exports){
+},{}],127:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeigborBackpropProgram = (function () {
@@ -17354,7 +18286,7 @@ var ResizeNearestNeigborBackpropProgram = (function () {
 }());
 exports.ResizeNearestNeigborBackpropProgram = ResizeNearestNeigborBackpropProgram;
 
-},{}],119:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeighborProgram = (function () {
@@ -17378,7 +18310,7 @@ var ResizeNearestNeighborProgram = (function () {
 }());
 exports.ResizeNearestNeighborProgram = ResizeNearestNeighborProgram;
 
-},{}],120:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17408,7 +18340,41 @@ var ReverseProgram = (function () {
 }());
 exports.ReverseProgram = ReverseProgram;
 
-},{"./shader_compiler":123}],121:[function(require,module,exports){
+},{"./shader_compiler":133}],130:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var ScatterProgram = (function () {
+    function ScatterProgram(updateSize, sliceDim, indicesRank, updatesRank, strides, shape, summingDupeIndex) {
+        if (summingDupeIndex === void 0) { summingDupeIndex = true; }
+        this.variableNames = ['updates', 'indices', 'defaultValue'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var indicesString = '';
+        if (indicesRank === 1) {
+            indicesString = 'i';
+        }
+        else if (indicesRank === 2) {
+            indicesString = 'i, j';
+        }
+        var indicesSnippet = "getIndices(" + indicesString + ")";
+        var updatesString = '';
+        if (updatesRank === 1) {
+            updatesString = 'i';
+        }
+        else if (updatesRank === 2) {
+            updatesString = 'i, coords[1]';
+        }
+        var updatesSnippet = "getUpdates(" + updatesString + ")";
+        var strideString = sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + strides + ");\n\n        void main() {\n          " + dtype + " coords = getOutputCoords();\n          float sum = 0.0;\n          bool found = false;\n          for (int i = 0; i < " + updateSize + "; i++) {\n            int flattenedIndex = 0;\n            for (int j = 0; j < " + sliceDim + "; j++) {\n              int index = round(" + indicesSnippet + ");\n              flattenedIndex += index * " + strideString + ";\n            }\n            if (flattenedIndex == coords[0]) {\n              sum += " + updatesSnippet + ";\n              found = true;\n            }\n          }\n          setOutput(mix(getDefaultValue(), sum, float(found)));\n        }\n      ";
+    }
+    return ScatterProgram;
+}());
+exports.ScatterProgram = ScatterProgram;
+
+},{"./shader_compiler":133}],131:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var SegmentOpProgram = (function () {
@@ -17439,7 +18405,7 @@ var SegmentOpProgram = (function () {
 }());
 exports.SegmentOpProgram = SegmentOpProgram;
 
-},{}],122:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17476,7 +18442,7 @@ var SelectProgram = (function () {
 }());
 exports.SelectProgram = SelectProgram;
 
-},{"./shader_compiler":123}],123:[function(require,module,exports){
+},{"./shader_compiler":133}],133:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -17493,11 +18459,21 @@ function makeShader(inputsInfo, outputShape, userCode, broadcast) {
     var inputSamplingSnippet = inputsInfo.map(function (x) { return getInputSamplingSnippet(x, outputShape, broadcast); })
         .join('\n');
     var outTexShape = outputShape.texShape;
-    var outputSamplingSnippet = getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    var outputSamplingSnippet;
+    var floatTextureSetOutputSnippet;
+    if (outputShape.isPacked) {
+        outputSamplingSnippet =
+            getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    }
+    else {
+        outputSamplingSnippet =
+            getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    }
     var source = [
-        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-        FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-        inputSamplingSnippet, userCode
+        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+        inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
     ].join('\n');
     return source;
 }
@@ -17524,14 +18500,47 @@ function getSamplerFromInInfo(inInfo) {
                 " is not yet supported");
     }
 }
+function getPackedSamplerFromInInfo(inInfo) {
+    var shape = inInfo.shapeInfo.logicalShape;
+    switch (shape.length) {
+        case 1:
+            return getPackedSampler1D(inInfo);
+        case 2:
+            return getPackedSampler2D(inInfo);
+        case 4:
+            return getPackedSampler4D(inInfo);
+        default:
+            throw new Error("Packed " + shape.length + "-D input sampling" +
+                " is not yet supported");
+    }
+}
 function getInputSamplingSnippet(inInfo, outShapeInfo, broadcast) {
     var res = getSamplerFlat(inInfo);
-    res += getSamplerFromInInfo(inInfo);
+    if (inInfo.shapeInfo.isPacked) {
+        res += getPackedSamplerFromInInfo(inInfo);
+    }
+    else {
+        res += getSamplerFromInInfo(inInfo);
+    }
     if (broadcast ||
         util.arraysEqual(inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
         res += getSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     }
     return res;
+}
+function getPackedOutputSamplingSnippet(outShape, outTexShape) {
+    switch (outShape.length) {
+        case 0:
+            return getOutputScalarCoords();
+        case 1:
+            return getOutputPacked1DCoords(outShape, outTexShape);
+        case 2:
+            return getOutputPacked2DCoords(outShape, outTexShape);
+        case 4:
+            return getOutputPacked4DCoords(outShape, outTexShape);
+        default:
+            throw new Error(outShape.length + "-D output packed sampling is not yet supported");
+    }
 }
 function getOutputSamplingSnippet(outShape, outTexShape) {
     switch (outShape.length) {
@@ -17553,17 +18562,28 @@ function getOutputSamplingSnippet(outShape, outTexShape) {
             throw new Error(outShape.length + "-D output sampling is not yet supported");
     }
 }
-var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom1D(int texNumR, int texNumC, int index) {\n  int texelIndex = index / 2;\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom2D(int texelsInLogicalRow, int texNumR,\n  int texNumC, int row, int col) {\n  int texelIndex = (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_3D_SNIPPET = "\nvec2 UVfrom3D(int texNumR, int texNumC, int stride0,\n    int stride1, int row, int col, int depth) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,\n    int texelsInBatch, int texelsInLogicalRow, int b2, int b,\n    int row, int col) {\n  int index = b2 * texelsInBatch2 + b * texelsInBatch +\n    (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_5D_SNIPPET = "\nvec2 UVfrom5D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int row, int col, int depth,\n    int depth2, int depth3) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 +\n              depth * stride2 + depth2 * stride3 + depth3;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_6D_SNIPPET = "\nvec2 UVfrom6D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int stride4,\n    int row, int col, int depth, int depth2, int depth3, int depth4) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2 *\n    stride3 + depth3 * stride4 + depth4;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var FLOAT_TEXTURE_SAMPLE_SNIPPET = "\n  float sampleTexture(sampler2D textureSampler, vec2 uv) {\n    return texture2D(textureSampler, uv).r;\n  }\n";
-var FLOAT_TEXTURE_SETOUTPUT_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
-var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
+var FLOAT_TEXTURE_SET_R_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
+var FLOAT_TEXTURE_SET_RGBA_SNIPPET = "\n  void setOutput(vec4 val) {\n    gl_FragColor = val;\n  }\n";
+var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
 function getOutputScalarCoords() {
     return "\n    int getOutputCoords() {\n      return 0;\n    }\n  ";
+}
+function getOutputPacked1DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (texShape[0] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.x * " + packedTexShape[1] + ".0);\n      }\n    ";
+    }
+    if (texShape[1] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.y * " + packedTexShape[0] + ".0);\n      }\n    ";
+    }
+    return "\n    int getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      return resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n    }\n  ";
 }
 function getOutput1DCoords(shape, texShape) {
     if (texShape[0] === 1) {
@@ -17578,6 +18598,13 @@ function getOutput3DCoords(shape, texShape) {
     var stride0 = shape[1] * shape[2];
     var stride1 = shape[2];
     return "\n    ivec3 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n      int c = index / " + stride1 + ";\n      int d = index - c * " + stride1 + ";\n      return ivec3(r, c, d);\n    }\n  ";
+}
+function getOutputPacked4DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texelsInLogicalRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    ivec4 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n\n      int b2 = index / " + texelsInBatch2 + ";\n      index -= b2 * " + texelsInBatch2 + ";\n\n      int b = index / " + texelsInBatch + ";\n      index -= b * " + texelsInBatch + ";\n\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = int(mod(float(index), " + texelsInLogicalRow + ".)) * 2;\n\n      return ivec4(b2, b, r, c);\n    }\n  ";
 }
 function getOutput4DCoords(shape, texShape) {
     var stride2 = shape[3];
@@ -17600,6 +18627,14 @@ function getOutput6DCoords(shape, texShape) {
     var stride0 = shape[1] * stride1;
     return "\n    ivec6 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n        vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n\n      int c = index / " + stride1 + ";\n      index -= c * " + stride1 + ";\n\n      int d = index / " + stride2 + ";\n      index -= d * " + stride2 + ";\n\n      int d2 = index / " + stride3 + ";\n      index -= d2 * " + stride3 + ";\n\n      int d3 = index / " + stride4 + ";\n      int d4 = index - d3 * " + stride4 + ";\n\n      ivec6 result = ivec6(r, c, d, d2, d3, d4);\n      return result;\n    }\n  ";
 }
+function getOutputPacked2DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (util.arraysEqual(shape, texShape)) {
+        return "\n      ivec2 getOutputCoords() {\n        return 2 * ivec2(resultUV.yx * vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      }\n    ";
+    }
+    var texelsInLogicalRow = Math.ceil(shape[1] / 2);
+    return "\n    ivec2 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = imod(index, " + texelsInLogicalRow + ") * 2;\n\n      return ivec2(r, c);\n    }\n  ";
+}
 function getOutput2DCoords(shape, texShape) {
     if (util.arraysEqual(shape, texShape)) {
         return "\n      ivec2 getOutputCoords() {\n        return ivec2(resultUV.yx * vec2(" + texShape[0] + ", " + texShape[1] + "));\n      }\n    ";
@@ -17620,10 +18655,31 @@ function getSamplerScalar(inputInfo) {
     }
     return "\n    float " + funcName + "() {\n      return sampleTexture(" + texName + ", halfCR);\n    }\n  ";
 }
+function getPackedSampler1D(inputInfo) {
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    return "\n    vec4 " + funcName + "(int index) {\n      vec2 uv = packedUVfrom1D(\n        " + packedTexShape[0] + ", " + packedTexShape[1] + ", index);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
+}
 function getSampler1D(inputInfo) {
     var texName = inputInfo.name;
     var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
     return "\n    float " + funcName + "(int index) {\n      return " + funcName + "Flat(index);\n    }\n  ";
+}
+function getPackedSampler2D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var texNumR = texShape[0];
+    var texNumC = texShape[1];
+    if (texShape != null && util.arraysEqual(shape, texShape)) {
+        return "\n      vec4 " + funcName + "(int row, int col) {\n        vec2 uv = (vec2(col, row) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n\n        return texture2D(" + texName + ", uv);\n      }\n    ";
+    }
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var valuesPerRow = Math.ceil(shape[1] / 2);
+    return "\n    vec4 " + funcName + "(int row, int col) {\n      vec2 uv = packedUVfrom2D(" + valuesPerRow + ", " + packedTexShape[0] + ", " + packedTexShape[1] + ", row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler2D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17643,15 +18699,15 @@ function getSampler2D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col) {\n        int index = row * " + shape[1] + " + col;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col) {\n        float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2(0.5, (float(index) + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2(0.5, (index + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     if (texNumR === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2((float(index) + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2((index + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n  float " + funcName + "(int row, int col) {\n    vec2 uv = UVfrom2D(" + texNumR + ", " + texNumC + ", " + shape[1] + ", row, col);\n    return sampleTexture(" + texName + ", uv);\n  }\n";
 }
@@ -17669,18 +18725,31 @@ function getSampler3D(inputInfo) {
         return "\n        " + getSamplerFromInInfo(newInputInfo) + "\n        float " + funcName + "(int row, int col, int depth) {\n          return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n        }\n      ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth) {\n        int index = row * " + stride0 + " + col * " + stride1 + " + depth;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth) {\n        float index = dot(vec3(row, col, depth),\n                          vec3(" + stride0 + ", " + stride1 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n        float " + funcName + "(int row, int col, int depth) {\n          int texR = row;\n          int texC = col * " + stride1 + " + depth;\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
+        return "\n        float " + funcName + "(int row, int col, int depth) {\n          float texR = float(row);\n          float texC = dot(vec2(col, depth), vec2(" + stride1 + ", 1));\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
     }
     if (texNumC === stride1) {
-        return "\n    float " + funcName + "(int row, int col, int depth) {\n      int texR = row * " + shape[1] + " + col;\n      int texC = depth;\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col, int depth) {\n      float texR = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      float texC = float(depth);\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n      float " + funcName + "(int row, int col, int depth) {\n        vec2 uv = UVfrom3D(\n            " + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ", row, col, depth);\n        return sampleTexture(" + texName + ", uv);\n      }\n  ";
+}
+function getPackedSampler4D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texNumR = packedTexShape[0];
+    var texNumC = packedTexShape[1];
+    var valuesPerRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    vec4 " + funcName + "(int b2, int b, int row, int col) {\n      vec2 uv = packedUVfrom4D(\n        " + texNumR + ", " + texNumC + ", " + texelsInBatch2 + ",\n        " + texelsInBatch + ", " + valuesPerRow + ", b2, b, row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler4D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17696,16 +18765,16 @@ function getSampler4D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float index = dot(vec4(row, col, depth, depth2),\n                          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = float(row);\n        float texC =\n            dot(vec3(col, depth, depth2), vec3(" + stride1 + ", " + stride2 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride2) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = dot(vec3(row, col, depth),\n                         vec3(" + shape[1] * shape[2] + ", " + shape[2] + ", 1));\n        float texC = float(depth2);\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2) {\n      vec2 uv = UVfrom4D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", row, col, depth, depth2);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17724,16 +18793,16 @@ function getSampler5D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " +\n                   depth2 * " + stride3 + " + depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride3) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " +\n                   depth * " + shape[3] + " + depth2;\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] + ", " + shape[2] * shape[3] + ",\n            " + shape[3] + ", 1));\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n      vec2 uv = UVfrom5D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", row, col, depth, depth2, depth3);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17753,16 +18822,16 @@ function getSampler6D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3 * " + stride3 + "\n            + depth4\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          dot(\n            vec2(depth3, depth4),\n            vec2(" + stride4 + ", 1));\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", " + stride4 + ")) + depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride4) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] * shape[4] + ",\n               " + shape[2] * shape[3] * shape[4] + ",\n               " + shape[3] * shape[4] + ",\n               " + shape[4] + ")) + depth3;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n      vec2 uv = UVfrom6D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", " + stride4 + "\n          ,row, col, depth, depth2, depth3, depth4);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17891,7 +18960,7 @@ function getSqueezedParams(params, keptDims) {
     return keptDims.map(function (d) { return params[d]; }).join(', ');
 }
 
-},{"../../ops/broadcast_util":139,"../../util":194}],124:[function(require,module,exports){
+},{"../../ops/broadcast_util":151,"../../util":214}],134:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17955,7 +19024,7 @@ function getCoords(rank) {
     }
 }
 
-},{"./shader_compiler":123}],125:[function(require,module,exports){
+},{"./shader_compiler":133}],135:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17993,9 +19062,10 @@ var StridedSliceProgram = (function () {
 }());
 exports.StridedSliceProgram = StridedSliceProgram;
 
-},{"./shader_compiler":123}],126:[function(require,module,exports){
+},{"./shader_compiler":133}],136:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var util = require("../../util");
 var TextureUsage;
 (function (TextureUsage) {
     TextureUsage[TextureUsage["RENDER"] = 0] = "RENDER";
@@ -18005,9 +19075,11 @@ var TextureUsage;
 })(TextureUsage = exports.TextureUsage || (exports.TextureUsage = {}));
 var PhysicalTextureType;
 (function (PhysicalTextureType) {
-    PhysicalTextureType[PhysicalTextureType["FLOAT16"] = 0] = "FLOAT16";
-    PhysicalTextureType[PhysicalTextureType["FLOAT32"] = 1] = "FLOAT32";
-    PhysicalTextureType[PhysicalTextureType["UNSIGNED_BYTE"] = 2] = "UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT16"] = 0] = "UNPACKED_FLOAT16";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT32"] = 1] = "UNPACKED_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_4X1_UNSIGNED_BYTE"] = 2] = "PACKED_4X1_UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT32"] = 3] = "PACKED_2X2_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT16"] = 4] = "PACKED_2X2_FLOAT16";
 })(PhysicalTextureType = exports.PhysicalTextureType || (exports.PhysicalTextureType = {}));
 function getUnpackedMatrixTextureShapeWidthHeight(rows, columns) {
     return [columns, rows];
@@ -18075,118 +19147,130 @@ function getPackedRGBAArraySizeFromMatrixShape(rows, columns) {
     return w * h * 4;
 }
 exports.getPackedRGBAArraySizeFromMatrixShape = getPackedRGBAArraySizeFromMatrixShape;
-function encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA) {
+function encodeMatrixToPackedRGBA(matrix, batches, rows, columns, packedRGBA) {
     var requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
     if (packedRGBA.length < requiredSize) {
-        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >= " + requiredSize);
+        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >=\n        " + requiredSize);
     }
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    {
-        var dstStride = (oddWidth ? 4 : 0);
-        var oneRow = columns;
-        var dst = 0;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            var matrixSrcRow = (blockY * 2 * columns);
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                var matrixSrcCol = blockX * 2;
-                var src = matrixSrcRow + matrixSrcCol;
-                packedRGBA[dst] = matrix[src];
-                packedRGBA[dst + 1] = matrix[src + 1];
-                packedRGBA[dst + 2] = matrix[src + oneRow];
-                packedRGBA[dst + 3] = matrix[src + oneRow + 1];
-                dst += 4;
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var sourceOffset = batch * rows * columns;
+        var batchOffset = batch * flattenedMatrixSize;
+        {
+            var dstStride = (oddWidth ? 4 : 0);
+            var oneRow = columns;
+            var dst = batchOffset;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                var matrixSrcRow = (blockY * 2 * columns);
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    var matrixSrcCol = blockX * 2;
+                    var src = sourceOffset + matrixSrcRow + matrixSrcCol;
+                    packedRGBA[dst] = matrix[src];
+                    packedRGBA[dst + 1] = matrix[src + 1];
+                    packedRGBA[dst + 2] = matrix[src + oneRow];
+                    packedRGBA[dst + 3] = matrix[src + oneRow + 1];
+                    dst += 4;
+                }
+                dst += dstStride;
             }
-            dst += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = columns - 1;
-        var dst = (textureWidth - 1) * 4;
-        var srcStride = 2 * columns;
-        var dstStride = textureWidth * 4;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            packedRGBA[dst] = matrix[src];
-            packedRGBA[dst + 2] = matrix[src + columns];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + columns - 1;
+            var dst = batchOffset + (texelsPerRow - 1) * 4;
+            var srcStride = 2 * columns;
+            var dstStride = texelsPerRow * 4;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                packedRGBA[dst] = matrix[src];
+                packedRGBA[dst + 2] = matrix[src + columns];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (rows - 1) * columns;
-        var dst = (textureHeight - 1) * textureWidth * 4;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            packedRGBA[dst++] = matrix[src++];
-            packedRGBA[dst++] = matrix[src++];
-            dst += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (rows - 1) * columns;
+            var dst = batchOffset + (texelsPerBatch - texelsPerRow) * 4;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                packedRGBA[dst++] = matrix[src++];
+                packedRGBA[dst++] = matrix[src++];
+                dst += 2;
+            }
+            if (oddWidth && oddHeight) {
+                packedRGBA[batchOffset + flattenedMatrixSize - 4] = matrix[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        packedRGBA[packedRGBA.length - 4] = matrix[matrix.length - 1];
     }
     return packedRGBA;
 }
 exports.encodeMatrixToPackedRGBA = encodeMatrixToPackedRGBA;
-function decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix) {
+function decodeMatrixFromPackedRGBA(packedRGBA, batches, rows, columns, matrix) {
     var requiredSize = rows * columns;
-    if (requiredSize < matrix.length) {
+    if (matrix.length < requiredSize) {
         throw new Error("matrix length (" + matrix.length + ") must be >= " + requiredSize);
     }
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
-    {
-        var srcStride = oddWidth ? 4 : 0;
-        var dstStride = columns + (oddWidth ? 1 : 0);
-        var src = 0;
-        var dstRow1 = 0;
-        var dstRow2 = columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var batchOffset = batch * rows * columns;
+        var sourceOffset = batch * flattenedMatrixSize;
+        {
+            var srcStride = oddWidth ? 4 : 0;
+            var dstStride = columns + (oddWidth ? 1 : 0);
+            var src = sourceOffset;
+            var dstRow1 = batchOffset;
+            var dstRow2 = batchOffset + columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                }
+                src += srcStride;
+                dstRow1 += dstStride;
+                dstRow2 += dstStride;
             }
-            src += srcStride;
-            dstRow1 += dstStride;
-            dstRow2 += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = (textureWidth - 1) * 4;
-        var dst = columns - 1;
-        var srcStride = textureWidth * 4;
-        var dstStride = 2 * columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            matrix[dst] = packedRGBA[src];
-            matrix[dst + columns] = packedRGBA[src + 2];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + (texelsPerRow - 1) * 4;
+            var dst = batchOffset + columns - 1;
+            var srcStride = texelsPerRow * 4;
+            var dstStride = 2 * columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                matrix[dst] = packedRGBA[src];
+                matrix[dst + columns] = packedRGBA[src + 2];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (textureHeight - 1) * textureWidth * 4;
-        var dst = (rows - 1) * columns;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            matrix[dst++] = packedRGBA[src++];
-            matrix[dst++] = packedRGBA[src++];
-            src += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (texelsPerBatch - texelsPerRow) * 4;
+            var dst = batchOffset + (rows - 1) * columns;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                matrix[dst++] = packedRGBA[src++];
+                matrix[dst++] = packedRGBA[src++];
+                src += 2;
+            }
+            if (oddWidth) {
+                matrix[batchOffset + (rows * columns) - 1] = packedRGBA[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        matrix[matrix.length - 1] = packedRGBA[packedRGBA.length - 4];
     }
     return matrix;
 }
 exports.decodeMatrixFromPackedRGBA = decodeMatrixFromPackedRGBA;
 
-},{}],127:[function(require,module,exports){
+},{"../../util":214}],137:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
@@ -18200,9 +19284,9 @@ var TextureManager = (function () {
         this.logEnabled = false;
         this.usedTextures = {};
     }
-    TextureManager.prototype.acquireTexture = function (shapeRC, usage) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(usage);
-        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType);
+    TextureManager.prototype.acquireTexture = function (shapeRC, usage, isPacked) {
+        var physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
+        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18220,24 +19304,34 @@ var TextureManager = (function () {
         this.numUsedTextures++;
         this.log();
         var newTexture;
-        if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT32) {
+        if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32) {
+            newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16) {
+            newTexture =
+                this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32) {
             newTexture =
                 this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT16) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16) {
             newTexture =
                 this.gpgpu.createFloat16MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNSIGNED_BYTE) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE) {
             newTexture =
                 this.gpgpu.createUnsignedBytesMatrixTexture(shapeRC[0], shapeRC[1]);
         }
         this.usedTextures[shapeKey].push(newTexture);
         return newTexture;
     };
-    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType);
-        var shapeKey = getKeyFromTextureShape(shape, physicalTexType);
+    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType, isPacked) {
+        if (this.freeTextures == null) {
+            return;
+        }
+        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+        var shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18289,26 +19383,31 @@ var TextureManager = (function () {
     return TextureManager;
 }());
 exports.TextureManager = TextureManager;
-function getPhysicalFromLogicalTextureType(logicalTexType) {
-    if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
+function getPhysicalFromLogicalTextureType(logicalTexType, isPacked) {
+    if (isPacked) {
+        return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32 :
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    else if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
         logicalTexType === tex_util_1.TextureUsage.PIXELS) {
-        return tex_util_1.PhysicalTextureType.UNSIGNED_BYTE;
+        return tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.UPLOAD) {
-        return tex_util_1.PhysicalTextureType.FLOAT32;
+        return tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.RENDER) {
         return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-            tex_util_1.PhysicalTextureType.FLOAT32 :
-            tex_util_1.PhysicalTextureType.FLOAT16;
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32 :
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16;
     }
     throw new Error("Unknown logical texture type " + logicalTexType);
 }
-function getKeyFromTextureShape(shapeRowsCol, physicalTexType) {
-    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType;
+function getKeyFromTextureShape(shapeRowsCol, physicalTexType, isPacked) {
+    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType + "_" + isPacked;
 }
 
-},{"../../environment":64,"./tex_util":126}],128:[function(require,module,exports){
+},{"../../environment":64,"./tex_util":136}],138:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18344,7 +19443,7 @@ function getSourceCoords(aShape) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],129:[function(require,module,exports){
+},{"./shader_compiler":133}],139:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18377,7 +19476,7 @@ function getSwitchedCoords(newDim) {
     return switchedCoords.join();
 }
 
-},{"./shader_compiler":123}],130:[function(require,module,exports){
+},{"./shader_compiler":133}],140:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var erf_util = require("../../ops/erf_util");
@@ -18444,12 +19543,33 @@ exports.RECIPROCAL = "return 1.0 / x;";
 exports.LOGICAL_NOT = "return float(!(x >= 1.0));";
 exports.TO_INT = "return float(int(x));";
 
-},{"../../ops/erf_util":146,"../../ops/selu_util":166}],131:[function(require,module,exports){
+},{"../../ops/erf_util":159,"../../ops/selu_util":183}],141:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var MAX_TEXTURE_SIZE = null;
-var util = require("../../util");
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var UnpackProgram = (function () {
+    function UnpackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var sourceCoords = packing_util_1.getSourceCoords(rank, channels);
+        var innerDims = packing_util_1.getInnerDims(rank, channels);
+        var coords = rank === 1 ? 'rc' : innerDims.join(',');
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n        vec2 modCoord = mod(vec2(" + coords + "), 2.);\n        vec4 packedInput = getA(" + sourceCoords + ");\n\n        setOutput(\n          modCoord.x == 0. ?\n            (modCoord.y == 0. ? packedInput.r : packedInput.g) :\n            (modCoord.y == 0. ? packedInput.b : packedInput.a)\n        );\n      }\n    ";
+    }
+    return UnpackProgram;
+}());
+exports.UnpackProgram = UnpackProgram;
+
+},{"../packing_util":86,"./shader_compiler":133}],142:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 function createWebGLRenderingContext(attributes) {
     var canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -18600,15 +19720,6 @@ function createStaticIndexBuffer(gl, data) {
     return buffer;
 }
 exports.createStaticIndexBuffer = createStaticIndexBuffer;
-function queryMaxTextureSize(gl) {
-    if (MAX_TEXTURE_SIZE != null) {
-        return MAX_TEXTURE_SIZE;
-    }
-    MAX_TEXTURE_SIZE =
-        callAndCheck(gl, function () { return gl.getParameter(gl.MAX_TEXTURE_SIZE); });
-    return MAX_TEXTURE_SIZE;
-}
-exports.queryMaxTextureSize = queryMaxTextureSize;
 function getNumChannels() {
     if (environment_1.ENV.get('WEBGL_VERSION') === 2) {
         return 1;
@@ -18620,8 +19731,8 @@ function createTexture(gl) {
     return throwIfNull(gl, function () { return gl.createTexture(); }, 'Unable to create WebGLTexture.');
 }
 exports.createTexture = createTexture;
-function validateTextureSize(gl, width, height) {
-    var maxTextureSize = queryMaxTextureSize(gl);
+function validateTextureSize(width, height) {
+    var maxTextureSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
     if ((width <= 0) || (height <= 0)) {
         var requested = "[" + width + "x" + height + "]";
         throw new Error('Requested texture size ' + requested + ' is invalid.');
@@ -18727,12 +19838,19 @@ function validateTextureUnit(gl, textureUnit) {
         throw new Error("textureUnit must be in " + textureUnitRange + ".");
     }
 }
-function getTextureShapeFromLogicalShape(gl, logShape) {
+function getTextureShapeFromLogicalShape(logShape, isPacked) {
+    if (isPacked === void 0) { isPacked = false; }
+    var maxTexSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    if (isPacked) {
+        maxTexSize = maxTexSize * 2;
+        logShape = logShape.map(function (d, i) { return i >= logShape.length - 2 ?
+            util.nearestLargerEven(logShape[i]) :
+            logShape[i]; });
+    }
     if (logShape.length !== 2) {
         var squeezeResult = util.squeezeShape(logShape);
         logShape = squeezeResult.newShape;
     }
-    var maxTexSize = queryMaxTextureSize(gl);
     var size = util.sizeFromShape(logShape);
     if (logShape.length <= 1 && size <= maxTexSize) {
         return [size, 1];
@@ -18741,9 +19859,18 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
         logShape[1] <= maxTexSize) {
         return logShape;
     }
+    else if (logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+        logShape[2] <= maxTexSize) {
+        return [logShape[0] * logShape[1], logShape[2]];
+    }
     else if (logShape.length === 3 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] <= maxTexSize) {
         return [logShape[0], logShape[1] * logShape[2]];
+    }
+    else if (logShape.length === 4 &&
+        logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+        logShape[3] <= maxTexSize) {
+        return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
     }
     else if (logShape.length === 4 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
@@ -18755,7 +19882,7 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
 }
 exports.getTextureShapeFromLogicalShape = getTextureShapeFromLogicalShape;
 
-},{"../../environment":64,"../../util":194}],132:[function(require,module,exports){
+},{"../../environment":64,"../../util":214}],143:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var array_ops_1 = require("../ops/array_ops");
@@ -18777,7 +19904,7 @@ function whereImpl(condShape, condVals) {
 }
 exports.whereImpl = whereImpl;
 
-},{"../ops/array_ops":134}],133:[function(require,module,exports){
+},{"../ops/array_ops":146}],144:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -18802,7 +19929,13 @@ function log() {
 }
 exports.log = log;
 
-},{"./environment":64}],134:[function(require,module,exports){
+},{"./environment":64}],145:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var confusion_matrix_1 = require("./ops/confusion_matrix");
+exports.confusionMatrix = confusion_matrix_1.confusionMatrix;
+
+},{"./ops/confusion_matrix":156}],146:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -19201,9 +20334,10 @@ function stack_(tensors, axis) {
 function batchToSpaceND_(x, blockShape, crops) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'batchToSpaceND');
     var prod = blockShape.reduce(function (a, b) { return a * b; });
-    util.assert($x.rank >= 1 + blockShape.length, "input rank should be > than [blockShape] but got " + $x.rank);
-    util.assert(crops.length === blockShape.length, "crops.shape[0] must be equal to [blockShape] but got " + crops.length);
-    util.assert($x.shape[0] % prod === 0, "input tensor batch must be divisible by prod( blockShape )");
+    util.assert($x.rank >= 1 + blockShape.length, "input rank is " + $x.rank + " but should be > than blockShape.length " + blockShape.length);
+    util.assert(crops.length === blockShape.length, "crops.length is " + crops.length + " but should be equal to blockShape.length  " + blockShape.length);
+    util.assert($x.shape[0] % prod === 0, "input tensor batch is " + $x.shape[0] + " but is not divisible by the product of " +
+        ("the elements of blockShape " + blockShape.join(' * ') + " === " + prod));
     var grad = function (dy) {
         return { $x: function () { return dy.spaceToBatchND(blockShape, crops); } };
     };
@@ -19330,7 +20464,7 @@ exports.tile = operation_1.op({ tile_: tile_ });
 exports.truncatedNormal = operation_1.op({ truncatedNormal_: truncatedNormal_ });
 exports.unstack = operation_1.op({ unstack_: unstack_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_split":142,"./operation":156,"./rand":159,"./tensor_ops":171}],135:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_split":154,"./operation":171,"./rand":174,"./tensor_ops":191}],147:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getReshaped(inputShape, blockShape, prod, batchToSpace) {
@@ -19428,7 +20562,7 @@ function getSliceSize(uncroppedShape, crops, blockShape) {
 }
 exports.getSliceSize = getSliceSize;
 
-},{}],136:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -19518,7 +20652,7 @@ function getInnerMostAxes(numAxes, rank) {
 }
 exports.getInnerMostAxes = getInnerMostAxes;
 
-},{"../util":194}],137:[function(require,module,exports){
+},{"../util":214}],149:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19738,7 +20872,7 @@ exports.batchNormalization3d = operation_1.op({ batchNormalization3d_: batchNorm
 exports.batchNormalization4d = operation_1.op({ batchNormalization4d_: batchNormalization4d_ });
 exports.batchNormalization = operation_1.op({ batchNormalization_: batchNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],138:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],150:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20104,7 +21238,7 @@ exports.squaredDifferenceStrict = operation_1.op({ squaredDifferenceStrict_: squ
 exports.sub = operation_1.op({ sub_: sub_ });
 exports.subStrict = operation_1.op({ subStrict_: subStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../types":193,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],139:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../types":213,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],151:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getBroadcastDims(inShape, outShape) {
@@ -20174,7 +21308,7 @@ function assertAndGetBroadcastShape(shapeA, shapeB) {
 }
 exports.assertAndGetBroadcastShape = assertAndGetBroadcastShape;
 
-},{}],140:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20278,7 +21412,7 @@ exports.lessStrict = operation_1.op({ lessStrict_: lessStrict_ });
 exports.notEqual = operation_1.op({ notEqual_: notEqual_ });
 exports.notEqualStrict = operation_1.op({ notEqualStrict_: notEqualStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],141:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],153:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20304,7 +21438,7 @@ exports.complex = operation_1.op({ complex_: complex_ });
 exports.real = operation_1.op({ real_: real_ });
 exports.imag = operation_1.op({ imag_: imag_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],142:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],154:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20330,6 +21464,7 @@ function concat_(tensors, axis) {
     if (axis === void 0) { axis = 0; }
     util_1.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     var $tensors = tensor_util_env_1.convertToTensorArray(tensors, 'tensors', 'concat');
+    axis = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var outShape = concat_util_1.computeOutShape($tensors.map(function (t) { return t.shape; }), axis);
     if (util_1.sizeFromShape(outShape) === 0) {
         return tensor_ops_1.tensor([], outShape);
@@ -20338,16 +21473,15 @@ function concat_(tensors, axis) {
     if ($tensors.length === 1) {
         return $tensors[0];
     }
-    var axes = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var shapes = $tensors.map(function (t) { return t.shape; });
-    concat_util_1.assertParamsConsistent(shapes, axes);
+    concat_util_1.assertParamsConsistent(shapes, axis);
     var der = function (dy) {
         var sizeSplits = shapes.map(function (s) { return s[axis]; });
         var derTensors = exports.split(dy, sizeSplits, axis);
         return derTensors.map(function (t) { return function () { return t; }; });
     };
     var inputs = $tensors;
-    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axes); }, inputs, der);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axis); }, inputs, der);
 }
 function split_(x, numOrSizeSplits, axis) {
     if (axis === void 0) { axis = 0; }
@@ -20372,7 +21506,7 @@ exports.concat3d = operation_1.op({ concat3d_: concat3d_ });
 exports.concat4d = operation_1.op({ concat4d_: concat4d_ });
 exports.split = operation_1.op({ split_: split_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_util":143,"./operation":156,"./tensor_ops":171}],143:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_util":155,"./operation":171,"./tensor_ops":191}],155:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -20402,13 +21536,40 @@ function computeOutShape(shapes, axis) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194}],144:[function(require,module,exports){
+},{"../util":214}],156:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tensor_util_env_1 = require("../tensor_util_env");
+var util = require("../util");
+var array_ops_1 = require("./array_ops");
+var operation_1 = require("./operation");
+function confusionMatrix_(labels, predictions, numClasses) {
+    var $labels = tensor_util_env_1.convertToTensor(labels, 'label', 'confusionMatrix', 'int32');
+    var $predictions = tensor_util_env_1.convertToTensor(predictions, 'label', 'confusionMatrix', 'int32');
+    util.assert(numClasses == null || numClasses > 0 && Number.isInteger(numClasses), "If provided, numClasses must be a positive integer, " +
+        ("but got " + numClasses));
+    util.assert($labels.rank === 1, "Expected the rank of labels to be 1, but got " + $labels.rank);
+    util.assert($predictions.rank === 1, "Expected the rank of predictions to be 1, " +
+        ("but got " + $predictions.rank));
+    util.assert($labels.shape[0] === $predictions.shape[0], "Mismatch in the number of examples: " +
+        ($labels.shape[0] + " vs. " + $predictions.shape[0] + ". ") +
+        "Labels and predictions should have the same number of elements.");
+    util.assert(numClasses > 0 && Number.isInteger(numClasses), "numClasses is required to be a positive integer, but got " + numClasses);
+    var oneHotLabels = array_ops_1.oneHot($labels, numClasses);
+    var oneHotPredictions = array_ops_1.oneHot($predictions, numClasses);
+    return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+exports.confusionMatrix_ = confusionMatrix_;
+exports.confusionMatrix = operation_1.op({ confusionMatrix_: confusionMatrix_ });
+
+},{"../tensor_util_env":210,"../util":214,"./array_ops":146,"./operation":171}],157:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
+var matmul_1 = require("./matmul");
 var operation_1 = require("./operation");
 function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) {
     if (dataFormat === void 0) { dataFormat = 'NWC'; }
@@ -20430,7 +21591,7 @@ function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) 
     }
     util.assert(x3D.shape[2] === $filter.shape[1], "Error in conv1d: depth of input (" + x3D.shape[2] + ") must match " +
         ("input depth for filter " + $filter.shape[1] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
         ("Got stride " + stride + " and dilation '" + dilation + "'"));
     util.assert(dataFormat === 'NWC', "Error in conv1d: got dataFormat of " + dataFormat + " but only NWC is currently supported.");
     var filter4D = $filter.as4D(1, $filter.shape[0], $filter.shape[1], $filter.shape[2]);
@@ -20464,19 +21625,30 @@ function conv2d_(x, filter, strides, pad, dataFormat, dilations, dimRoundingMode
     }
     util.assert(x4D.shape[3] === $filter.shape[2], "Error in conv2d: depth of input (" + x4D.shape[3] + ") must match " +
         ("input depth for filter " + $filter.shape[2] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert(dataFormat === 'NHWC', "Error in conv2d: got dataFormat of " + dataFormat + " but only NHWC is currently supported.");
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
-    var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
-            ("yet supported in gradients. Got dilations '" + dilations + "'"));
-        return {
-            x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
-            $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+    var res;
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' || convInfo.padInfo.type === 'VALID')) {
+        var x2d = x4D.reshape([-1, convInfo.inChannels]);
+        var w2d = $filter.reshape([convInfo.inChannels, convInfo.outChannels]);
+        res = matmul_1.matMul(x2d, w2d).reshape(convInfo.outShape);
+    }
+    else {
+        var grad = function (dy) {
+            util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+                ("yet supported in gradients. Got dilations '" + dilations + "'"));
+            return {
+                x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
+                $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+            };
         };
-    };
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+        res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+    }
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20510,8 +21682,15 @@ function conv2dDerInput_(xShape, dy, filter, strides, pad, dimRoundingMode) {
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
     var dilations = 1;
+    var grad = function (ddx) {
+        var dataFormat = 'NHWC';
+        return {
+            dy4D: function () { return exports.conv2d(ddx, filter, strides, pad, dataFormat, dilations, dimRoundingMode); },
+            filter: function () { return exports.conv2dDerFilter(ddx, dy4D, filter.shape, strides, pad, dimRoundingMode); }
+        };
+    };
     var convInfo = conv_util.computeConv2DInfo(xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D });
+    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D, filter: filter }, grad);
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20570,7 +21749,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     if (dilations == null) {
         dilations = [1, 1];
     }
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in depthwiseConv2d: pad must be an integer when using, " +
@@ -20578,7 +21757,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     }
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode, true);
     var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+        util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
             ("1 are not yet supported. Got dilations '" + dilations + "'"));
         return {
             x: function () { return depthwiseConv2dDerInput(x4D.shape, dy, $filter, convInfo); },
@@ -20630,16 +21809,6 @@ function separableConv2d_(x, depthwiseFilter, pointwiseFilter, strides, pad, dil
     }
     return res;
 }
-function parseTupleParam(param) {
-    return typeof param === 'number' ? [param, param] : param;
-}
-function tupleValuesAreOne(param) {
-    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
-    return dimA === 1 && dimB === 1;
-}
-function eitherStridesOrDilationsAreOne(strides, dilations) {
-    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
-}
 function depthwiseConv2dDerInput(xShape, dy, filter, convInfo) {
     var dy4D = dy;
     var reshapedTo4D = false;
@@ -20666,15 +21835,16 @@ function depthwiseConv2dDerFilter(x, dy, filterShape, convInfo) {
 }
 exports.conv1d = operation_1.op({ conv1d_: conv1d_ });
 exports.conv2d = operation_1.op({ conv2d_: conv2d_ });
+exports.conv2dDerFilter = operation_1.op({ conv2dDerFilter_: conv2dDerFilter_ });
 exports.depthwiseConv2d = operation_1.op({ depthwiseConv2d_: depthwiseConv2d_ });
 exports.separableConv2d = operation_1.op({ separableConv2d_: separableConv2d_ });
 exports.conv2dTranspose = operation_1.op({ conv2dTranspose_: conv2dTranspose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],145:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./matmul":168,"./operation":171}],158:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
-function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, dataFormat) {
+function computePool2DInfo(inShape, filterSize, strides, dilations, pad, roundingMode, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var _a = parseTupleParam(filterSize), filterHeight = _a[0], filterWidth = _a[1];
     var filterShape;
@@ -20687,7 +21857,6 @@ function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, data
     else {
         throw new Error("Unknown dataFormat " + dataFormat);
     }
-    var dilations = 1;
     return computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundingMode, false, dataFormat);
 }
 exports.computePool2DInfo = computePool2DInfo;
@@ -20732,6 +21901,8 @@ function computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundi
         strideWidth: strideWidth,
         filterHeight: filterHeight,
         filterWidth: filterWidth,
+        effectiveFilterHeight: effectiveFilterHeight,
+        effectiveFilterWidth: effectiveFilterWidth,
         dilationHeight: dilationHeight,
         dilationWidth: dilationWidth,
         inShape: inShape,
@@ -20816,8 +21987,17 @@ function conditionalRound(value, roundingMode) {
             throw new Error("Unknown roundingMode " + roundingMode);
     }
 }
+function tupleValuesAreOne(param) {
+    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
+    return dimA === 1 && dimB === 1;
+}
+exports.tupleValuesAreOne = tupleValuesAreOne;
+function eitherStridesOrDilationsAreOne(strides, dilations) {
+    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+exports.eitherStridesOrDilationsAreOne = eitherStridesOrDilationsAreOne;
 
-},{"../util":194}],146:[function(require,module,exports){
+},{"../util":214}],159:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ERF_P = 0.3275911;
@@ -20827,7 +22007,64 @@ exports.ERF_A3 = 1.421413741;
 exports.ERF_A4 = -1.453152027;
 exports.ERF_A5 = 1.061405429;
 
-},{}],147:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function gatherND_(x, indices) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'gatherND', 'int32');
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'gatherND');
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.gatherND($x, $indices); }, { $x: $x, $indices: $indices });
+}
+exports.gatherND = operation_1.op({ gatherND_: gatherND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],161:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function prepareAndValidate(tensor, indices) {
+    if (tensor.rank < 1) {
+        throw new Error('tf.gatherND() expects the input to be rank 1 or higher,' +
+            (" but the rank was " + tensor.rank + "."));
+    }
+    if (indices.rank < 1) {
+        throw new Error('tf.gatherND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error('tf.gatherND() expects the indices to be int32 type,' +
+            (" but the dtype was " + indices.dtype + "."));
+    }
+    if (indices.shape[indices.rank - 1] > tensor.rank) {
+        throw new Error('index innermost dimension length must be <= tensor rank; saw: ' +
+            (indices.shape[indices.rank - 1] + " vs. " + tensor.rank));
+    }
+    if (tensor.size === 0) {
+        throw new Error('Requested more than 0 entries, but input is empty.' +
+            (" Input shape: " + tensor.shape + "."));
+    }
+    var indicesShape = indices.shape;
+    var sliceRank = indicesShape[indicesShape.length - 1];
+    var nResult = 1;
+    for (var i = 0; i < indicesShape.length - 1; ++i) {
+        nResult *= indicesShape[i];
+    }
+    var inputShape = tensor.shape;
+    var resultShape = indicesShape.slice();
+    resultShape.pop();
+    var sliceSize = 1;
+    for (var i = sliceRank; i < tensor.rank; ++i) {
+        sliceSize *= inputShape[i];
+        resultShape.push(inputShape[i]);
+    }
+    var strides = util_1.computeStrides(tensor.shape).map(function (stride) { return stride / sliceSize; }).concat([1]).slice(0, sliceRank);
+    return [resultShape, nResult, sliceSize, strides];
+}
+exports.prepareAndValidate = prepareAndValidate;
+
+},{"../util":214}],162:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21022,7 +22259,7 @@ exports.nonMaxSuppression = operation_1.op({ nonMaxSuppression_: nonMaxSuppressi
 exports.nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
 exports.cropAndResize = cropAndResize_;
 
-},{"../environment":64,"../kernels/non_max_suppression_impl":84,"../tensor_util_env":190,"../util":194,"./operation":156}],148:[function(require,module,exports){
+},{"../environment":64,"../kernels/non_max_suppression_impl":85,"../tensor_util_env":210,"../util":214,"./operation":171}],163:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21168,7 +22405,7 @@ function qr2d(x, fullMatrices) {
 exports.gramSchmidt = operation_1.op({ gramSchmidt_: gramSchmidt_ });
 exports.qr = operation_1.op({ qr_: qr_ });
 
-},{"../environment":64,"../globals":66,"../util":194,"./array_ops":134,"./concat_split":142,"./norm":155,"./operation":156,"./reduction_ops":161,"./tensor_ops":171}],149:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../util":214,"./array_ops":146,"./concat_split":154,"./norm":170,"./operation":171,"./reduction_ops":176,"./tensor_ops":191}],164:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21285,7 +22522,7 @@ exports.logicalXor = operation_1.op({ logicalXor_: logicalXor_ });
 exports.where = operation_1.op({ where_: where_ });
 exports.whereAsync = whereAsync_;
 
-},{"../environment":64,"../kernels/where_impl":132,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],150:[function(require,module,exports){
+},{"../environment":64,"../kernels/where_impl":143,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],165:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var globals_1 = require("../globals");
@@ -21510,7 +22747,7 @@ exports.meanSquaredError = operation_1.op({ meanSquaredError_: meanSquaredError_
 exports.sigmoidCrossEntropy = operation_1.op({ sigmoidCrossEntropy_: sigmoidCrossEntropy_ });
 exports.softmaxCrossEntropy = operation_1.op({ softmaxCrossEntropy_: softmaxCrossEntropy_ });
 
-},{"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],151:[function(require,module,exports){
+},{"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],166:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21547,7 +22784,7 @@ function localResponseNormalization_(x, depthRadius, bias, alpha, beta) {
 }
 exports.localResponseNormalization = operation_1.op({ localResponseNormalization_: localResponseNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],152:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],167:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21596,7 +22833,7 @@ function basicLSTMCell_(forgetBias, lstmKernel, lstmBias, data, c, h) {
 exports.basicLSTMCell = operation_1.op({ basicLSTMCell_: basicLSTMCell_ });
 exports.multiRNNCell = operation_1.op({ multiRNNCell_: multiRNNCell_ });
 
-},{"../tensor_util_env":190,"./operation":156}],153:[function(require,module,exports){
+},{"../tensor_util_env":210,"./operation":171}],168:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21692,7 +22929,7 @@ exports.matMul = operation_1.op({ matMul_: matMul_ });
 exports.dot = operation_1.op({ dot_: dot_ });
 exports.outerProduct = operation_1.op({ outerProduct_: outerProduct_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],154:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],169:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_1 = require("../tensor_util");
@@ -21720,7 +22957,7 @@ function movingAverage_(v, x, decay, step, zeroDebias) {
 }
 exports.movingAverage = operation_1.op({ movingAverage_: movingAverage_ });
 
-},{"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],155:[function(require,module,exports){
+},{"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],170:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21783,7 +23020,7 @@ function normImpl(x, p, axis) {
 }
 exports.norm = operation_1.op({ norm_: norm_ });
 
-},{"../tensor_util_env":190,"./axis_util":136,"./operation":156,"./tensor_ops":171}],156:[function(require,module,exports){
+},{"../tensor_util_env":210,"./axis_util":148,"./operation":171,"./tensor_ops":191}],171:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21823,7 +23060,7 @@ function op(f) {
 }
 exports.op = op;
 
-},{"../environment":64}],157:[function(require,module,exports){
+},{"../environment":64}],172:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -21854,6 +23091,10 @@ __export(require("./lstm"));
 __export(require("./moving_average"));
 __export(require("./strided_slice"));
 __export(require("./topk"));
+__export(require("./scatter_nd"));
+__export(require("./spectral_ops"));
+__export(require("./sparse_to_dense"));
+__export(require("./gather_nd"));
 var operation_1 = require("./operation");
 exports.op = operation_1.op;
 var losses = require("./loss_ops");
@@ -21862,8 +23103,10 @@ var linalg = require("./linalg_ops");
 exports.linalg = linalg;
 var image = require("./image_ops");
 exports.image = image;
+var spectral = require("./spectral_ops");
+exports.spectral = spectral;
 
-},{"./array_ops":134,"./batchnorm":137,"./binary_ops":138,"./compare":140,"./complex_ops":141,"./concat_split":142,"./conv":144,"./image_ops":147,"./linalg_ops":148,"./logical_ops":149,"./loss_ops":150,"./lrn":151,"./lstm":152,"./matmul":153,"./moving_average":154,"./norm":155,"./operation":156,"./pool":158,"./reduction_ops":161,"./relu_ops":162,"./reverse":163,"./segment_ops":164,"./slice":167,"./softmax":169,"./strided_slice":170,"./tensor_ops":171,"./topk":172,"./transpose":173,"./unary_ops":174}],158:[function(require,module,exports){
+},{"./array_ops":146,"./batchnorm":149,"./binary_ops":150,"./compare":152,"./complex_ops":153,"./concat_split":154,"./conv":157,"./gather_nd":160,"./image_ops":162,"./linalg_ops":163,"./logical_ops":164,"./loss_ops":165,"./lrn":166,"./lstm":167,"./matmul":168,"./moving_average":169,"./norm":170,"./operation":171,"./pool":173,"./reduction_ops":176,"./relu_ops":177,"./reverse":178,"./scatter_nd":179,"./segment_ops":181,"./slice":184,"./softmax":186,"./sparse_to_dense":187,"./spectral_ops":189,"./strided_slice":190,"./tensor_ops":191,"./topk":192,"./transpose":193,"./unary_ops":194}],173:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21871,7 +23114,7 @@ var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
 var operation_1 = require("./operation");
-function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'maxPool');
     var x4D = $x;
     var reshapedTo4D = false;
@@ -21879,18 +23122,21 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
         reshapedTo4D = true;
         x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
     }
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
     util.assert(x4D.rank === 4, "Error in maxPool: input must be rank 4 but got rank " + x4D.rank + ".");
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in maxPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var grad = function (dy, saved) {
         var y4D = saved[0];
         return {
-            x: function () {
-                return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, pad);
-            }
+            x: function () { return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, dilations, pad); }
         };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.maxPool(x4D, convInfo)); }, { x: x4D }, grad);
@@ -21899,9 +23145,17 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return maxPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function avgPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'avgPool');
     util.assert($x.dtype === 'float32', 'The input dtype to avgPool must be float32');
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var x4D = $x;
     var reshapedTo4D = false;
     if ($x.rank === 3) {
@@ -21913,9 +23167,11 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
         util.assert(util.isInt(pad), "Error in avgPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad);
     var grad = function (dy) {
-        return { x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, pad); } };
+        return {
+            x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, dilations, pad); }
+        };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPool(x4D, convInfo); }, { x: x4D }, grad);
     res = res.cast($x.dtype);
@@ -21924,11 +23180,33 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundingMode) {
+function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return avgPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function pool_(input, windowShape, poolingType, padding, dilationRate, strides) {
+    if (dilationRate == null) {
+        dilationRate = 1;
+    }
+    if (strides == null) {
+        strides = 1;
+    }
+    if (poolingType === 'avg') {
+        return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+    else {
+        return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+}
+function maxPoolBackprop(dy, input, output, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'maxPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'maxPoolBackprop');
     var $output = tensor_util_env_1.convertToTensor(output, 'output', 'maxPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPoolBackProp: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert($dy.rank === 4, "Error in maxPoolBackprop: dy must be rank 4 but got rank " +
         ($dy.rank + "."));
     util.assert($input.rank === 4, "Error in maxPoolBackprop: input must be rank 4 but got rank " +
@@ -21937,14 +23215,19 @@ function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundin
         util.assert(util.isInt(pad), "Error in maxPoolBackprop: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.maxPoolBackprop($dy, $input, $output, convInfo); }, { $dy: $dy, $input: $input });
     return res;
 }
-function avgPoolBackprop(dy, input, filterSize, strides, pad) {
+function avgPoolBackprop(dy, input, filterSize, strides, dilations, pad) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'avgPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'avgPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPoolBackprop: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var input4D = $input;
     var dy4D = $dy;
     var reshapedTo4D = false;
@@ -21957,7 +23240,7 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
         (dy4D.rank + "."));
     util.assert(input4D.rank === 4, "Error in avgPoolBackprop: input must be rank 4 but got rank " +
         (input4D.rank + "."));
-    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, dilations, pad);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPoolBackprop(dy4D, input4D, convInfo); }, { dy4D: dy4D, input4D: input4D });
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
@@ -21966,8 +23249,9 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
 }
 exports.maxPool = operation_1.op({ maxPool_: maxPool_ });
 exports.avgPool = operation_1.op({ avgPool_: avgPool_ });
+exports.pool = operation_1.op({ pool_: pool_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],159:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./operation":171}],174:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var seedrandom = require("seedrandom");
@@ -22025,7 +23309,7 @@ var MPRandGauss = (function () {
 }());
 exports.MPRandGauss = MPRandGauss;
 
-},{"seedrandom":281}],160:[function(require,module,exports){
+},{"seedrandom":305}],175:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22038,7 +23322,7 @@ function computeOptimalWindowSize(inSize) {
 }
 exports.computeOptimalWindowSize = computeOptimalWindowSize;
 
-},{"../util":194}],161:[function(require,module,exports){
+},{"../util":214}],176:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22099,6 +23383,28 @@ function sum_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function prod_(x, axis, keepDims) {
+    if (axis === void 0) { axis = null; }
+    if (keepDims === void 0) { keepDims = false; }
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'prod');
+    if ($x.dtype === 'bool') {
+        $x = $x.toInt();
+    }
+    var axes = axis_util.parseAxisParam(axis, $x.shape);
+    var permutation = axis_util.getAxesPermutation(axes, $x.rank);
+    var reductionAxes = axes;
+    var permutedX = $x;
+    if (permutation != null) {
+        permutedX = $x.transpose(permutation);
+        reductionAxes = axis_util.getInnerMostAxes(reductionAxes.length, $x.rank);
+    }
+    var value = environment_1.ENV.engine.runKernel(function (backend) { return backend.prod(permutedX, reductionAxes); }, { permutedX: permutedX });
+    if (keepDims) {
+        var newShape = axis_util.expandShapeToKeepDim(value.shape, axes);
+        value = value.reshape(newShape);
+    }
+    return value;
+}
 function mean_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
@@ -22125,10 +23431,26 @@ function mean_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes) {
+    var y = saved[0];
+    if (y.rank < xOrig.rank) {
+        y = y.reshape(axis_util.expandShapeToKeepDim(y.shape, origAxes));
+    }
+    if (dy.rank < xOrig.rank) {
+        dy = dy.reshape(axis_util.expandShapeToKeepDim(dy.shape, origAxes));
+    }
+    return {
+        $x: function () {
+            var dx = dy.mul(xOrig.equal(y).cast(dy.dtype));
+            return permutedAxes == null ? dx : dx.transpose(permutedAxes);
+        }
+    };
+}
 function min_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'min');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22136,10 +23458,13 @@ function min_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.min($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.min($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22147,6 +23472,7 @@ function max_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'max');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22154,10 +23480,13 @@ function max_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.max($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.max($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22257,8 +23586,9 @@ exports.mean = operation_1.op({ mean_: mean_ });
 exports.min = operation_1.op({ min_: min_ });
 exports.moments = operation_1.op({ moments_: moments_ });
 exports.sum = operation_1.op({ sum_: sum_ });
+exports.prod = operation_1.op({ prod_: prod_ });
 
-},{"../environment":64,"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156,"./tensor_ops":171}],162:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171,"./tensor_ops":191}],177:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22324,7 +23654,7 @@ exports.prelu = operation_1.op({ prelu_: prelu_ });
 exports.relu = operation_1.op({ relu_: relu_ });
 exports.selu = operation_1.op({ selu_: selu_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./binary_ops":138,"./logical_ops":149,"./operation":156,"./selu_util":166,"./tensor_ops":171}],163:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./binary_ops":150,"./logical_ops":164,"./operation":171,"./selu_util":183,"./tensor_ops":191}],178:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22370,7 +23700,99 @@ exports.reverse2d = operation_1.op({ reverse2d_: reverse2d_ });
 exports.reverse3d = operation_1.op({ reverse3d_: reverse3d_ });
 exports.reverse4d = operation_1.op({ reverse4d_: reverse4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],164:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],179:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+var scatter_nd_util = require("./scatter_nd_util");
+function scatterND_(indices, updates, shape) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'scatterND', 'int32');
+    var $updates = tensor_util_env_1.convertToTensor(updates, 'updates', 'scatterND');
+    scatter_nd_util.validateInput($updates, $indices, shape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.scatterND($indices, $updates, shape); }, { $indices: $indices, $updates: $updates });
+}
+exports.scatterND = operation_1.op({ scatterND_: scatterND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171,"./scatter_nd_util":180}],180:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function validateUpdateShape(shape, indices, updates) {
+    var sliceDim = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var batchDim = (indices.rank > 1) ? indices.rank - 1 : 1;
+    var shapeError = 'Must have updates.shape = indices.shape[:batchDim] + ' +
+        ("shape[sliceDim:], got updates.shape: " + updates.shape) +
+        (", indices.shape: " + indices.shape + ", shape: " + shape) +
+        (", sliceDim: " + sliceDim + ", and batchDim: " + batchDim + ".");
+    if (updates.rank < batchDim) {
+        throw new Error(shapeError + (" update.rank < " + batchDim + ". "));
+    }
+    if (shape.length < sliceDim + (updates.rank - batchDim)) {
+        throw new Error(shapeError +
+            (" Output shape length < " + (sliceDim + (updates.rank - batchDim))));
+    }
+    if (updates.rank !== batchDim + shape.length - sliceDim) {
+        throw new Error(shapeError + (" update.rank != " + (batchDim + shape.length - sliceDim)));
+    }
+    for (var d = 0; d < batchDim; ++d) {
+        if (updates.shape[d] !== indices.shape[d]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + d + "] (" + updates.shape[d] + ") != indices.shape[" + d + "] (" + indices.shape[d] + ")."));
+        }
+    }
+    for (var d = 0; d < updates.rank - batchDim; ++d) {
+        if (updates.shape[d + batchDim] !== shape[d + sliceDim]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + (d + batchDim) + "] (" + updates.shape[d + batchDim] + ") != shape[" + (d + batchDim) + "] (" + shape[d + batchDim] + ")"));
+        }
+    }
+}
+exports.validateUpdateShape = validateUpdateShape;
+function validateInput(updates, indices, shape) {
+    if (indices.rank < 1) {
+        throw new Error('tf.scatterND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (updates.rank < 1) {
+        throw new Error('tf.scatterND() expects the updates to be rank 1 or higher,' +
+            (" but the rank was " + updates.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error("The dtype of 'indices' should be int32, but got dtype: " + indices.dtype);
+    }
+    if (shape.length < 1) {
+        throw new Error("Output rank must be greater or equal to 1, but got shape: " + shape);
+    }
+    if (shape.length === 0) {
+        if (indices.size === 0) {
+            throw new Error("Indices specified for empty output. indices shape: " + indices.shape);
+        }
+        if (updates.size === 0) {
+            throw new Error("Updates specified for empty output. updates shape: " + updates.shape);
+        }
+    }
+    validateUpdateShape(shape, indices, updates);
+}
+exports.validateInput = validateInput;
+function calculateShapes(updates, indices, shape) {
+    var sliceRank = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var totalNd = shape.length;
+    var sliceSize = 1;
+    for (var i = sliceRank; i < totalNd; ++i) {
+        sliceSize *= shape[i];
+    }
+    var safeSliceDim = (sliceRank < 1) ? 1 : sliceRank;
+    var numUpdates = indices.size / safeSliceDim;
+    var outputStrides = util_1.computeStrides(shape).concat([1]);
+    var strides = outputStrides.slice(outputStrides.length - sliceRank, outputStrides.length);
+    var outputSize = util_1.sizeFromShape(shape);
+    return { sliceRank: sliceRank, numUpdates: numUpdates, sliceSize: sliceSize, strides: strides, outputSize: outputSize };
+}
+exports.calculateShapes = calculateShapes;
+
+},{"../util":214}],181:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22462,7 +23884,7 @@ function gatherDropNegatives(x, indices) {
 exports.gather = operation_1.op({ gather_: gather_ });
 exports.unsortedSegmentSum = operation_1.op({ unsortedSegmentSum_: unsortedSegmentSum_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./axis_util":136,"./binary_ops":138,"./compare":140,"./logical_ops":149,"./operation":156,"./tensor_ops":171}],165:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./axis_util":148,"./binary_ops":150,"./compare":152,"./logical_ops":164,"./operation":171,"./tensor_ops":191}],182:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22504,13 +23926,13 @@ function computeOutShape(aShape, axis, numSegments) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194,"./reduce_util":160}],166:[function(require,module,exports){
+},{"../util":214,"./reduce_util":175}],183:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SELU_SCALEALPHA = 1.7580993408473768599402175208123;
 exports.SELU_SCALE = 1.0507009873554804934193349852946;
 
-},{}],167:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22525,17 +23947,17 @@ function slice1d_(x, begin, size) {
 }
 function slice2d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice2d');
-    util.assert($x.rank === 2, "slice1d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 2, "slice2d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice3d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice3d');
-    util.assert($x.rank === 3, "slice1d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 3, "slice3d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice4d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice4d');
-    util.assert($x.rank === 4, "slice1d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 4, "slice4d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice_(x, begin, size) {
@@ -22592,7 +24014,7 @@ exports.slice2d = operation_1.op({ slice2d_: slice2d_ });
 exports.slice3d = operation_1.op({ slice3d_: slice3d_ });
 exports.slice4d = operation_1.op({ slice4d_: slice4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./slice_util":168}],168:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./slice_util":185}],185:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -22683,7 +24105,7 @@ function stopForAxis(endMask, stopIndices, strides, inputShape, axis) {
 }
 exports.stopForAxis = stopForAxis;
 
-},{"../util":194}],169:[function(require,module,exports){
+},{"../util":214}],186:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gradients_1 = require("../gradients");
@@ -22715,7 +24137,67 @@ function softmax_(logits, dim) {
 }
 exports.softmax = operation_1.op({ softmax_: softmax_ });
 
-},{"../gradients":67,"../tensor_util_env":190,"./operation":156}],170:[function(require,module,exports){
+},{"../gradients":67,"../tensor_util_env":210,"./operation":171}],187:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var sparse_to_dense = require("../ops/sparse_to_dense_util");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function sparseToDense_(sparseIndices, sparseValues, outputShape, defaultValue) {
+    var $sparseIndices = tensor_util_env_1.convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
+    var $sparseValues = tensor_util_env_1.convertToTensor(sparseValues, 'sparseValues', 'sparseToDense');
+    var $defaultValue = tensor_util_env_1.convertToTensor(defaultValue, 'defaultValue', 'sparseToDense');
+    sparse_to_dense.validateInput($sparseIndices, $sparseValues, outputShape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.sparseToDense($sparseIndices, $sparseValues, outputShape, $defaultValue); }, { $sparseIndices: $sparseIndices, $sparseValues: $sparseValues, $defaultValue: $defaultValue });
+}
+exports.sparseToDense = operation_1.op({ sparseToDense_: sparseToDense_ });
+
+},{"../environment":64,"../ops/sparse_to_dense_util":188,"../tensor_util_env":210,"./operation":171}],188:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateInput(sparseIndices, sparseValues, outputShape) {
+    if (sparseIndices.dtype !== 'int32') {
+        throw new Error('tf.sparseToDense() expects the indices to be int32 type,' +
+            (" but the dtype was " + sparseIndices.dtype + "."));
+    }
+    if (sparseIndices.rank > 2) {
+        throw new Error('sparseIndices should be a scalar, vector, or matrix,' +
+            (" but got shape " + sparseIndices.shape + "."));
+    }
+    var numElems = sparseIndices.rank > 0 ? sparseIndices.shape[0] : 1;
+    var numDims = sparseIndices.rank > 1 ? sparseIndices.shape[1] : 1;
+    if (outputShape.length !== numDims) {
+        throw new Error('outputShape has incorrect number of elements:,' +
+            (" " + outputShape.length + ", should be: " + numDims + "."));
+    }
+    var numValues = sparseValues.size;
+    if (!(sparseValues.rank === 0 ||
+        sparseValues.rank === 1 && numValues === numElems)) {
+        throw new Error('sparseValues has incorrect shape ' +
+            (sparseValues.shape + ", should be [] or [" + numElems + "]"));
+    }
+}
+exports.validateInput = validateInput;
+
+},{}],189:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var operation_1 = require("../ops/operation");
+var util_1 = require("../util");
+function fft_(input) {
+    util_1.assert(input.dtype === 'complex64', "The dtype for tf.spectral.fft() must be complex64 " +
+        ("but got " + input.dtype + "."));
+    var innerDimensionSize = input.shape[input.shape.length - 1];
+    var batch = input.size / innerDimensionSize;
+    var input2D = input.as2D(batch, innerDimensionSize);
+    var ret = environment_1.ENV.engine.runKernel(function (backend) { return backend.fft(input2D); }, { input: input });
+    return ret.reshape(input.shape);
+}
+exports.fft = operation_1.op({ fft_: fft_ });
+
+},{"../environment":64,"../ops/operation":171,"../util":214}],190:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22738,12 +24220,13 @@ function stridedSlice_(x, begin, end, strides, beginMask, endMask, ellipsisMask,
 }
 exports.stridedSlice = operation_1.op({ stridedSlice_: stridedSlice_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],171:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],191:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_1 = require("../tensor");
 var tensor_util_env_1 = require("../tensor_util_env");
+var tensor_util_env_2 = require("../tensor_util_env");
 var util_1 = require("../util");
 var complex_ops_1 = require("./complex_ops");
 var operation_1 = require("./operation");
@@ -22758,7 +24241,7 @@ function tensor(values, shape, dtype) {
         throw new Error('values passed to tensor(values) must be an ' +
             'array of numbers or booleans, or a TypedArray');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (shape != null && inferredShape.length !== 1) {
         util_1.assertShapesMatch(shape, inferredShape, "Error creating a new Tensor. " +
             ("Inferred shape (" + inferredShape + ") does not match the ") +
@@ -22785,7 +24268,7 @@ exports.scalar = scalar;
 function tensor1d(values, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     util_1.assertNonNull(values);
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 1) {
         throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
@@ -22798,7 +24281,7 @@ function tensor2d(values, shape, dtype) {
     if (shape != null && shape.length !== 2) {
         throw new Error('tensor2d() requires shape to have two numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
         throw new Error('tensor2d() requires values to be number[][] or flat/TypedArray');
     }
@@ -22816,7 +24299,7 @@ function tensor3d(values, shape, dtype) {
     if (shape != null && shape.length !== 3) {
         throw new Error('tensor3d() requires shape to have three numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
         throw new Error('tensor3d() requires values to be number[][][] or flat/TypedArray');
     }
@@ -22834,7 +24317,7 @@ function tensor4d(values, shape, dtype) {
     if (shape != null && shape.length !== 4) {
         throw new Error('tensor4d() requires shape to have four numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
         throw new Error('tensor4d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22852,7 +24335,7 @@ function tensor5d(values, shape, dtype) {
     if (shape != null && shape.length !== 5) {
         throw new Error('tensor5d() requires shape to have five numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 5 && inferredShape.length !== 1) {
         throw new Error('tensor5d() requires values to be ' +
             'number[][][][][] or flat/TypedArray');
@@ -22871,7 +24354,7 @@ function tensor6d(values, shape, dtype) {
     if (shape != null && shape.length !== 6) {
         throw new Error('tensor6d() requires shape to have six numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 6 && inferredShape.length !== 1) {
         throw new Error('tensor6d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22962,7 +24445,7 @@ exports.range = range;
 exports.onesLike = operation_1.op({ onesLike_: onesLike_ });
 exports.zerosLike = operation_1.op({ zerosLike_: zerosLike_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./complex_ops":141,"./operation":156}],172:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./complex_ops":153,"./operation":171}],192:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22985,7 +24468,7 @@ function topk_(x, k, sorted) {
 }
 exports.topk = operation_1.op({ topk_: topk_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],173:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],193:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23015,7 +24498,7 @@ function transpose_(x, perm) {
 }
 exports.transpose = operation_1.op({ transpose_: transpose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],174:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],194:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23305,7 +24788,7 @@ exports.step = operation_1.op({ step_: step_ });
 exports.tan = operation_1.op({ tan_: tan_ });
 exports.tanh = operation_1.op({ tanh_: tanh_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./tensor_ops":171}],175:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./tensor_ops":191}],195:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23412,7 +24895,7 @@ var AdadeltaOptimizer = (function (_super) {
 exports.AdadeltaOptimizer = AdadeltaOptimizer;
 serialization_1.registerClass(AdadeltaOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],176:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],196:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23494,7 +24977,7 @@ var AdagradOptimizer = (function (_super) {
 exports.AdagradOptimizer = AdagradOptimizer;
 serialization_1.registerClass(AdagradOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],177:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],197:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23613,7 +25096,7 @@ var AdamOptimizer = (function (_super) {
 exports.AdamOptimizer = AdamOptimizer;
 serialization_1.registerClass(AdamOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],178:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],198:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23734,7 +25217,7 @@ var AdamaxOptimizer = (function (_super) {
 exports.AdamaxOptimizer = AdamaxOptimizer;
 serialization_1.registerClass(AdamaxOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],179:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],199:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23824,7 +25307,7 @@ var MomentumOptimizer = (function (_super) {
 exports.MomentumOptimizer = MomentumOptimizer;
 serialization_1.registerClass(MomentumOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./sgd_optimizer":183}],180:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./sgd_optimizer":203}],200:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23865,7 +25348,7 @@ var Optimizer = (function (_super) {
 }(serialization_1.Serializable));
 exports.Optimizer = Optimizer;
 
-},{"../globals":66,"../serialization":185}],181:[function(require,module,exports){
+},{"../globals":66,"../serialization":205}],201:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./adadelta_optimizer");
@@ -23921,7 +25404,7 @@ var OptimizerConstructors = (function () {
 }());
 exports.OptimizerConstructors = OptimizerConstructors;
 
-},{"./adadelta_optimizer":175,"./adagrad_optimizer":176,"./adam_optimizer":177,"./adamax_optimizer":178,"./momentum_optimizer":179,"./rmsprop_optimizer":182,"./sgd_optimizer":183}],182:[function(require,module,exports){
+},{"./adadelta_optimizer":195,"./adagrad_optimizer":196,"./adam_optimizer":197,"./adamax_optimizer":198,"./momentum_optimizer":199,"./rmsprop_optimizer":202,"./sgd_optimizer":203}],202:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24065,7 +25548,7 @@ var RMSPropOptimizer = (function (_super) {
 exports.RMSPropOptimizer = RMSPropOptimizer;
 serialization_1.registerClass(RMSPropOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],183:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],203:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24125,7 +25608,7 @@ var SGDOptimizer = (function (_super) {
 exports.SGDOptimizer = SGDOptimizer;
 serialization_1.registerClass(SGDOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],184:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],204:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("./util");
@@ -24149,7 +25632,11 @@ var Profiler = (function () {
             var vals = r.dataSync();
             util.checkComputationForNaN(vals, r.dtype, name);
             timer.then(function (timing) {
-                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+                var extraInfo = '';
+                if (timing.getExtraProfileInfo != null) {
+                    extraInfo = timing.getExtraProfileInfo();
+                }
+                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
             });
         });
         return result;
@@ -24160,19 +25647,19 @@ exports.Profiler = Profiler;
 var Logger = (function () {
     function Logger() {
     }
-    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs) {
+    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs, extraInfo) {
         var time = util.rightPad(timeMs + "ms", 9);
         var paddedName = util.rightPad(name, 25);
         var rank = result.rank;
         var size = result.size;
         var shape = util.rightPad(result.shape.toString(), 14);
-        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size + "\t%c" + extraInfo, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange', 'color: green');
     };
     return Logger;
 }());
 exports.Logger = Logger;
 
-},{"./util":194}],185:[function(require,module,exports){
+},{"./util":214}],205:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -24217,7 +25704,7 @@ function registerClass(cls) {
 }
 exports.registerClass = registerClass;
 
-},{"./util":194}],186:[function(require,module,exports){
+},{"./util":214}],206:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -24330,7 +25817,7 @@ function backpropagateGradients(tensorAccumulatedGradientMap, filteredTape) {
 }
 exports.backpropagateGradients = backpropagateGradients;
 
-},{"./tensor":187,"./util":194}],187:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],207:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24716,6 +26203,12 @@ var Tensor = (function () {
         if (keepDims === void 0) { keepDims = false; }
         this.throwIfDisposed();
         return opHandler.sum(this, axis, keepDims);
+    };
+    Tensor.prototype.prod = function (axis, keepDims) {
+        if (axis === void 0) { axis = null; }
+        if (keepDims === void 0) { keepDims = false; }
+        this.throwIfDisposed();
+        return opHandler.prod(this, axis, keepDims);
     };
     Tensor.prototype.mean = function (axis, keepDims) {
         if (axis === void 0) { axis = null; }
@@ -25117,6 +26610,10 @@ var Tensor = (function () {
         if (beta === void 0) { beta = 0.5; }
         return opHandler.localResponseNormalization(this, radius, bias, alpha, beta);
     };
+    Tensor.prototype.pool = function (windowShape, poolingType, padding, dilationRate, strides) {
+        this.throwIfDisposed();
+        return opHandler.pool(this, windowShape, poolingType, padding, dilationRate, strides);
+    };
     Tensor.prototype.variable = function (trainable, name, dtype) {
         if (trainable === void 0) { trainable = true; }
         this.throwIfDisposed();
@@ -25149,6 +26646,10 @@ var Tensor = (function () {
     Tensor.prototype.depthToSpace = function (blockSize, dataFormat) {
         this.throwIfDisposed();
         return opHandler.depthToSpace(this, blockSize, dataFormat);
+    };
+    Tensor.prototype.fft = function () {
+        this.throwIfDisposed();
+        return opHandler.spectral.fft(this);
     };
     Tensor.nextId = 0;
     return Tensor;
@@ -25212,7 +26713,7 @@ Object.defineProperty(Variable, Symbol.hasInstance, {
 var variable = Variable.variable;
 exports.variable = variable;
 
-},{"./tensor_format":188,"./util":194}],188:[function(require,module,exports){
+},{"./tensor_format":208,"./util":214}],208:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -25343,7 +26844,7 @@ function createComplexTuples(vals) {
     return complexTuples;
 }
 
-},{"./util":194}],189:[function(require,module,exports){
+},{"./util":214}],209:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -25418,12 +26919,47 @@ function isIterable(obj) {
     return Array.isArray(obj) || typeof obj === 'object';
 }
 
-},{"./tensor":187,"./util":194}],190:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],210:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
 var tensor_1 = require("./tensor");
 var util_1 = require("./util");
+function inferShape(val) {
+    var firstElem = val;
+    if (util_1.isTypedArray(val)) {
+        return [val.length];
+    }
+    if (!Array.isArray(val)) {
+        return [];
+    }
+    var shape = [];
+    while (firstElem instanceof Array) {
+        shape.push(firstElem.length);
+        firstElem = firstElem[0];
+    }
+    if (val instanceof Array && environment_1.ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+        deepAssertShapeConsistency(val, shape, []);
+    }
+    return shape;
+}
+exports.inferShape = inferShape;
+function deepAssertShapeConsistency(val, shape, indices) {
+    indices = indices || [];
+    if (!(val instanceof Array)) {
+        util_1.assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
+            ("but should be an array of " + shape[0] + " elements"); });
+        return;
+    }
+    util_1.assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
+        ("but is an array of " + val.length + " elements"); });
+    util_1.assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
+        ("elements, but has " + val.length + " elements"); });
+    var subShape = shape.slice(1);
+    for (var i = 0; i < val.length; ++i) {
+        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
+    }
+}
 function convertToTensor(x, argName, functionName, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     dtype = dtype || 'float32';
@@ -25435,7 +26971,7 @@ function convertToTensor(x, argName, functionName, dtype) {
         throw new Error("Argument '" + argName + "' passed to '" + functionName + "' must be a " +
             ("Tensor or TensorLike, but got " + x.constructor.name));
     }
-    var inferredShape = util_1.inferShape(x);
+    var inferredShape = inferShape(x);
     if (!util_1.isTypedArray(x) && !Array.isArray(x)) {
         x = [x];
     }
@@ -25452,7 +26988,7 @@ function convertToTensorArray(arg, argName, functionName) {
 }
 exports.convertToTensorArray = convertToTensorArray;
 
-},{"./environment":64,"./tensor":187,"./util":194}],191:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],211:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -25472,6 +27008,9 @@ exports.BROWSER_ENVS = {
 };
 exports.CPU_ENVS = {
     'HAS_WEBGL': false
+};
+exports.BROWSER_CPU_ENVS = {
+    'BACKEND': 'test-cpu'
 };
 exports.ALL_ENVS = {};
 function expectArraysClose(actual, expected, epsilon) {
@@ -25573,7 +27112,7 @@ function expectArrayBuffersEqual(actual, expected) {
 }
 exports.expectArrayBuffersEqual = expectArrayBuffersEqual;
 
-},{"./environment":64,"./tensor":187,"./util":194}],192:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],212:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./optimizers/adadelta_optimizer");
@@ -25596,7 +27135,7 @@ exports.train = {
     adam: optimizer_constructors_1.OptimizerConstructors.adam
 };
 
-},{"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer_constructors":181,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183}],193:[function(require,module,exports){
+},{"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer_constructors":201,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203}],213:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DType;
@@ -25658,7 +27197,7 @@ function sumOutType(type) {
 }
 exports.sumOutType = sumOutType;
 
-},{}],194:[function(require,module,exports){
+},{}],214:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -25679,6 +27218,18 @@ function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 exports.clamp = clamp;
+function nearestLargerEven(val) {
+    return val % 2 === 0 ? val : val + 1;
+}
+exports.nearestLargerEven = nearestLargerEven;
+function sum(arr) {
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) {
+        sum += arr[i];
+    }
+    return sum;
+}
+exports.sum = sum;
 function randUniform(a, b) {
     var r = Math.random();
     return (b * r) + (1 - r) * a;
@@ -25721,41 +27272,6 @@ function flatten(arr, ret) {
     return ret;
 }
 exports.flatten = flatten;
-function inferShape(val) {
-    var firstElem = val;
-    if (isTypedArray(val)) {
-        return [val.length];
-    }
-    if (!Array.isArray(val)) {
-        return [];
-    }
-    var shape = [];
-    while (firstElem instanceof Array) {
-        shape.push(firstElem.length);
-        firstElem = firstElem[0];
-    }
-    if (val instanceof Array) {
-        deepAssertShapeConsistency(val, shape, []);
-    }
-    return shape;
-}
-exports.inferShape = inferShape;
-function deepAssertShapeConsistency(val, shape, indices) {
-    indices = indices || [];
-    if (!(val instanceof Array)) {
-        assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
-            ("but should be an array of " + shape[0] + " elements"); });
-        return;
-    }
-    assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
-        ("but is an array of " + val.length + " elements"); });
-    assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
-        ("elements, but has " + val.length + " elements"); });
-    var subShape = shape.slice(1);
-    for (var i = 0; i < val.length; ++i) {
-        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
-    }
-}
 function sizeFromShape(shape) {
     if (shape.length === 0) {
         return 1;
@@ -25772,6 +27288,12 @@ function isScalarShape(shape) {
 }
 exports.isScalarShape = isScalarShape;
 function arraysEqual(n1, n2) {
+    if (n1 === n2) {
+        return true;
+    }
+    if (n1 == null || n2 == null) {
+        return false;
+    }
     if (n1.length !== n2.length) {
         return false;
     }
@@ -26089,13 +27611,13 @@ function now() {
 exports.now = now;
 
 }).call(this,require('_process'))
-},{"_process":269}],195:[function(require,module,exports){
+},{"_process":293}],215:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.17';
+var version = '0.13.8';
 exports.version = version;
 
-},{}],196:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gpgpu_util = require("./kernels/webgl/gpgpu_util");
@@ -26107,7 +27629,7 @@ exports.MathBackendWebGL = backend_webgl_1.MathBackendWebGL;
 var gpgpu_context_1 = require("./kernels/webgl/gpgpu_context");
 exports.GPGPUContext = gpgpu_context_1.GPGPUContext;
 
-},{"./kernels/backend_webgl":82,"./kernels/webgl/gpgpu_context":104,"./kernels/webgl/gpgpu_util":106,"./kernels/webgl/webgl_util":131}],197:[function(require,module,exports){
+},{"./kernels/backend_webgl":83,"./kernels/webgl/gpgpu_context":110,"./kernels/webgl/gpgpu_util":112,"./kernels/webgl/webgl_util":142}],217:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26149,7 +27671,7 @@ var Elu = (function (_super) {
     return Elu;
 }(Activation));
 exports.Elu = Elu;
-tfjs_core_1.serialization.SerializationMap.register(Elu);
+tfjs_core_1.serialization.registerClass(Elu);
 var Selu = (function (_super) {
     __extends(Selu, _super);
     function Selu() {
@@ -26162,7 +27684,7 @@ var Selu = (function (_super) {
     return Selu;
 }(Activation));
 exports.Selu = Selu;
-tfjs_core_1.serialization.SerializationMap.register(Selu);
+tfjs_core_1.serialization.registerClass(Selu);
 var Relu = (function (_super) {
     __extends(Relu, _super);
     function Relu() {
@@ -26175,7 +27697,7 @@ var Relu = (function (_super) {
     return Relu;
 }(Activation));
 exports.Relu = Relu;
-tfjs_core_1.serialization.SerializationMap.register(Relu);
+tfjs_core_1.serialization.registerClass(Relu);
 var Relu6 = (function (_super) {
     __extends(Relu6, _super);
     function Relu6() {
@@ -26188,7 +27710,7 @@ var Relu6 = (function (_super) {
     return Relu6;
 }(Activation));
 exports.Relu6 = Relu6;
-tfjs_core_1.serialization.SerializationMap.register(Relu6);
+tfjs_core_1.serialization.registerClass(Relu6);
 var Linear = (function (_super) {
     __extends(Linear, _super);
     function Linear() {
@@ -26201,7 +27723,7 @@ var Linear = (function (_super) {
     return Linear;
 }(Activation));
 exports.Linear = Linear;
-tfjs_core_1.serialization.SerializationMap.register(Linear);
+tfjs_core_1.serialization.registerClass(Linear);
 var Sigmoid = (function (_super) {
     __extends(Sigmoid, _super);
     function Sigmoid() {
@@ -26214,7 +27736,7 @@ var Sigmoid = (function (_super) {
     return Sigmoid;
 }(Activation));
 exports.Sigmoid = Sigmoid;
-tfjs_core_1.serialization.SerializationMap.register(Sigmoid);
+tfjs_core_1.serialization.registerClass(Sigmoid);
 var HardSigmoid = (function (_super) {
     __extends(HardSigmoid, _super);
     function HardSigmoid() {
@@ -26227,7 +27749,7 @@ var HardSigmoid = (function (_super) {
     return HardSigmoid;
 }(Activation));
 exports.HardSigmoid = HardSigmoid;
-tfjs_core_1.serialization.SerializationMap.register(HardSigmoid);
+tfjs_core_1.serialization.registerClass(HardSigmoid);
 var Softplus = (function (_super) {
     __extends(Softplus, _super);
     function Softplus() {
@@ -26240,7 +27762,7 @@ var Softplus = (function (_super) {
     return Softplus;
 }(Activation));
 exports.Softplus = Softplus;
-tfjs_core_1.serialization.SerializationMap.register(Softplus);
+tfjs_core_1.serialization.registerClass(Softplus);
 var Softsign = (function (_super) {
     __extends(Softsign, _super);
     function Softsign() {
@@ -26253,7 +27775,7 @@ var Softsign = (function (_super) {
     return Softsign;
 }(Activation));
 exports.Softsign = Softsign;
-tfjs_core_1.serialization.SerializationMap.register(Softsign);
+tfjs_core_1.serialization.registerClass(Softsign);
 var Tanh = (function (_super) {
     __extends(Tanh, _super);
     function Tanh() {
@@ -26266,7 +27788,7 @@ var Tanh = (function (_super) {
     return Tanh;
 }(Activation));
 exports.Tanh = Tanh;
-tfjs_core_1.serialization.SerializationMap.register(Tanh);
+tfjs_core_1.serialization.registerClass(Tanh);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax() {
@@ -26280,7 +27802,7 @@ var Softmax = (function (_super) {
     return Softmax;
 }(Activation));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 function serializeActivation(activation) {
     return activation.getClassName();
 }
@@ -26308,7 +27830,7 @@ function getActivation(identifier) {
 }
 exports.getActivation = getActivation;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],198:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],218:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26326,7 +27848,7 @@ function imageDataFormat() {
 }
 exports.imageDataFormat = imageDataFormat;
 
-},{"@tensorflow/tfjs-core":68}],199:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26371,7 +27893,7 @@ function disposeScalarCache() {
 }
 exports.disposeScalarCache = disposeScalarCache;
 
-},{"@tensorflow/tfjs-core":68}],200:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -26580,27 +28102,42 @@ function randomNormal(shape, mean, stddev, dtype, seed) {
 }
 exports.randomNormal = randomNormal;
 function dot(x, y) {
-    if (y.rank !== 2) {
-        throw new errors_1.NotImplementedError("dot support for y other than rank 2 is not yet implemented: " +
-            ("y shape = " + y.shape));
+    if ((x.rank < 2) || (y.rank < 2)) {
+        throw new errors_1.NotImplementedError("dot requires both inputs to be rank >= 2" +
+            (" but got x shape = " + x.shape + " and y shape = " + y.shape));
+    }
+    if (y.rank >= 3) {
+        var xLastDim = x.shape.slice(-1)[0];
+        var ySecondLastDim = y.shape.slice(-2)[0];
+        if (xLastDim !== ySecondLastDim) {
+            throw new errors_1.NotImplementedError("If rank y >= 3, then the second last dim" +
+                (" of y must equal the last dim of x but got x shape = " + x.shape + " and ") +
+                (" y shape = " + y.shape));
+        }
+    }
+    if ((x.rank === 2) && (y.rank === 2)) {
+        return tfc.matMul(x, y);
     }
     else {
-        if (x.rank === 2) {
-            return tfc.matMul(x, y);
-        }
-        else if (x.rank === 3) {
-            var xShape0 = x.shape[0];
-            var xShape1 = x.shape[1];
-            var xShape2 = x.shape[2];
-            x = x.reshape([xShape0 * xShape1, xShape2]);
-            return tfc.matMul(x, y).reshape([
-                xShape0, xShape1, y.shape[1]
-            ]);
-        }
-        else {
-            throw new errors_1.NotImplementedError("dot support for x of rank " + x.rank + " is not yet implemented: " +
-                ("x shape = " + x.shape));
-        }
+        var xFirstDims = x.shape.slice();
+        var xLastDim = xFirstDims.pop();
+        x = x.reshape([-1, xLastDim]);
+        var yShape = y.shape.slice();
+        var yLastDim = yShape.pop();
+        var ySecondLastDim = yShape.pop();
+        var yOtherDims = yShape.concat([yLastDim]);
+        var perm = Array.from({ length: y.rank }, function (_, i) {
+            if (i === 0) {
+                return y.rank - 2;
+            }
+            else if (i <= y.rank - 2) {
+                return i - 1;
+            }
+            return i;
+        });
+        y = y.transpose(perm).reshape([ySecondLastDim, -1]);
+        var outputShape = xFirstDims.concat(yOtherDims);
+        return tfc.matMul(x, y).reshape(outputShape);
     }
 }
 exports.dot = dot;
@@ -26768,7 +28305,7 @@ function inTrainPhase(x, alt, training) {
 }
 exports.inTrainPhase = inTrainPhase;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/math_utils":240,"./common":198,"@tensorflow/tfjs-core":68}],201:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/math_utils":264,"./common":218,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26818,8 +28355,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("./backend/state");
+var errors_1 = require("./errors");
 var logs_1 = require("./logs");
 var generic_utils = require("./utils/generic_utils");
+var ModelLoggingVerbosity;
+(function (ModelLoggingVerbosity) {
+    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
+    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
+})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
 var BaseCallback = (function () {
     function BaseCallback() {
         this.validationData = null;
@@ -26973,19 +28516,22 @@ var CallbackList = (function () {
                         if (logs == null) {
                             logs = {};
                         }
-                        _i = 0, _a = this.callbacks;
-                        _b.label = 1;
+                        return [4, logs_1.resolveScalarsInLogs(logs)];
                     case 1:
-                        if (!(_i < _a.length)) return [3, 4];
+                        _b.sent();
+                        _i = 0, _a = this.callbacks;
+                        _b.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3, 5];
                         callback = _a[_i];
                         return [4, callback.onBatchEnd(batch, logs)];
-                    case 2:
-                        _b.sent();
-                        _b.label = 3;
                     case 3:
+                        _b.sent();
+                        _b.label = 4;
+                    case 4:
                         _i++;
-                        return [3, 1];
-                    case 4: return [2];
+                        return [3, 2];
+                    case 5: return [2];
                 }
             });
         });
@@ -27469,8 +29015,70 @@ function standardizeCallbacks(callbacks) {
     return callbackConfigs.map(function (callbackConfig) { return new CustomCallback(callbackConfig); });
 }
 exports.standardizeCallbacks = standardizeCallbacks;
+var CallbackConstructorRegistry = (function () {
+    function CallbackConstructorRegistry() {
+    }
+    CallbackConstructorRegistry.registerCallbackConstructor = function (verbosityLevel, callbackConstructor) {
+        tfjs_core_1.util.assert(verbosityLevel >= 0 && Number.isInteger(verbosityLevel), "Verbosity level is expected to be an integer >= 0, " +
+            ("but got " + verbosityLevel));
+        CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
+        if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {
+            CallbackConstructorRegistry.constructors[verbosityLevel] = [];
+        }
+        CallbackConstructorRegistry.constructors[verbosityLevel].push(callbackConstructor);
+    };
+    CallbackConstructorRegistry.checkForDuplicate = function (callbackConstructor) {
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var constructors = CallbackConstructorRegistry.constructors[+levelName];
+            constructors.forEach(function (ctor) {
+                if (ctor === callbackConstructor) {
+                    throw new errors_1.ValueError('Duplicate callback constructor.');
+                }
+            });
+        }
+    };
+    CallbackConstructorRegistry.clear = function () {
+        CallbackConstructorRegistry.constructors = {};
+    };
+    CallbackConstructorRegistry.createCallbacks = function (verbosityLevel) {
+        var constructors = [];
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var level = +levelName;
+            if (verbosityLevel >= level) {
+                constructors.push.apply(constructors, CallbackConstructorRegistry.constructors[level]);
+            }
+        }
+        return constructors.map(function (ctor) { return new ctor(); });
+    };
+    CallbackConstructorRegistry.constructors = {};
+    return CallbackConstructorRegistry;
+}());
+exports.CallbackConstructorRegistry = CallbackConstructorRegistry;
+function configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics) {
+    var history = new History();
+    var actualCallbacks = [
+        new BaseLogger(yieldEvery)
+    ].concat(CallbackConstructorRegistry.createCallbacks(verbose));
+    if (callbacks != null) {
+        actualCallbacks.push.apply(actualCallbacks, callbacks);
+    }
+    actualCallbacks.push(history);
+    var callbackList = new CallbackList(actualCallbacks);
+    callbackList.setParams({
+        epochs: epochs,
+        initialEpoch: initialEpoch,
+        samples: numTrainSamples,
+        steps: stepsPerEpoch,
+        batchSize: batchSize,
+        verbose: verbose,
+        doValidation: doValidation,
+        metrics: callbackMetrics,
+    });
+    return { callbackList: callbackList, history: history };
+}
+exports.configureCallbacks = configureCallbacks;
 
-},{"./backend/state":199,"./logs":231,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],202:[function(require,module,exports){
+},{"./backend/state":219,"./errors":233,"./logs":255,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27502,7 +29110,7 @@ var Callback = (function (_super) {
 }(base_callbacks_1.BaseCallback));
 exports.Callback = Callback;
 
-},{"./base_callbacks":201,"./engine/training":209}],203:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/training":230}],223:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils_1 = require("./utils/generic_utils");
@@ -27571,13 +29179,13 @@ function getUniqueTensorName(scopedName) {
     }
 }
 exports.getUniqueTensorName = getUniqueTensorName;
-var tensorNameRegex = new RegExp(/^[A-Za-z][A-Za-z0-9\._\/]*$/);
+var tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
 function isValidTensorName(name) {
     return name.match(tensorNameRegex) ? true : false;
 }
 exports.isValidTensorName = isValidTensorName;
 
-},{"./utils/generic_utils":238}],204:[function(require,module,exports){
+},{"./utils/generic_utils":262}],224:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27635,7 +29243,7 @@ var MaxNorm = (function (_super) {
     return MaxNorm;
 }(Constraint));
 exports.MaxNorm = MaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MaxNorm);
+tfjs_core_1.serialization.registerClass(MaxNorm);
 var UnitNorm = (function (_super) {
     __extends(UnitNorm, _super);
     function UnitNorm(config) {
@@ -27655,7 +29263,7 @@ var UnitNorm = (function (_super) {
     return UnitNorm;
 }(Constraint));
 exports.UnitNorm = UnitNorm;
-tfjs_core_1.serialization.SerializationMap.register(UnitNorm);
+tfjs_core_1.serialization.registerClass(UnitNorm);
 var NonNeg = (function (_super) {
     __extends(NonNeg, _super);
     function NonNeg() {
@@ -27668,7 +29276,7 @@ var NonNeg = (function (_super) {
     return NonNeg;
 }(Constraint));
 exports.NonNeg = NonNeg;
-tfjs_core_1.serialization.SerializationMap.register(NonNeg);
+tfjs_core_1.serialization.registerClass(NonNeg);
 var MinMaxNorm = (function (_super) {
     __extends(MinMaxNorm, _super);
     function MinMaxNorm(config) {
@@ -27705,7 +29313,7 @@ var MinMaxNorm = (function (_super) {
     return MinMaxNorm;
 }(Constraint));
 exports.MinMaxNorm = MinMaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MinMaxNorm);
+tfjs_core_1.serialization.registerClass(MinMaxNorm);
 exports.CONSTRAINT_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'maxNorm': 'MaxNorm',
     'minMaxNorm': 'MinMaxNorm',
@@ -27741,7 +29349,7 @@ function getConstraint(identifier) {
 }
 exports.getConstraint = getConstraint;
 
-},{"./backend/common":198,"./backend/state":199,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],205:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28404,7 +30012,7 @@ var Container = (function (_super) {
             keptNodes = layer instanceof Container ? 1 : 0;
             for (var originalNodeIndex = 0; originalNodeIndex < layer.inboundNodes.length; originalNodeIndex++) {
                 var nodeKey = Container.nodeKey(layer, originalNodeIndex);
-                if (nodeKey in this.containerNodes) {
+                if (this.containerNodes.has(nodeKey)) {
                     nodeConversionMap[nodeKey] = keptNodes;
                     keptNodes += 1;
                 }
@@ -28487,7 +30095,7 @@ var Container = (function (_super) {
                             var tensorIndex = node.tensorIndices[i];
                             var nodeKey_1 = Container.nodeKey(inboundLayer, nodeIndex);
                             var newNodeIndex = nodeConversionMap[nodeKey_1];
-                            if (newNodeIndex === null || newNodeIndex === undefined) {
+                            if (newNodeIndex == null) {
                                 newNodeIndex = 0;
                             }
                             nodeData.push([inboundLayer.name, newNodeIndex, tensorIndex, kwargs]);
@@ -28608,19 +30216,20 @@ var Container = (function (_super) {
                 var layerData = layersFromConfig_2[_a];
                 var layer = createdLayers[layerData.name];
                 if (layer.name in unprocessedNodes) {
-                    for (var _b = 0, _c = unprocessedNodes[layer.name]; _b < _c.length; _b++) {
-                        var nodeData = _c[_b];
+                    var currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
+                    delete unprocessedNodes[layer.name];
+                    for (var _b = 0, currentUnprocessedNodesForLayer_1 = currentUnprocessedNodesForLayer; _b < currentUnprocessedNodesForLayer_1.length; _b++) {
+                        var nodeData = currentUnprocessedNodesForLayer_1[_b];
                         processNode(layer, nodeData);
                     }
-                    delete unprocessedNodes[layer.name];
                 }
             }
         }
         var inputTensors = [];
         var outputTensors = [];
         var inputLayersFromConfig = config.inputLayers;
-        for (var _d = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _d < inputLayersFromConfig_1.length; _d++) {
-            var layerData = inputLayersFromConfig_1[_d];
+        for (var _c = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _c < inputLayersFromConfig_1.length; _c++) {
+            var layerData = inputLayersFromConfig_1[_c];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28630,8 +30239,8 @@ var Container = (function (_super) {
             inputTensors.push(layerOutputTensors[tensorIndex]);
         }
         var outputLayersFromConfig = config.outputLayers;
-        for (var _e = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _e < outputLayersFromConfig_1.length; _e++) {
-            var layerData = outputLayersFromConfig_1[_e];
+        for (var _d = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _d < outputLayersFromConfig_1.length; _d++) {
+            var layerData = outputLayersFromConfig_1[_d];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28674,7 +30283,23 @@ var Container = (function (_super) {
 }(topology_1.Layer));
 exports.Container = Container;
 
-},{"../backend/state":199,"../errors":210,"../layers/serialization":229,"../utils/generic_utils":238,"../utils/serialization_utils":241,"../utils/types_utils":242,"../variables":244,"../version":245,"./input_layer":207,"./topology":208,"@tensorflow/tfjs-core":68}],206:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"../layers/serialization":253,"../utils/generic_utils":262,"../utils/serialization_utils":265,"../utils/types_utils":266,"../variables":268,"../version":269,"./input_layer":228,"./topology":229,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyIterator = (function () {
+    function LazyIterator() {
+    }
+    return LazyIterator;
+}());
+exports.LazyIterator = LazyIterator;
+var Dataset = (function () {
+    function Dataset() {
+    }
+    return Dataset;
+}());
+exports.Dataset = Dataset;
+
+},{}],227:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -28808,7 +30433,7 @@ function getNodeOutputs(fetch) {
     return layerOutputs;
 }
 
-},{"../errors":210,"./input_layer":207,"@tensorflow/tfjs-core":68}],207:[function(require,module,exports){
+},{"../errors":233,"./input_layer":228,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28887,10 +30512,7 @@ var InputLayer = (function (_super) {
             ("InputLayer's apply() method. InputLayer name: " + this.name));
     };
     InputLayer.prototype.dispose = function () {
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: 0
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: 0 };
     };
     InputLayer.prototype.getConfig = function () {
         return {
@@ -28904,7 +30526,7 @@ var InputLayer = (function (_super) {
     return InputLayer;
 }(topology_1.Layer));
 exports.InputLayer = InputLayer;
-tfjs_core_1.serialization.SerializationMap.register(InputLayer);
+tfjs_core_1.serialization.registerClass(InputLayer);
 function Input(config) {
     if (config.batchShape == null && config.shape == null) {
         throw new Error('Please provide to Input either a `shape`' +
@@ -28935,7 +30557,7 @@ function Input(config) {
 }
 exports.Input = Input;
 
-},{"../backend/state":199,"../errors":210,"./topology":208,"@tensorflow/tfjs-core":68}],208:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"./topology":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29623,10 +31245,7 @@ var Layer = (function (_super) {
         if (--this._refCount === 0) {
             numDisposedVariables = this.disposeWeights();
         }
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: numDisposedVariables
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: numDisposedVariables };
     };
     return Layer;
 }(tfjs_core_1.serialization.Serializable));
@@ -29677,7 +31296,7 @@ function getSourceInputs(tensor, layer, nodeIndex) {
 }
 exports.getSourceInputs = getSourceInputs;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"../utils/variable_utils":243,"../variables":244,"@tensorflow/tfjs-core":68}],209:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"../utils/variable_utils":267,"../variables":268,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29729,10 +31348,8 @@ var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
-var base_callbacks_1 = require("../base_callbacks");
 var common_1 = require("../common");
 var errors_1 = require("../errors");
-var logs_1 = require("../logs");
 var losses = require("../losses");
 var Metrics = require("../metrics");
 var optimizers = require("../optimizers");
@@ -29741,6 +31358,8 @@ var layer_utils_1 = require("../utils/layer_utils");
 var math_utils_1 = require("../utils/math_utils");
 var container_1 = require("./container");
 var executor_1 = require("./executor");
+var training_dataset_1 = require("./training_dataset");
+var training_tensors_1 = require("./training_tensors");
 function isDataTensor(x) {
     return x instanceof tfjs_core_1.Tensor;
 }
@@ -29905,46 +31524,6 @@ function checkLossAndTargetCompatibility(targets, lossFns, outputShapes) {
         }
     }
 }
-function makeBatches(size, batchSize) {
-    var output = [];
-    var batchStart = 0;
-    var batchEnd = null;
-    while (batchStart < size) {
-        batchEnd = batchStart + batchSize;
-        if (batchEnd >= size) {
-            batchEnd = size;
-        }
-        output.push([batchStart, batchEnd]);
-        batchStart = batchEnd;
-    }
-    return output;
-}
-exports.makeBatches = makeBatches;
-function sliceArrays(arrays, start, stop) {
-    if (arrays == null) {
-        return [null];
-    }
-    else if (Array.isArray(arrays)) {
-        return arrays.map(function (array) { return K.sliceAlongFirstAxis(array, start, stop - start); });
-    }
-    else {
-        return K.sliceAlongFirstAxis(arrays, start, stop - start);
-    }
-}
-function sliceArraysByIndices(arrays, indices) {
-    return tfc.tidy(function () {
-        if (arrays == null) {
-            return null;
-        }
-        else if (Array.isArray(arrays)) {
-            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
-        }
-        else {
-            return K.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
-        }
-    });
-}
-exports.sliceArraysByIndices = sliceArraysByIndices;
 function checkInputData(data, names, shapes, checkBatchAxis, exceptionPrefix) {
     if (checkBatchAxis === void 0) { checkBatchAxis = true; }
     if (exceptionPrefix === void 0) { exceptionPrefix = ''; }
@@ -30017,14 +31596,6 @@ function collectMetrics(metrics, outputNames) {
         throw new TypeError('Type of metrics argument not understood. Expected an Array or ' +
             'Object, found: ' + metrics);
     }
-}
-var ModelLoggingVerbosity;
-(function (ModelLoggingVerbosity) {
-    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
-    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
-})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
-function checkBatchSize(batchSize) {
-    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
 }
 var Model = (function (_super) {
     __extends(Model, _super);
@@ -30215,13 +31786,21 @@ var Model = (function (_super) {
     Model.prototype.evaluate = function (x, y, config) {
         if (config === void 0) { config = {}; }
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         var standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
         var ins = standardizedOuts[0].concat(standardizedOuts[1]);
         this.makeTestFunction();
         var f = this.testFunction;
         var testOuts = this.testLoop(f, ins, batchSize, config.verbose, config.steps);
         return generic_utils_1.singletonOrArray(testOuts);
+    };
+    Model.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                this.makeTestFunction();
+                return [2, training_dataset_1.evaluateDataset(this, dataset, config)];
+            });
+        });
     };
     Model.prototype.checkNumSamples = function (ins, batchSize, steps, stepsName) {
         if (stepsName === void 0) { stepsName = 'steps'; }
@@ -30326,13 +31905,13 @@ var Model = (function (_super) {
             if (verbose) {
                 throw new errors_1.NotImplementedError('Verbose predictLoop() is not implemented yet.');
             }
-            var batches = makeBatches(numSamples, batchSize);
+            var batches = training_tensors_1.makeBatches(numSamples, batchSize);
             var outs = [];
             var _loop_3 = function (batchIndex) {
                 var batchOuts = tfc.tidy(function () {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
-                    var insBatch = sliceArrays(ins, batchStart, batchEnd);
+                    var insBatch = training_tensors_1.sliceArrays(ins, batchStart, batchEnd);
                     var feeds = [];
                     if (Array.isArray(insBatch)) {
                         for (var i = 0; i < insBatch.length; ++i) {
@@ -30367,7 +31946,7 @@ var Model = (function (_super) {
         if (config === void 0) { config = {}; }
         checkInputData(x, this.inputNames, this.feedInputShapes, false);
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         return this.predictLoop(x, batchSize);
     };
     Model.prototype.predictOnBatch = function (x) {
@@ -30404,204 +31983,26 @@ var Model = (function (_super) {
         }
         return [x, y, null];
     };
-    Model.prototype.fitLoop = function (f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var doValidation, numTrainSamples, indexArray, baseLogger, callbackList, _loop_4, this_1, epoch, state_2;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (batchSize == null) {
-                            batchSize = 32;
-                        }
-                        if (epochs == null) {
-                            epochs = 1;
-                        }
-                        if (shuffle == null) {
-                            shuffle = true;
-                        }
-                        if (initialEpoch == null) {
-                            initialEpoch = 0;
-                        }
-                        doValidation = false;
-                        if (valF != null && valIns != null) {
-                            doValidation = true;
-                        }
-                        if (validationSteps != null) {
-                            doValidation = true;
-                            if (stepsPerEpoch == null) {
-                                throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
-                                    'i.e., `stepsPerEpoch` must be set.');
-                            }
-                        }
-                        numTrainSamples = this.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
-                        if (numTrainSamples != null) {
-                            indexArray = math_utils_1.range(0, numTrainSamples);
-                        }
-                        this.history = new base_callbacks_1.History();
-                        baseLogger = new base_callbacks_1.BaseLogger(yieldEvery);
-                        if (callbacks == null) {
-                            callbacks = [baseLogger];
-                        }
-                        else {
-                            callbacks = [baseLogger].concat(callbacks);
-                        }
-                        callbacks = callbacks.concat([this.history]);
-                        if (verbose > 0) {
-                            throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
-                        }
-                        callbackList = new base_callbacks_1.CallbackList(callbacks);
-                        callbackList.setModel(this);
-                        callbackList.setParams({
-                            epochs: epochs,
-                            initialEpoch: initialEpoch,
-                            samples: numTrainSamples,
-                            steps: stepsPerEpoch,
-                            batchSize: batchSize,
-                            verbose: verbose,
-                            doValidation: doValidation,
-                            metrics: callbackMetrics,
-                        });
-                        return [4, callbackList.onTrainBegin()];
-                    case 1:
-                        _a.sent();
-                        this.stopTraining_ = false;
-                        _loop_4 = function (epoch) {
-                            var epochLogs, epochIndexArray1D_1, batches_1, _loop_5, batchIndex, state_3;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4, callbackList.onEpochBegin(epoch)];
-                                    case 1:
-                                        _a.sent();
-                                        epochLogs = {};
-                                        if (!(stepsPerEpoch != null)) return [3, 2];
-                                        throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
-                                    case 2:
-                                        if (shuffle === 'batch') {
-                                            throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
-                                        }
-                                        else if (shuffle) {
-                                            tfjs_core_1.util.shuffle(indexArray);
-                                        }
-                                        epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
-                                        batches_1 = makeBatches(numTrainSamples, batchSize);
-                                        _loop_5 = function (batchIndex) {
-                                            var batchLogs;
-                                            return __generator(this, function (_a) {
-                                                switch (_a.label) {
-                                                    case 0:
-                                                        batchLogs = {};
-                                                        return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
-                                                    case 1:
-                                                        _a.sent();
-                                                        tfc.tidy(function () {
-                                                            var batchStart = batches_1[batchIndex][0];
-                                                            var batchEnd = batches_1[batchIndex][1];
-                                                            var batchIds = K.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
-                                                            batchLogs['batch'] = batchIndex;
-                                                            batchLogs['size'] = batchEnd - batchStart;
-                                                            var insBatch = sliceArraysByIndices(ins, batchIds);
-                                                            var outs = f(insBatch);
-                                                            for (var i = 0; i < outLabels.length; ++i) {
-                                                                var label = outLabels[i];
-                                                                var out = outs[i];
-                                                                batchLogs[label] = out;
-                                                                tfc.keep(out);
-                                                            }
-                                                            if (batchIndex === batches_1.length - 1) {
-                                                                if (doValidation) {
-                                                                    var valOuts = _this.testLoop(valF, valIns, batchSize);
-                                                                    for (var i = 0; i < outLabels.length; ++i) {
-                                                                        var label = outLabels[i];
-                                                                        var out = valOuts[i];
-                                                                        tfc.keep(out);
-                                                                        epochLogs['val_' + label] = out;
-                                                                    }
-                                                                }
-                                                            }
-                                                        });
-                                                        return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
-                                                    case 2:
-                                                        _a.sent();
-                                                        logs_1.disposeTensorsInLogs(batchLogs);
-                                                        if (this_1.stopTraining_) {
-                                                            return [2, "break"];
-                                                        }
-                                                        return [2];
-                                                }
-                                            });
-                                        };
-                                        batchIndex = 0;
-                                        _a.label = 3;
-                                    case 3:
-                                        if (!(batchIndex < batches_1.length)) return [3, 6];
-                                        return [5, _loop_5(batchIndex)];
-                                    case 4:
-                                        state_3 = _a.sent();
-                                        if (state_3 === "break")
-                                            return [3, 6];
-                                        _a.label = 5;
-                                    case 5:
-                                        ++batchIndex;
-                                        return [3, 3];
-                                    case 6:
-                                        epochIndexArray1D_1.dispose();
-                                        _a.label = 7;
-                                    case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
-                                    case 8:
-                                        _a.sent();
-                                        if (this_1.stopTraining_) {
-                                            return [2, "break"];
-                                        }
-                                        return [2];
-                                }
-                            });
-                        };
-                        this_1 = this;
-                        epoch = initialEpoch;
-                        _a.label = 2;
-                    case 2:
-                        if (!(epoch < epochs)) return [3, 5];
-                        return [5, _loop_4(epoch)];
-                    case 3:
-                        state_2 = _a.sent();
-                        if (state_2 === "break")
-                            return [3, 5];
-                        _a.label = 4;
-                    case 4:
-                        ++epoch;
-                        return [3, 2];
-                    case 5: return [4, callbackList.onTrainEnd()];
-                    case 6:
-                        _a.sent();
-                        return [4, this.history.syncData()];
-                    case 7:
-                        _a.sent();
-                        return [2, this.history];
-                }
-            });
-        });
-    };
     Model.prototype.testLoop = function (f, ins, batchSize, verbose, steps) {
         var _this = this;
         if (verbose === void 0) { verbose = 0; }
         return tfc.tidy(function () {
             var numSamples = _this.checkNumSamples(ins, batchSize, steps, 'steps');
             var outs = [];
-            if (verbose === 1) {
+            if (verbose > 0) {
                 throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
             }
             if (steps != null) {
                 throw new errors_1.NotImplementedError('steps mode in testLoop() is not implemented yet');
             }
             else {
-                var batches = makeBatches(numSamples, batchSize);
+                var batches = training_tensors_1.makeBatches(numSamples, batchSize);
                 var indexArray = tfjs_core_1.tensor1d(math_utils_1.range(0, numSamples));
                 for (var batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
                     var batchIds = K.sliceAlongFirstAxis(indexArray, batchStart, batchEnd - batchStart);
-                    var insBatch = sliceArraysByIndices(ins, batchIds);
+                    var insBatch = training_tensors_1.sliceArraysByIndices(ins, batchIds);
                     var batchOuts = f(insBatch);
                     if (batchIndex === 0) {
                         for (var i = 0; i < batchOuts.length; ++i) {
@@ -30634,6 +32035,54 @@ var Model = (function (_super) {
             dedupedOutLabels.push(newLabel);
         }
         return dedupedOutLabels;
+    };
+    Model.prototype.makeTrainFunction = function () {
+        var _this = this;
+        return function (data) {
+            var losses = [];
+            var lossValues = [];
+            var inputs = data.slice(0, _this.inputs.length);
+            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
+            var metricsValues = [];
+            var totalLossFunction = function () {
+                var feeds = [];
+                for (var i = 0; i < _this.inputs.length; ++i) {
+                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
+                }
+                var feedDict = new executor_1.FeedDict(feeds);
+                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
+                var totalLoss;
+                for (var i = 0; i < _this.lossFunctions.length; ++i) {
+                    var lossFunction = _this.lossFunctions[i];
+                    var loss = lossFunction(targets[i], outputs[i]);
+                    losses.push(loss);
+                    var meanLoss = tfc.mean(loss);
+                    lossValues.push(meanLoss);
+                    if (i === 0) {
+                        totalLoss = loss;
+                    }
+                    else {
+                        totalLoss = tfc.add(totalLoss, loss);
+                    }
+                }
+                for (var i = 0; i < _this.metricsTensors.length; ++i) {
+                    var metric = _this.metricsTensors[i][0];
+                    var outputIndex = _this.metricsTensors[i][1];
+                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
+                    tfc.keep(meanMetric);
+                    metricsValues.push(meanMetric);
+                }
+                totalLoss = tfc.mean(totalLoss);
+                _this.calculateLosses().forEach(function (regularizerLoss) {
+                    totalLoss = tfc.add(totalLoss, regularizerLoss);
+                });
+                return totalLoss;
+            };
+            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
+            var returnCost = true;
+            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
+            return [totalLossValue].concat(metricsValues);
+        };
     };
     Model.prototype.makeTestFunction = function () {
         var _this = this;
@@ -30673,139 +32122,15 @@ var Model = (function (_super) {
     Model.prototype.fit = function (x, y, config) {
         if (config === void 0) { config = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (this.isTraining) {
-                            throw new Error('Cannot start training because another fit() call is ongoing.');
-                        }
-                        this.isTraining = true;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, , 3, 4]);
-                        batchSize = config.batchSize == null ? 32 : config.batchSize;
-                        checkBatchSize(batchSize);
-                        standardizedOuts = this.standardizeUserData(x, y, false, batchSize);
-                        inputs = standardizedOuts[0];
-                        targets = standardizedOuts[1];
-                        doValidation = false;
-                        valX = void 0;
-                        valY = void 0;
-                        valIns = void 0;
-                        needValidationDisposal = false;
-                        if (config.validationData != null && config.validationData.length > 0) {
-                            doValidation = true;
-                            if (config.validationData.length === 2) {
-                                valX = config.validationData[0];
-                                valY = config.validationData[1];
-                            }
-                            else if (config.validationData.length === 3) {
-                                throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
-                            }
-                            else {
-                                throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
-                                    "or 3 (valX, valY, valSampleWeight) items; " +
-                                    (config.validationData + " is invalid."));
-                            }
-                            valStandardized = this.standardizeUserData(valX, valY, true, batchSize);
-                            valX = valStandardized[0];
-                            valY = valStandardized[1];
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSplit != null && config.validationSplit > 0 &&
-                            config.validationSplit < 1) {
-                            doValidation = true;
-                            splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
-                            originalBatchSize = inputs[0].shape[0];
-                            valX = sliceArrays(inputs, splitAt, originalBatchSize);
-                            inputs = sliceArrays(inputs, 0, splitAt);
-                            valY = sliceArrays(targets, splitAt, originalBatchSize);
-                            targets = sliceArrays(targets, 0, splitAt);
-                            needValidationDisposal = true;
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSteps != null) {
-                            doValidation = true;
-                        }
-                        ins = inputs.concat(targets);
-                        this.checkTrainableWeightsConsistency();
-                        trainFunction = function (data) {
-                            var losses = [];
-                            var lossValues = [];
-                            var inputs = data.slice(0, _this.inputs.length);
-                            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
-                            var metricsValues = [];
-                            var totalLossFunction = function () {
-                                var feeds = [];
-                                for (var i = 0; i < _this.inputs.length; ++i) {
-                                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
-                                }
-                                var feedDict = new executor_1.FeedDict(feeds);
-                                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
-                                var totalLoss;
-                                for (var i = 0; i < _this.lossFunctions.length; ++i) {
-                                    var lossFunction = _this.lossFunctions[i];
-                                    var loss = lossFunction(targets[i], outputs[i]);
-                                    losses.push(loss);
-                                    var meanLoss = tfc.mean(loss);
-                                    lossValues.push(meanLoss);
-                                    if (i === 0) {
-                                        totalLoss = loss;
-                                    }
-                                    else {
-                                        totalLoss = tfc.add(totalLoss, loss);
-                                    }
-                                }
-                                for (var i = 0; i < _this.metricsTensors.length; ++i) {
-                                    var metric = _this.metricsTensors[i][0];
-                                    var outputIndex = _this.metricsTensors[i][1];
-                                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
-                                    tfc.keep(meanMetric);
-                                    metricsValues.push(meanMetric);
-                                }
-                                totalLoss = tfc.mean(totalLoss);
-                                _this.calculateLosses().forEach(function (regularizerLoss) {
-                                    totalLoss = tfc.add(totalLoss, regularizerLoss);
-                                });
-                                return totalLoss;
-                            };
-                            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
-                            var returnCost = true;
-                            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
-                            return [totalLossValue].concat(metricsValues);
-                        };
-                        outLabels = this.getDedupedMetricsNames();
-                        valFunction = void 0;
-                        callbackMetrics = void 0;
-                        if (doValidation) {
-                            this.makeTestFunction();
-                            valFunction = this.testFunction;
-                            callbackMetrics =
-                                outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
-                        }
-                        else {
-                            valFunction = null;
-                            valIns = [];
-                            callbackMetrics = outLabels.slice();
-                        }
-                        callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
-                        return [4, this.fitLoop(trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
-                    case 2:
-                        out = _a.sent();
-                        if (needValidationDisposal) {
-                            valIns.forEach(function (tensor) { return tensor.dispose(); });
-                            inputs.forEach(function (tensor) { return tensor.dispose(); });
-                            targets.forEach(function (tensor) { return tensor.dispose(); });
-                        }
-                        this.isTraining = false;
-                        return [2, out];
-                    case 3:
-                        this.isTraining = false;
-                        return [7];
-                    case 4: return [2];
-                }
+                return [2, training_tensors_1.fitTensors(this, x, y, config)];
+            });
+        });
+    };
+    Model.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, training_dataset_1.fitDataset(this, dataset, config)];
             });
         });
     };
@@ -30869,9 +32194,699 @@ var Model = (function (_super) {
     return Model;
 }(container_1.Container));
 exports.Model = Model;
-tfjs_core_1.serialization.SerializationMap.register(Model);
+tfjs_core_1.serialization.registerClass(Model);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../base_callbacks":201,"../common":203,"../errors":210,"../logs":231,"../losses":232,"../metrics":233,"../optimizers":235,"../utils/generic_utils":238,"../utils/layer_utils":239,"../utils/math_utils":240,"./container":205,"./executor":206,"@tensorflow/tfjs-core":68}],210:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../errors":233,"../losses":256,"../metrics":257,"../optimizers":259,"../utils/generic_utils":262,"../utils/layer_utils":263,"../utils/math_utils":264,"./container":225,"./executor":227,"./training_dataset":231,"./training_tensors":232,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var state_1 = require("../backend/state");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var generic_utils_1 = require("../utils/generic_utils");
+var dataset_stub_1 = require("./dataset_stub");
+var DEFAULT_VALIDATION_BATCH_SIZE = 32;
+function standardizeDataIteratorOutput(model, iteratorOut) {
+    if (model.outputs.length > 1) {
+        throw new errors_1.NotImplementedError("Support for training a model with multiple output tensors with " +
+            "a dataset object is not implemented yet.");
+    }
+    tfc.util.assert(Array.isArray(iteratorOut) && iteratorOut.length === 2, 'Dataset iterator for fitDataset() is expected to generate ' +
+        'an Array of length 2: `[xs, ys]`, but instead generates ' +
+        iteratorOut);
+    iteratorOut = iteratorOut;
+    var ys = iteratorOut[1];
+    var xs = iteratorOut[0];
+    if (xs instanceof tfc.Tensor) {
+        tfc.util.assert(model.inputs.length === 1, "Model has multiple " + model.inputs.length + " inputs, hence it " +
+            "expects the input dataset to generate a dictionary of tensors " +
+            (" (with keys " + JSON.stringify(model.inputNames) + ", ") +
+            "but received a single tensor.");
+        tfc.util.assert(xs.shape[0] === ys.shape[0], "Mismatch in batch size between x and y tensors (" + xs.shape[0] + " vs. " +
+            (ys.shape[0] + ")"));
+        return [xs, ys];
+    }
+    else {
+        var batchSize = void 0;
+        xs = xs;
+        var flattendXs = [];
+        for (var _i = 0, _a = model.inputNames; _i < _a.length; _i++) {
+            var inputName = _a[_i];
+            if (xs[inputName] == null) {
+                throw new errors_1.ValueError("The feature data generated by the dataset lacks the required " +
+                    ("input key '" + inputName + "'."));
+            }
+            flattendXs.push(xs[inputName]);
+            if (batchSize == null) {
+                batchSize = xs[inputName].shape[0];
+            }
+            else {
+                tfc.util.assert(xs[inputName].shape[0] === batchSize, "Mismatch in batch size between x and y tensors " +
+                    ("(" + xs[inputName].shape[0] + " vs. " + ys.shape[0] + ")"));
+            }
+        }
+        return flattendXs.concat(ys);
+    }
+}
+function standardizeTensorValidationData(data) {
+    if (data.length === 3) {
+        throw new errors_1.NotImplementedError('Validation with sample weights is not implemented yet.');
+    }
+    return { xs: data[0], ys: data[1] };
+}
+function fitDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, validationDataIterator, valXs, valYs, validationData, trainFunction, outLabels, callbackMetrics, callbacks, _a, callbackList, history_1, epoch, epochLogs, dataIterator, stepsDone, batchIndex, iteratorOut, xsAndYs, batchLogs, outs, i, label, out, valOuts, _b, i;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    tfc.util.assert(model.optimizer != null, 'You must compile a model before training/testing. Use ' +
+                        'Model.compile(modelCompileConfig).');
+                    tfc.util.assert(config != null, "For fitDataset(), the 2nd argument (config) is required, " +
+                        "but it is not provided in this call.");
+                    tfc.util.assert(config.epochs != null && config.epochs > 0 &&
+                        Number.isInteger(config.epochs), "For fitDataset(), config.epochs is expected to be a positive " +
+                        ("integer, but got " + config.epochs));
+                    tfc.util.assert(config.batchesPerEpoch != null && config.batchesPerEpoch > 0 &&
+                        Number.isInteger(config.batchesPerEpoch), "For fitDataset(), config.batchesPerEpoch is expected to be a " +
+                        ("positive integer, but got " + config.batchesPerEpoch));
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _c.label = 1;
+                case 1:
+                    _c.trys.push([1, , 21, 22]);
+                    doValidation = config.validationData != null;
+                    validationDataIterator = void 0;
+                    valXs = void 0;
+                    valYs = void 0;
+                    if (!doValidation) return [3, 4];
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 3];
+                    tfc.util.assert(config.validationBatches > 0 &&
+                        Number.isInteger(config.validationBatches), "For fitDataset() with dataset-based validation, " +
+                        "config.validationBatches is expected to be a " +
+                        ("positive integer, but got " + config.validationBatches));
+                    return [4, config.validationData.iterator()];
+                case 2:
+                    validationDataIterator = _c.sent();
+                    return [3, 4];
+                case 3:
+                    validationData = standardizeTensorValidationData(config.validationData);
+                    valXs = validationData.xs;
+                    valYs = validationData.ys;
+                    _c.label = 4;
+                case 4:
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    _a = base_callbacks_1.configureCallbacks(callbacks, config.yieldEvery, config.verbose, config.epochs, null, null, config.batchesPerEpoch, null, doValidation, callbackMetrics), callbackList = _a.callbackList, history_1 = _a.history;
+                    model.history = history_1;
+                    return [4, callbackList.onTrainBegin()];
+                case 5:
+                    _c.sent();
+                    epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
+                    epochLogs = {};
+                    return [4, dataset.iterator()];
+                case 6:
+                    dataIterator = _c.sent();
+                    _c.label = 7;
+                case 7:
+                    if (!(epoch < config.epochs)) return [3, 18];
+                    return [4, callbackList.onEpochBegin(epoch)];
+                case 8:
+                    _c.sent();
+                    stepsDone = 0;
+                    batchIndex = 0;
+                    _c.label = 9;
+                case 9:
+                    if (!(stepsDone < config.batchesPerEpoch)) return [3, 16];
+                    return [4, dataIterator.next()];
+                case 10:
+                    iteratorOut = _c.sent();
+                    if (iteratorOut.done) {
+                        console.warn('Your dataset iterator ran out of data; ' +
+                            'interrupting training. Make sure that your ' +
+                            'dataset can generate at least `batchesPerEpoch * epochs` ' +
+                            'batches (in this case, ' +
+                            (config.batchesPerEpoch * config.epochs + " batches). ") +
+                            'You may need to use the repeat() function when building ' +
+                            'your dataset.');
+                        return [3, 16];
+                    }
+                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                    batchLogs = {};
+                    batchLogs['batch'] = batchIndex;
+                    batchLogs['size'] = xsAndYs[0].shape[0];
+                    callbackList.onBatchBegin(batchIndex, batchLogs);
+                    outs = trainFunction(xsAndYs);
+                    tfc.dispose(xsAndYs);
+                    for (i = 0; i < outLabels.length; ++i) {
+                        label = outLabels[i];
+                        out = outs[i];
+                        batchLogs[label] = out;
+                        tfc.keep(out);
+                    }
+                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                case 11:
+                    _c.sent();
+                    logs_1.disposeTensorsInLogs(batchLogs);
+                    batchIndex++;
+                    stepsDone++;
+                    if (!(stepsDone >= config.batchesPerEpoch && doValidation)) return [3, 15];
+                    valOuts = void 0;
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 13];
+                    _b = generic_utils_1.toList;
+                    return [4, model.evaluateDataset(validationDataIterator, { batches: config.validationBatches })];
+                case 12:
+                    valOuts = _b.apply(void 0, [_c.sent()]);
+                    return [3, 14];
+                case 13:
+                    valOuts = generic_utils_1.toList(model.evaluate(valXs, valYs, {
+                        batchSize: config.validationBatchSize == null ?
+                            DEFAULT_VALIDATION_BATCH_SIZE :
+                            config.validationBatchSize,
+                        verbose: 0
+                    }));
+                    _c.label = 14;
+                case 14:
+                    for (i = 0; i < model.metricsNames.length; ++i) {
+                        epochLogs["val_" + model.metricsNames[i]] = valOuts[i];
+                    }
+                    _c.label = 15;
+                case 15:
+                    if (model.stopTraining_) {
+                        return [3, 16];
+                    }
+                    return [3, 9];
+                case 16: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                case 17:
+                    _c.sent();
+                    epoch++;
+                    if (model.stopTraining_) {
+                        return [3, 18];
+                    }
+                    return [3, 7];
+                case 18: return [4, callbackList.onTrainEnd()];
+                case 19:
+                    _c.sent();
+                    return [4, model.history.syncData()];
+                case 20:
+                    _c.sent();
+                    return [2, model.history];
+                case 21:
+                    model.isTraining = false;
+                    return [7];
+                case 22: return [2];
+            }
+        });
+    });
+}
+exports.fitDataset = fitDataset;
+function evaluateDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var f, outs, dataIterator, _a, numExamples, _loop_1, batch, state_2, _loop_2, i;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    f = model.testFunction;
+                    outs = [];
+                    if (config.verbose > 0) {
+                        throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
+                    }
+                    tfc.util.assert(config.batches > 0 && Number.isInteger(config.batches), 'Test loop expects `batches` to be a positive integer, but ' +
+                        ("received " + JSON.stringify(config.batches)));
+                    if (!(dataset instanceof dataset_stub_1.LazyIterator)) return [3, 1];
+                    _a = dataset;
+                    return [3, 3];
+                case 1: return [4, dataset.iterator()];
+                case 2:
+                    _a = _b.sent();
+                    _b.label = 3;
+                case 3:
+                    dataIterator = _a;
+                    numExamples = 0;
+                    _loop_1 = function (batch) {
+                        var iteratorOut, xsAndYs, batchOuts, i, batchSize, _loop_3, i;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, dataIterator.next()];
+                                case 1:
+                                    iteratorOut = _a.sent();
+                                    if (iteratorOut.done) {
+                                        console.warn('Your dataset iterator ran out of data during evaluateDataset(). ' +
+                                            'Interrupting evalution. Make sure that your ' +
+                                            'dataset can generate at least `batches` ' +
+                                            ("batches (in this case, " + config.batches + " batches). ") +
+                                            'You may need to use the repeat() function when building ' +
+                                            'your dataset.');
+                                        return [2, "break"];
+                                    }
+                                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                                    batchOuts = tfc.tidy(function () { return f(xsAndYs); });
+                                    tfc.dispose(xsAndYs);
+                                    if (batch === 0) {
+                                        for (i = 0; i < batchOuts.length; ++i) {
+                                            outs.push(state_1.getScalar(0));
+                                        }
+                                    }
+                                    batchSize = xsAndYs[0].shape[0];
+                                    _loop_3 = function (i) {
+                                        var batchOut = batchOuts[i];
+                                        var oldScalar = outs[i];
+                                        outs[i] = tfc.tidy(function () { return tfc.add(outs[i], tfc.mul(state_1.getScalar(batchSize), batchOut)); });
+                                        if (batch > 0) {
+                                            tfc.dispose(oldScalar);
+                                        }
+                                    };
+                                    for (i = 0; i < batchOuts.length; ++i) {
+                                        _loop_3(i);
+                                    }
+                                    tfc.dispose(batchOuts);
+                                    numExamples += batchSize;
+                                    return [2];
+                            }
+                        });
+                    };
+                    batch = 0;
+                    _b.label = 4;
+                case 4:
+                    if (!(batch < config.batches)) return [3, 7];
+                    return [5, _loop_1(batch)];
+                case 5:
+                    state_2 = _b.sent();
+                    if (state_2 === "break")
+                        return [3, 7];
+                    _b.label = 6;
+                case 6:
+                    ++batch;
+                    return [3, 4];
+                case 7:
+                    _loop_2 = function (i) {
+                        var oldScalar = outs[i];
+                        outs[i] =
+                            tfc.tidy(function () { return tfc.div(outs[i], state_1.getScalar(numExamples)); });
+                        tfc.dispose(oldScalar);
+                    };
+                    for (i = 0; i < outs.length; ++i) {
+                        _loop_2(i);
+                    }
+                    return [2, generic_utils_1.singletonOrArray(outs)];
+            }
+        });
+    });
+}
+exports.evaluateDataset = evaluateDataset;
+
+},{"../backend/state":219,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/generic_utils":262,"./dataset_stub":226,"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfjs_backend_1 = require("../backend/tfjs_backend");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var math_utils_1 = require("../utils/math_utils");
+function checkBatchSize(batchSize) {
+    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
+}
+exports.checkBatchSize = checkBatchSize;
+function sliceArrays(arrays, start, stop) {
+    if (arrays == null) {
+        return [null];
+    }
+    else if (Array.isArray(arrays)) {
+        return arrays.map(function (array) { return tfjs_backend_1.sliceAlongFirstAxis(array, start, stop - start); });
+    }
+    else {
+        return tfjs_backend_1.sliceAlongFirstAxis(arrays, start, stop - start);
+    }
+}
+exports.sliceArrays = sliceArrays;
+function sliceArraysByIndices(arrays, indices) {
+    return tfc.tidy(function () {
+        if (arrays == null) {
+            return null;
+        }
+        else if (Array.isArray(arrays)) {
+            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
+        }
+        else {
+            return tfjs_backend_1.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
+        }
+    });
+}
+exports.sliceArraysByIndices = sliceArraysByIndices;
+function makeBatches(size, batchSize) {
+    var output = [];
+    var batchStart = 0;
+    var batchEnd = null;
+    while (batchStart < size) {
+        batchEnd = batchStart + batchSize;
+        if (batchEnd >= size) {
+            batchEnd = size;
+        }
+        output.push([batchStart, batchEnd]);
+        batchStart = batchEnd;
+    }
+    return output;
+}
+exports.makeBatches = makeBatches;
+function fitLoop(model, f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, numTrainSamples, indexArray, _a, callbackList, history, _loop_1, epoch, state_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (batchSize == null) {
+                        batchSize = 32;
+                    }
+                    if (epochs == null) {
+                        epochs = 1;
+                    }
+                    if (shuffle == null) {
+                        shuffle = true;
+                    }
+                    if (initialEpoch == null) {
+                        initialEpoch = 0;
+                    }
+                    doValidation = false;
+                    if (valF != null && valIns != null) {
+                        doValidation = true;
+                    }
+                    if (validationSteps != null) {
+                        doValidation = true;
+                        if (stepsPerEpoch == null) {
+                            throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
+                                'i.e., `stepsPerEpoch` must be set.');
+                        }
+                    }
+                    numTrainSamples = model.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
+                    if (numTrainSamples != null) {
+                        indexArray = math_utils_1.range(0, numTrainSamples);
+                    }
+                    if (verbose == null) {
+                        verbose = 1;
+                    }
+                    _a = base_callbacks_1.configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics), callbackList = _a.callbackList, history = _a.history;
+                    callbackList.setModel(model);
+                    model.history = history;
+                    return [4, callbackList.onTrainBegin()];
+                case 1:
+                    _b.sent();
+                    model.stopTraining_ = false;
+                    _loop_1 = function (epoch) {
+                        var epochLogs, epochIndexArray1D_1, batches_1, _loop_2, batchIndex, state_2;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, callbackList.onEpochBegin(epoch)];
+                                case 1:
+                                    _a.sent();
+                                    epochLogs = {};
+                                    if (!(stepsPerEpoch != null)) return [3, 2];
+                                    throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
+                                case 2:
+                                    if (shuffle === 'batch') {
+                                        throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
+                                    }
+                                    else if (shuffle) {
+                                        tfjs_core_1.util.shuffle(indexArray);
+                                    }
+                                    epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
+                                    batches_1 = makeBatches(numTrainSamples, batchSize);
+                                    _loop_2 = function (batchIndex) {
+                                        var batchLogs;
+                                        return __generator(this, function (_a) {
+                                            switch (_a.label) {
+                                                case 0:
+                                                    batchLogs = {};
+                                                    return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
+                                                case 1:
+                                                    _a.sent();
+                                                    tfc.tidy(function () {
+                                                        var batchStart = batches_1[batchIndex][0];
+                                                        var batchEnd = batches_1[batchIndex][1];
+                                                        var batchIds = tfjs_backend_1.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
+                                                        batchLogs['batch'] = batchIndex;
+                                                        batchLogs['size'] = batchEnd - batchStart;
+                                                        var insBatch = sliceArraysByIndices(ins, batchIds);
+                                                        var outs = f(insBatch);
+                                                        for (var i = 0; i < outLabels.length; ++i) {
+                                                            var label = outLabels[i];
+                                                            var out = outs[i];
+                                                            batchLogs[label] = out;
+                                                            tfc.keep(out);
+                                                        }
+                                                        if (batchIndex === batches_1.length - 1) {
+                                                            if (doValidation) {
+                                                                var valOuts = model.testLoop(valF, valIns, batchSize);
+                                                                for (var i = 0; i < outLabels.length; ++i) {
+                                                                    var label = outLabels[i];
+                                                                    var out = valOuts[i];
+                                                                    tfc.keep(out);
+                                                                    epochLogs['val_' + label] = out;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                                                case 2:
+                                                    _a.sent();
+                                                    logs_1.disposeTensorsInLogs(batchLogs);
+                                                    if (model.stopTraining_) {
+                                                        return [2, "break"];
+                                                    }
+                                                    return [2];
+                                            }
+                                        });
+                                    };
+                                    batchIndex = 0;
+                                    _a.label = 3;
+                                case 3:
+                                    if (!(batchIndex < batches_1.length)) return [3, 6];
+                                    return [5, _loop_2(batchIndex)];
+                                case 4:
+                                    state_2 = _a.sent();
+                                    if (state_2 === "break")
+                                        return [3, 6];
+                                    _a.label = 5;
+                                case 5:
+                                    ++batchIndex;
+                                    return [3, 3];
+                                case 6:
+                                    epochIndexArray1D_1.dispose();
+                                    _a.label = 7;
+                                case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                                case 8:
+                                    _a.sent();
+                                    if (model.stopTraining_) {
+                                        return [2, "break"];
+                                    }
+                                    return [2];
+                            }
+                        });
+                    };
+                    epoch = initialEpoch;
+                    _b.label = 2;
+                case 2:
+                    if (!(epoch < epochs)) return [3, 5];
+                    return [5, _loop_1(epoch)];
+                case 3:
+                    state_1 = _b.sent();
+                    if (state_1 === "break")
+                        return [3, 5];
+                    _b.label = 4;
+                case 4:
+                    ++epoch;
+                    return [3, 2];
+                case 5: return [4, callbackList.onTrainEnd()];
+                case 6:
+                    _b.sent();
+                    return [4, model.history.syncData()];
+                case 7:
+                    _b.sent();
+                    return [2, model.history];
+            }
+        });
+    });
+}
+function fitTensors(model, x, y, config) {
+    if (config === void 0) { config = {}; }
+    return __awaiter(this, void 0, void 0, function () {
+        var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, , 3, 4]);
+                    batchSize = config.batchSize == null ? 32 : config.batchSize;
+                    checkBatchSize(batchSize);
+                    standardizedOuts = model.standardizeUserData(x, y, false, batchSize);
+                    inputs = standardizedOuts[0];
+                    targets = standardizedOuts[1];
+                    doValidation = false;
+                    valX = void 0;
+                    valY = void 0;
+                    valIns = void 0;
+                    needValidationDisposal = false;
+                    if (config.validationData != null && config.validationData.length > 0) {
+                        doValidation = true;
+                        if (config.validationData.length === 2) {
+                            valX = config.validationData[0];
+                            valY = config.validationData[1];
+                        }
+                        else if (config.validationData.length === 3) {
+                            throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
+                        }
+                        else {
+                            throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
+                                "or 3 (valX, valY, valSampleWeight) items; " +
+                                (config.validationData + " is invalid."));
+                        }
+                        valStandardized = model.standardizeUserData(valX, valY, true, batchSize);
+                        valX = valStandardized[0];
+                        valY = valStandardized[1];
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSplit != null && config.validationSplit > 0 &&
+                        config.validationSplit < 1) {
+                        doValidation = true;
+                        splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
+                        originalBatchSize = inputs[0].shape[0];
+                        valX = sliceArrays(inputs, splitAt, originalBatchSize);
+                        inputs = sliceArrays(inputs, 0, splitAt);
+                        valY = sliceArrays(targets, splitAt, originalBatchSize);
+                        targets = sliceArrays(targets, 0, splitAt);
+                        needValidationDisposal = true;
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSteps != null) {
+                        doValidation = true;
+                    }
+                    ins = inputs.concat(targets);
+                    model.checkTrainableWeightsConsistency();
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    valFunction = void 0;
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        model.makeTestFunction();
+                        valFunction = model.testFunction;
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        valFunction = null;
+                        valIns = [];
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    return [4, fitLoop(model, trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
+                case 2:
+                    out = _a.sent();
+                    if (needValidationDisposal) {
+                        valIns.forEach(function (tensor) { return tensor.dispose(); });
+                        inputs.forEach(function (tensor) { return tensor.dispose(); });
+                        targets.forEach(function (tensor) { return tensor.dispose(); });
+                    }
+                    model.isTraining = false;
+                    return [2, out];
+                case 3:
+                    model.isTraining = false;
+                    return [7];
+                case 4: return [2];
+            }
+        });
+    });
+}
+exports.fitTensors = fitTensors;
+
+},{"../backend/tfjs_backend":220,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/math_utils":264,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -30945,12 +32960,13 @@ var IndexError = (function (_super) {
 }(Error));
 exports.IndexError = IndexError;
 
-},{}],211:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
 var training_1 = require("./engine/training");
 var models_1 = require("./models");
+var base_callbacks_1 = require("./base_callbacks");
 function model(config) {
     return new training_1.Model(config);
 }
@@ -30968,8 +32984,12 @@ function input(config) {
     return input_layer_1.Input(config);
 }
 exports.input = input;
+function registerCallbackConstructor(verbosityLevel, callbackConstructor) {
+    base_callbacks_1.CallbackConstructorRegistry.registerCallbackConstructor(verbosityLevel, callbackConstructor);
+}
+exports.registerCallbackConstructor = registerCallbackConstructor;
 
-},{"./engine/input_layer":207,"./engine/training":209,"./models":234}],212:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/input_layer":228,"./engine/training":230,"./models":258}],235:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints_1 = require("./constraints");
@@ -30990,7 +33010,7 @@ function minMaxNorm(config) {
 }
 exports.minMaxNorm = minMaxNorm;
 
-},{"./constraints":204}],213:[function(require,module,exports){
+},{"./constraints":224}],236:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var initializers_1 = require("./initializers");
@@ -31047,7 +33067,7 @@ function orthogonal(config) {
 }
 exports.orthogonal = orthogonal;
 
-},{"./initializers":218}],214:[function(require,module,exports){
+},{"./initializers":242}],237:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
@@ -31176,6 +33196,10 @@ function multiply(config) {
     return new merge_1.Multiply(config);
 }
 exports.multiply = multiply;
+function dot(config) {
+    return new merge_1.Dot(config);
+}
+exports.dot = dot;
 function batchNormalization(config) {
     return new normalization_1.BatchNormalization(config);
 }
@@ -31277,7 +33301,7 @@ exports.globalMaxPool2d = globalMaxPooling2d;
 exports.maxPool1d = maxPooling1d;
 exports.maxPool2d = maxPooling2d;
 
-},{"./engine/input_layer":207,"./engine/topology":208,"./exports":211,"./layers/advanced_activations":219,"./layers/convolutional":220,"./layers/convolutional_depthwise":221,"./layers/core":222,"./layers/embeddings":223,"./layers/merge":224,"./layers/normalization":225,"./layers/padding":226,"./layers/pooling":227,"./layers/recurrent":228,"./layers/wrappers":230}],215:[function(require,module,exports){
+},{"./engine/input_layer":228,"./engine/topology":229,"./exports":234,"./layers/advanced_activations":243,"./layers/convolutional":244,"./layers/convolutional_depthwise":245,"./layers/core":246,"./layers/embeddings":247,"./layers/merge":248,"./layers/normalization":249,"./layers/padding":250,"./layers/pooling":251,"./layers/recurrent":252,"./layers/wrappers":254}],238:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var losses = require("./losses");
@@ -31298,6 +33322,14 @@ function categoricalCrossentropy(yTrue, yPred) {
     return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 exports.categoricalCrossentropy = categoricalCrossentropy;
+function precision(yTrue, yPred) {
+    return metrics.precision(yTrue, yPred);
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return metrics.recall(yTrue, yPred);
+}
+exports.recall = recall;
 function cosineProximity(yTrue, yPred) {
     return losses.cosineProximity(yTrue, yPred);
 }
@@ -31331,7 +33363,13 @@ function mse(yTrue, yPred) {
 }
 exports.mse = mse;
 
-},{"./losses":232,"./metrics":233}],216:[function(require,module,exports){
+},{"./losses":256,"./metrics":257}],239:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var models_1 = require("./models");
+exports.modelFromJSON = models_1.modelFromJSON;
+
+},{"./models":258}],240:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var regularizers = require("./regularizers");
@@ -31349,7 +33387,7 @@ function l2(config) {
 }
 exports.l2 = l2;
 
-},{"./regularizers":236}],217:[function(require,module,exports){
+},{"./regularizers":260}],241:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints = require("./exports_constraints");
@@ -31358,6 +33396,8 @@ var initializers = require("./exports_initializers");
 exports.initializers = initializers;
 var layers = require("./exports_layers");
 exports.layers = layers;
+var models = require("./exports_models");
+exports.models = models;
 var metrics = require("./exports_metrics");
 exports.metrics = metrics;
 var regularizers = require("./exports_regularizers");
@@ -31369,6 +33409,7 @@ exports.History = base_callbacks_1.History;
 var callbacks_1 = require("./callbacks");
 exports.Callback = callbacks_1.Callback;
 var topology_1 = require("./engine/topology");
+exports.InputSpec = topology_1.InputSpec;
 exports.SymbolicTensor = topology_1.SymbolicTensor;
 var training_1 = require("./engine/training");
 exports.Model = training_1.Model;
@@ -31376,6 +33417,7 @@ var exports_1 = require("./exports");
 exports.input = exports_1.input;
 exports.loadModel = exports_1.loadModel;
 exports.model = exports_1.model;
+exports.registerCallbackConstructor = exports_1.registerCallbackConstructor;
 exports.sequential = exports_1.sequential;
 var recurrent_1 = require("./layers/recurrent");
 exports.RNN = recurrent_1.RNN;
@@ -31386,7 +33428,7 @@ exports.LayerVariable = variables_1.LayerVariable;
 var version_1 = require("./version");
 exports.version_layers = version_1.version;
 
-},{"./base_callbacks":201,"./callbacks":202,"./engine/topology":208,"./engine/training":209,"./exports":211,"./exports_constraints":212,"./exports_initializers":213,"./exports_layers":214,"./exports_metrics":215,"./exports_regularizers":216,"./layers/recurrent":228,"./models":234,"./variables":244,"./version":245}],218:[function(require,module,exports){
+},{"./base_callbacks":221,"./callbacks":222,"./engine/topology":229,"./engine/training":230,"./exports":234,"./exports_constraints":235,"./exports_initializers":236,"./exports_layers":237,"./exports_metrics":238,"./exports_models":239,"./exports_regularizers":240,"./layers/recurrent":252,"./models":258,"./variables":268,"./version":269}],242:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31442,7 +33484,7 @@ var Zeros = (function (_super) {
     return Zeros;
 }(Initializer));
 exports.Zeros = Zeros;
-tfjs_core_1.serialization.SerializationMap.register(Zeros);
+tfjs_core_1.serialization.registerClass(Zeros);
 var Ones = (function (_super) {
     __extends(Ones, _super);
     function Ones() {
@@ -31455,7 +33497,7 @@ var Ones = (function (_super) {
     return Ones;
 }(Initializer));
 exports.Ones = Ones;
-tfjs_core_1.serialization.SerializationMap.register(Ones);
+tfjs_core_1.serialization.registerClass(Ones);
 var Constant = (function (_super) {
     __extends(Constant, _super);
     function Constant(config) {
@@ -31482,7 +33524,7 @@ var Constant = (function (_super) {
     return Constant;
 }(Initializer));
 exports.Constant = Constant;
-tfjs_core_1.serialization.SerializationMap.register(Constant);
+tfjs_core_1.serialization.registerClass(Constant);
 var RandomUniform = (function (_super) {
     __extends(RandomUniform, _super);
     function RandomUniform(config) {
@@ -31504,7 +33546,7 @@ var RandomUniform = (function (_super) {
     return RandomUniform;
 }(Initializer));
 exports.RandomUniform = RandomUniform;
-tfjs_core_1.serialization.SerializationMap.register(RandomUniform);
+tfjs_core_1.serialization.registerClass(RandomUniform);
 var RandomNormal = (function (_super) {
     __extends(RandomNormal, _super);
     function RandomNormal(config) {
@@ -31517,8 +33559,9 @@ var RandomNormal = (function (_super) {
         return _this;
     }
     RandomNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
         }
         return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31529,7 +33572,7 @@ var RandomNormal = (function (_super) {
     return RandomNormal;
 }(Initializer));
 exports.RandomNormal = RandomNormal;
-tfjs_core_1.serialization.SerializationMap.register(RandomNormal);
+tfjs_core_1.serialization.registerClass(RandomNormal);
 var TruncatedNormal = (function (_super) {
     __extends(TruncatedNormal, _super);
     function TruncatedNormal(config) {
@@ -31542,8 +33585,9 @@ var TruncatedNormal = (function (_super) {
         return _this;
     }
     TruncatedNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("truncatedNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("truncatedNormal does not support dType " + dtype + ".");
         }
         return tfjs_core_1.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31554,7 +33598,7 @@ var TruncatedNormal = (function (_super) {
     return TruncatedNormal;
 }(Initializer));
 exports.TruncatedNormal = TruncatedNormal;
-tfjs_core_1.serialization.SerializationMap.register(TruncatedNormal);
+tfjs_core_1.serialization.registerClass(TruncatedNormal);
 var Identity = (function (_super) {
     __extends(Identity, _super);
     function Identity(config) {
@@ -31581,7 +33625,7 @@ var Identity = (function (_super) {
     return Identity;
 }(Initializer));
 exports.Identity = Identity;
-tfjs_core_1.serialization.SerializationMap.register(Identity);
+tfjs_core_1.serialization.registerClass(Identity);
 function computeFans(shape, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var fanIn;
@@ -31641,8 +33685,9 @@ var VarianceScaling = (function (_super) {
         }
         if (this.distribution === 'normal') {
             var stddev = Math.sqrt(scale);
-            if (dtype === 'bool') {
-                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType bool.");
+            dtype = dtype || 'float32';
+            if (dtype !== 'float32' && dtype !== 'int32') {
+                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType " + dtype + ".");
             }
             return tfjs_core_1.truncatedNormal(shape, 0, stddev, dtype, this.seed);
         }
@@ -31663,7 +33708,7 @@ var VarianceScaling = (function (_super) {
     return VarianceScaling;
 }(Initializer));
 exports.VarianceScaling = VarianceScaling;
-tfjs_core_1.serialization.SerializationMap.register(VarianceScaling);
+tfjs_core_1.serialization.registerClass(VarianceScaling);
 var GlorotUniform = (function (_super) {
     __extends(GlorotUniform, _super);
     function GlorotUniform(config) {
@@ -31677,9 +33722,11 @@ var GlorotUniform = (function (_super) {
     GlorotUniform.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotUniform.className = 'GlorotUniform';
     return GlorotUniform;
 }(VarianceScaling));
 exports.GlorotUniform = GlorotUniform;
+tfjs_core_1.serialization.registerClass(GlorotUniform);
 var GlorotNormal = (function (_super) {
     __extends(GlorotNormal, _super);
     function GlorotNormal(config) {
@@ -31693,9 +33740,11 @@ var GlorotNormal = (function (_super) {
     GlorotNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotNormal.className = 'GlorotNormal';
     return GlorotNormal;
 }(VarianceScaling));
 exports.GlorotNormal = GlorotNormal;
+tfjs_core_1.serialization.registerClass(GlorotNormal);
 var HeNormal = (function (_super) {
     __extends(HeNormal, _super);
     function HeNormal(config) {
@@ -31709,9 +33758,11 @@ var HeNormal = (function (_super) {
     HeNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    HeNormal.className = 'HeNormal';
     return HeNormal;
 }(VarianceScaling));
 exports.HeNormal = HeNormal;
+tfjs_core_1.serialization.registerClass(HeNormal);
 var LeCunNormal = (function (_super) {
     __extends(LeCunNormal, _super);
     function LeCunNormal(config) {
@@ -31725,9 +33776,11 @@ var LeCunNormal = (function (_super) {
     LeCunNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    LeCunNormal.className = 'LeCunNormal';
     return LeCunNormal;
 }(VarianceScaling));
 exports.LeCunNormal = LeCunNormal;
+tfjs_core_1.serialization.registerClass(LeCunNormal);
 var Orthogonal = (function (_super) {
     __extends(Orthogonal, _super);
     function Orthogonal(config) {
@@ -31770,7 +33823,7 @@ var Orthogonal = (function (_super) {
     return Orthogonal;
 }(Initializer));
 exports.Orthogonal = Orthogonal;
-tfjs_core_1.serialization.SerializationMap.register(Orthogonal);
+tfjs_core_1.serialization.registerClass(Orthogonal);
 exports.INITIALIZER_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'constant': 'Constant',
     'glorotNormal': 'GlorotNormal',
@@ -31825,7 +33878,7 @@ function getInitializer(identifier) {
 }
 exports.getInitializer = getInitializer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./common":203,"./errors":210,"./utils/generic_utils":238,"./utils/math_utils":240,"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./common":223,"./errors":233,"./utils/generic_utils":262,"./utils/math_utils":264,"@tensorflow/tfjs-core":68}],243:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31876,7 +33929,7 @@ var ReLU = (function (_super) {
     return ReLU;
 }(topology_1.Layer));
 exports.ReLU = ReLU;
-tfjs_core_1.serialization.SerializationMap.register(ReLU);
+tfjs_core_1.serialization.registerClass(ReLU);
 var LeakyReLU = (function (_super) {
     __extends(LeakyReLU, _super);
     function LeakyReLU(config) {
@@ -31905,7 +33958,7 @@ var LeakyReLU = (function (_super) {
     return LeakyReLU;
 }(topology_1.Layer));
 exports.LeakyReLU = LeakyReLU;
-tfjs_core_1.serialization.SerializationMap.register(LeakyReLU);
+tfjs_core_1.serialization.registerClass(LeakyReLU);
 var ELU = (function (_super) {
     __extends(ELU, _super);
     function ELU(config) {
@@ -31938,7 +33991,7 @@ var ELU = (function (_super) {
     return ELU;
 }(topology_1.Layer));
 exports.ELU = ELU;
-tfjs_core_1.serialization.SerializationMap.register(ELU);
+tfjs_core_1.serialization.registerClass(ELU);
 var ThresholdedReLU = (function (_super) {
     __extends(ThresholdedReLU, _super);
     function ThresholdedReLU(config) {
@@ -31968,7 +34021,7 @@ var ThresholdedReLU = (function (_super) {
     return ThresholdedReLU;
 }(topology_1.Layer));
 exports.ThresholdedReLU = ThresholdedReLU;
-tfjs_core_1.serialization.SerializationMap.register(ThresholdedReLU);
+tfjs_core_1.serialization.registerClass(ThresholdedReLU);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax(config) {
@@ -31998,9 +34051,9 @@ var Softmax = (function (_super) {
     return Softmax;
 }(topology_1.Layer));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],244:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32315,7 +34368,7 @@ var Conv2D = (function (_super) {
     return Conv2D;
 }(Conv));
 exports.Conv2D = Conv2D;
-tfjs_core_1.serialization.SerializationMap.register(Conv2D);
+tfjs_core_1.serialization.registerClass(Conv2D);
 var Conv2DTranspose = (function (_super) {
     __extends(Conv2DTranspose, _super);
     function Conv2DTranspose(config) {
@@ -32431,7 +34484,7 @@ var Conv2DTranspose = (function (_super) {
     return Conv2DTranspose;
 }(Conv2D));
 exports.Conv2DTranspose = Conv2DTranspose;
-tfjs_core_1.serialization.SerializationMap.register(Conv2DTranspose);
+tfjs_core_1.serialization.registerClass(Conv2DTranspose);
 var SeparableConv = (function (_super) {
     __extends(SeparableConv, _super);
     function SeparableConv(rank, config) {
@@ -32558,7 +34611,7 @@ var SeparableConv2D = (function (_super) {
     return SeparableConv2D;
 }(SeparableConv));
 exports.SeparableConv2D = SeparableConv2D;
-tfjs_core_1.serialization.SerializationMap.register(SeparableConv2D);
+tfjs_core_1.serialization.registerClass(SeparableConv2D);
 var Conv1D = (function (_super) {
     __extends(Conv1D, _super);
     function Conv1D(config) {
@@ -32583,7 +34636,7 @@ var Conv1D = (function (_super) {
     return Conv1D;
 }(Conv));
 exports.Conv1D = Conv1D;
-tfjs_core_1.serialization.SerializationMap.register(Conv1D);
+tfjs_core_1.serialization.registerClass(Conv1D);
 var Cropping2D = (function (_super) {
     __extends(Cropping2D, _super);
     function Cropping2D(config) {
@@ -32607,15 +34660,17 @@ var Cropping2D = (function (_super) {
     Cropping2D.prototype.computeOutputShape = function (inputShape) {
         if (this.dataFormat === 'channelsFirst')
             return [
-                inputShape[0], inputShape[1],
+                inputShape[0],
+                inputShape[1],
                 inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+                inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
             ];
         else
             return [
                 inputShape[0],
                 inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+                inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+                inputShape[3]
             ];
     };
     Cropping2D.prototype.call = function (inputs, kwargs) {
@@ -32642,7 +34697,7 @@ var Cropping2D = (function (_super) {
     return Cropping2D;
 }(topology_1.Layer));
 exports.Cropping2D = Cropping2D;
-tfjs_core_1.serialization.SerializationMap.register(Cropping2D);
+tfjs_core_1.serialization.registerClass(Cropping2D);
 var UpSampling2D = (function (_super) {
     __extends(UpSampling2D, _super);
     function UpSampling2D(config) {
@@ -32695,9 +34750,9 @@ var UpSampling2D = (function (_super) {
     return UpSampling2D;
 }(topology_1.Layer));
 exports.UpSampling2D = UpSampling2D;
-tfjs_core_1.serialization.SerializationMap.register(UpSampling2D);
+tfjs_core_1.serialization.registerClass(UpSampling2D);
 
-},{"../activations":197,"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
+},{"../activations":217,"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32828,9 +34883,9 @@ var DepthwiseConv2D = (function (_super) {
     return DepthwiseConv2D;
 }(convolutional_1.BaseConv));
 exports.DepthwiseConv2D = DepthwiseConv2D;
-tfjs_core_1.serialization.SerializationMap.register(DepthwiseConv2D);
+tfjs_core_1.serialization.registerClass(DepthwiseConv2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],246:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32913,7 +34968,7 @@ var Dropout = (function (_super) {
     return Dropout;
 }(topology_1.Layer));
 exports.Dropout = Dropout;
-tfjs_core_1.serialization.SerializationMap.register(Dropout);
+tfjs_core_1.serialization.registerClass(Dropout);
 var Dense = (function (_super) {
     __extends(Dense, _super);
     function Dense(config) {
@@ -33003,7 +35058,7 @@ var Dense = (function (_super) {
     return Dense;
 }(topology_1.Layer));
 exports.Dense = Dense;
-tfjs_core_1.serialization.SerializationMap.register(Dense);
+tfjs_core_1.serialization.registerClass(Dense);
 var Flatten = (function (_super) {
     __extends(Flatten, _super);
     function Flatten(config) {
@@ -33035,7 +35090,7 @@ var Flatten = (function (_super) {
     return Flatten;
 }(topology_1.Layer));
 exports.Flatten = Flatten;
-tfjs_core_1.serialization.SerializationMap.register(Flatten);
+tfjs_core_1.serialization.registerClass(Flatten);
 var Activation = (function (_super) {
     __extends(Activation, _super);
     function Activation(config) {
@@ -33062,7 +35117,7 @@ var Activation = (function (_super) {
     return Activation;
 }(topology_1.Layer));
 exports.Activation = Activation;
-tfjs_core_1.serialization.SerializationMap.register(Activation);
+tfjs_core_1.serialization.registerClass(Activation);
 var RepeatVector = (function (_super) {
     __extends(RepeatVector, _super);
     function RepeatVector(config) {
@@ -33093,7 +35148,7 @@ var RepeatVector = (function (_super) {
     return RepeatVector;
 }(topology_1.Layer));
 exports.RepeatVector = RepeatVector;
-tfjs_core_1.serialization.SerializationMap.register(RepeatVector);
+tfjs_core_1.serialization.registerClass(RepeatVector);
 var Reshape = (function (_super) {
     __extends(Reshape, _super);
     function Reshape(config) {
@@ -33177,7 +35232,7 @@ var Reshape = (function (_super) {
     return Reshape;
 }(topology_1.Layer));
 exports.Reshape = Reshape;
-tfjs_core_1.serialization.SerializationMap.register(Reshape);
+tfjs_core_1.serialization.registerClass(Reshape);
 var Permute = (function (_super) {
     __extends(Permute, _super);
     function Permute(config) {
@@ -33223,9 +35278,9 @@ var Permute = (function (_super) {
     return Permute;
 }(topology_1.Layer));
 exports.Permute = Permute;
-tfjs_core_1.serialization.SerializationMap.register(Permute);
+tfjs_core_1.serialization.registerClass(Permute);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],223:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],247:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33342,9 +35397,9 @@ var Embedding = (function (_super) {
     return Embedding;
 }(topology_1.Layer));
 exports.Embedding = Embedding;
-tfjs_core_1.serialization.SerializationMap.register(Embedding);
+tfjs_core_1.serialization.registerClass(Embedding);
 
-},{"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],224:[function(require,module,exports){
+},{"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],248:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33363,6 +35418,7 @@ var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
 var topology_1 = require("../engine/topology");
 var errors_1 = require("../errors");
+var losses_1 = require("../losses");
 var generic_utils = require("../utils/generic_utils");
 var mathUtils = require("../utils/math_utils");
 var types_utils_1 = require("../utils/types_utils");
@@ -33540,6 +35596,9 @@ var Merge = (function (_super) {
         }
         return outputShape;
     };
+    Merge.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Merge yet');
+    };
     return Merge;
 }(topology_1.Layer));
 exports.Merge = Merge;
@@ -33561,7 +35620,7 @@ var Add = (function (_super) {
     return Add;
 }(Merge));
 exports.Add = Add;
-tfjs_core_1.serialization.SerializationMap.register(Add);
+tfjs_core_1.serialization.registerClass(Add);
 function add(config) {
     if (Array.isArray(config)) {
         var layer = new Add({});
@@ -33590,7 +35649,7 @@ var Multiply = (function (_super) {
     return Multiply;
 }(Merge));
 exports.Multiply = Multiply;
-tfjs_core_1.serialization.SerializationMap.register(Multiply);
+tfjs_core_1.serialization.registerClass(Multiply);
 function multiply(config) {
     if (Array.isArray(config)) {
         var layer = new Multiply({});
@@ -33619,7 +35678,7 @@ var Average = (function (_super) {
     return Average;
 }(Merge));
 exports.Average = Average;
-tfjs_core_1.serialization.SerializationMap.register(Average);
+tfjs_core_1.serialization.registerClass(Average);
 function average(config) {
     if (Array.isArray(config)) {
         var layer = new Average({});
@@ -33648,7 +35707,7 @@ var Maximum = (function (_super) {
     return Maximum;
 }(Merge));
 exports.Maximum = Maximum;
-tfjs_core_1.serialization.SerializationMap.register(Maximum);
+tfjs_core_1.serialization.registerClass(Maximum);
 function maximum(config) {
     if (Array.isArray(config)) {
         var layer = new Maximum({});
@@ -33677,7 +35736,7 @@ var Minimum = (function (_super) {
     return Minimum;
 }(Merge));
 exports.Minimum = Minimum;
-tfjs_core_1.serialization.SerializationMap.register(Minimum);
+tfjs_core_1.serialization.registerClass(Minimum);
 function minimum(config) {
     if (Array.isArray(config)) {
         var layer = new Minimum({});
@@ -33764,6 +35823,9 @@ var Concatenate = (function (_super) {
         }
         return outputShape;
     };
+    Concatenate.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Concatenate yet');
+    };
     Concatenate.prototype.getConfig = function () {
         var config = {
             'axis': this.axis,
@@ -33776,7 +35838,7 @@ var Concatenate = (function (_super) {
     return Concatenate;
 }(Merge));
 exports.Concatenate = Concatenate;
-tfjs_core_1.serialization.SerializationMap.register(Concatenate);
+tfjs_core_1.serialization.registerClass(Concatenate);
 function concatenate(config) {
     if (Array.isArray(config)) {
         var layer = new Concatenate({});
@@ -33787,8 +35849,184 @@ function concatenate(config) {
     }
 }
 exports.concatenate = concatenate;
+function interpretAxis(axis, dim) {
+    while (axis < 0) {
+        axis += dim;
+    }
+    return axis;
+}
+function batchDot(x, y, axes) {
+    if (x.shape.length > 3 || y.shape.length > 3) {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for tensors of 4D or higher rank yet');
+    }
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of x to be >= 2, " +
+        ("but got " + x.shape.length));
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of y to be >= 2, " +
+        ("but got " + y.shape.length));
+    if (typeof axes === 'number') {
+        axes = [axes, axes];
+    }
+    if (x.dtype === 'complex64' || y.dtype === 'complex64') {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for complex64-type Tensors yet.');
+    }
+    var xNDim = x.shape.length;
+    var yNDim = y.shape.length;
+    if (axes == null) {
+        axes = [xNDim - 1, yNDim - 2];
+    }
+    var axesArray = axes;
+    return tfc.tidy(function () {
+        var diff;
+        if (xNDim > yNDim) {
+            diff = xNDim - yNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            y = y.reshape(y.shape.concat(diffShape));
+        }
+        else if (yNDim > xNDim) {
+            diff = yNDim - xNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            x = x.reshape(x.shape.concat(diffShape));
+        }
+        else {
+            diff = 0;
+        }
+        var out;
+        if (x.shape.length === 2 && y.shape.length === 2) {
+            if (axesArray[0] === axesArray[1]) {
+                out = x.mulStrict(y).sum(axesArray[0]);
+            }
+            else {
+                out = x.transpose([1, 0]).mulStrict(y).sum(axesArray[1]);
+            }
+        }
+        else {
+            var adjX = axesArray[0] === x.shape.length - 1 ? null : true;
+            var adjY = axesArray[1] === y.shape.length - 1 ? true : null;
+            out = x.matMul(y, adjX, adjY);
+        }
+        if (diff > 0) {
+            var idx = void 0;
+            if (xNDim > yNDim) {
+                idx = xNDim + yNDim - 3;
+            }
+            else {
+                idx = xNDim - 1;
+            }
+            var squeezeAxes = [];
+            for (var i = idx; i < idx + diff; ++i) {
+                squeezeAxes.push(i);
+            }
+            out = out.squeeze(squeezeAxes);
+        }
+        if (out.shape.length === 1) {
+            out = out.expandDims(1);
+        }
+        return out;
+    });
+}
+var Dot = (function (_super) {
+    __extends(Dot, _super);
+    function Dot(config) {
+        var _this = _super.call(this, config) || this;
+        _this.axes = config.axes;
+        _this.normalize = config.normalize == null ? false : config.normalize;
+        _this.supportsMasking = true;
+        _this.reshapeRequired = false;
+        return _this;
+    }
+    Dot.prototype.build = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0];
+        var shape2 = inputShape[1];
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        if (shape1[axes[0]] !== shape2[axes[1]]) {
+            throw new errors_1.ValueError("Dimension incompatibility: " +
+                (shape1[axes[0]] + " !== " + shape2[axes[1]]));
+        }
+    };
+    Dot.prototype.mergeFunction = function (inputs) {
+        if (inputs.length !== 2) {
+            throw new errors_1.ValueError('A `Dot` layer must be called on exactly 2 inputs, ' +
+                ("but received " + inputs.length + " input(s)."));
+        }
+        var x1 = inputs[0];
+        var x2 = inputs[1];
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, x1.shape.length),
+                interpretAxis(this.axes, x2.shape.length)
+            ];
+        }
+        else {
+            axes = this.axes.map(function (axis, i) { return interpretAxis(axis, inputs[i].shape.length); });
+        }
+        if (this.normalize) {
+            x1 = losses_1.l2Normalize(x1, axes[0]);
+            x2 = losses_1.l2Normalize(x2, axes[1]);
+        }
+        return batchDot(x1, x2, axes);
+    };
+    Dot.prototype.interpretAxes = function (shape1, shape2) {
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, shape1.length),
+                interpretAxis(this.axes, shape2.length)
+            ];
+        }
+        else {
+            axes = this.axes;
+        }
+        return axes;
+    };
+    Dot.prototype.computeOutputShape = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0].slice();
+        var shape2 = inputShape[1].slice();
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        shape1.splice(axes[0], 1);
+        shape2.splice(axes[1], 1);
+        shape2.splice(0, 1);
+        var outputShape = shape1.concat(shape2);
+        if (outputShape.length === 1) {
+            outputShape.push(1);
+        }
+        return outputShape;
+    };
+    Dot.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Dot yet');
+    };
+    Dot.prototype.getConfig = function () {
+        var config = {
+            'axes': this.axes,
+            'normalize': this.normalize
+        };
+        var baseConfig = _super.prototype.getConfig.call(this);
+        Object.assign(config, baseConfig);
+        return config;
+    };
+    Dot.className = 'Dot';
+    return Dot;
+}(Merge));
+exports.Dot = Dot;
+tfjs_core_1.serialization.registerClass(Dot);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../losses":256,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],249:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33825,7 +36063,7 @@ function batchNormalization(x, mean, variance, beta, gamma, epsilon) {
         out = tfc.batchNormalization4d(x, mean, variance, epsilon, gamma, beta);
     }
     else {
-        throw new errors_1.NotImplementedError("batchNormalization is not implememnted for array of rank " + x.rank + " " +
+        throw new errors_1.NotImplementedError("batchNormalization is not implemented for array of rank " + x.rank + " " +
             "yet");
     }
     return out;
@@ -33878,7 +36116,11 @@ exports.normalizeBatchInTraining = normalizeBatchInTraining;
 var BatchNormalization = (function (_super) {
     __extends(BatchNormalization, _super);
     function BatchNormalization(config) {
-        var _this = _super.call(this, config) || this;
+        var _this = this;
+        if (config == null) {
+            config = {};
+        }
+        _this = _super.call(this, config) || this;
         _this.supportsMasking = true;
         _this.axis = config.axis == null ? -1 : config.axis;
         _this.momentum = config.momentum == null ? 0.99 : config.momentum;
@@ -33989,9 +36231,9 @@ var BatchNormalization = (function (_super) {
     return BatchNormalization;
 }(topology_1.Layer));
 exports.BatchNormalization = BatchNormalization;
-tfjs_core_1.serialization.SerializationMap.register(BatchNormalization);
+tfjs_core_1.serialization.registerClass(BatchNormalization);
 
-},{"../backend/state":199,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+},{"../backend/state":219,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],250:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34161,9 +36403,9 @@ var ZeroPadding2D = (function (_super) {
     return ZeroPadding2D;
 }(topology_1.Layer));
 exports.ZeroPadding2D = ZeroPadding2D;
-tfjs_core_1.serialization.SerializationMap.register(ZeroPadding2D);
+tfjs_core_1.serialization.registerClass(ZeroPadding2D);
 
-},{"../backend/common":198,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],227:[function(require,module,exports){
+},{"../backend/common":218,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],251:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34305,7 +36547,7 @@ var MaxPooling1D = (function (_super) {
     return MaxPooling1D;
 }(Pooling1D));
 exports.MaxPooling1D = MaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling1D);
+tfjs_core_1.serialization.registerClass(MaxPooling1D);
 var AveragePooling1D = (function (_super) {
     __extends(AveragePooling1D, _super);
     function AveragePooling1D(config) {
@@ -34320,7 +36562,7 @@ var AveragePooling1D = (function (_super) {
     return AveragePooling1D;
 }(Pooling1D));
 exports.AveragePooling1D = AveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling1D);
+tfjs_core_1.serialization.registerClass(AveragePooling1D);
 var Pooling2D = (function (_super) {
     __extends(Pooling2D, _super);
     function Pooling2D(config) {
@@ -34404,7 +36646,7 @@ var MaxPooling2D = (function (_super) {
     return MaxPooling2D;
 }(Pooling2D));
 exports.MaxPooling2D = MaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling2D);
+tfjs_core_1.serialization.registerClass(MaxPooling2D);
 var AveragePooling2D = (function (_super) {
     __extends(AveragePooling2D, _super);
     function AveragePooling2D(config) {
@@ -34419,7 +36661,7 @@ var AveragePooling2D = (function (_super) {
     return AveragePooling2D;
 }(Pooling2D));
 exports.AveragePooling2D = AveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling2D);
+tfjs_core_1.serialization.registerClass(AveragePooling2D);
 var GlobalPooling1D = (function (_super) {
     __extends(GlobalPooling1D, _super);
     function GlobalPooling1D(config) {
@@ -34451,7 +36693,7 @@ var GlobalAveragePooling1D = (function (_super) {
     return GlobalAveragePooling1D;
 }(GlobalPooling1D));
 exports.GlobalAveragePooling1D = GlobalAveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling1D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling1D);
 var GlobalMaxPooling1D = (function (_super) {
     __extends(GlobalMaxPooling1D, _super);
     function GlobalMaxPooling1D(config) {
@@ -34467,7 +36709,7 @@ var GlobalMaxPooling1D = (function (_super) {
     return GlobalMaxPooling1D;
 }(GlobalPooling1D));
 exports.GlobalMaxPooling1D = GlobalMaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling1D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling1D);
 var GlobalPooling2D = (function (_super) {
     __extends(GlobalPooling2D, _super);
     function GlobalPooling2D(config) {
@@ -34520,7 +36762,7 @@ var GlobalAveragePooling2D = (function (_super) {
     return GlobalAveragePooling2D;
 }(GlobalPooling2D));
 exports.GlobalAveragePooling2D = GlobalAveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling2D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling2D);
 var GlobalMaxPooling2D = (function (_super) {
     __extends(GlobalMaxPooling2D, _super);
     function GlobalMaxPooling2D() {
@@ -34542,9 +36784,9 @@ var GlobalMaxPooling2D = (function (_super) {
     return GlobalMaxPooling2D;
 }(GlobalPooling2D));
 exports.GlobalMaxPooling2D = GlobalMaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling2D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],252:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34600,9 +36842,10 @@ function standardizeArgs(inputs, initialState, constants, numConstants) {
     return { inputs: inputs, initialState: initialState, constants: constants };
 }
 exports.standardizeArgs = standardizeArgs;
-function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, inputLength) {
+function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, needPerStepOutputs) {
     if (goBackwards === void 0) { goBackwards = false; }
     if (unroll === void 0) { unroll = false; }
+    if (needPerStepOutputs === void 0) { needPerStepOutputs = false; }
     var ndim = inputs.shape.length;
     if (ndim < 3) {
         throw new errors_1.ValueError("Input should be at least 3D, but is " + ndim + "D.");
@@ -34628,24 +36871,27 @@ function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, 
     var lastOutput;
     var states = initialStates;
     var timeSteps = inputs.shape[0];
-    for (var t = 0; t < timeSteps; ++t) {
+    var _loop_1 = function (t) {
         var currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
         currentInput = currentInput.reshape(currentInput.shape.slice(1));
-        var stepOutputs = stepFunction(currentInput, states);
+        var stepOutputs = tfc.tidy(function () { return stepFunction(currentInput, states); });
         lastOutput = stepOutputs[0];
-        if (t === 0) {
-            outputs = lastOutput.reshape([1].concat(lastOutput.shape));
-        }
-        else {
-            outputs = K.concatAlongFirstAxis(outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        if (needPerStepOutputs) {
+            if (t === 0) {
+                outputs = lastOutput.expandDims(1);
+            }
+            else {
+                var newOutputs = tfc.concat([outputs, lastOutput.expandDims(1)], 1);
+                outputs.dispose();
+                outputs = newOutputs;
+            }
         }
         states = stepOutputs[1];
+    };
+    for (var t = 0; t < timeSteps; ++t) {
+        _loop_1(t);
     }
-    return [
-        lastOutput,
-        tfc.transpose(outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
-        states
-    ];
+    return [lastOutput, outputs, states];
 }
 exports.rnn = rnn;
 var RNN = (function (_super) {
@@ -34894,8 +37140,6 @@ var RNN = (function (_super) {
                 throw new errors_1.ValueError("RNN Layer has " + numStates + " state(s) but was passed " +
                     (initialState.length + " initial state(s)."));
             }
-            var inputShape = inputs.shape;
-            var timesteps = inputShape[1];
             if (_this.unroll) {
                 console.warn('Ignoring unroll = true for RNN layer, due to imperative backend.');
             }
@@ -34904,7 +37148,7 @@ var RNN = (function (_super) {
                 var outputs = _this.cell.call([inputs].concat(states), cellCallKwargs);
                 return [outputs[0], outputs.slice(1)];
             };
-            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, timesteps);
+            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, _this.returnSequences);
             var lastOutput = rnnOutputs[0];
             var outputs = rnnOutputs[1];
             var states = rnnOutputs[2];
@@ -34980,7 +37224,7 @@ var RNN = (function (_super) {
     return RNN;
 }(topology_2.Layer));
 exports.RNN = RNN;
-tfjs_core_1.serialization.SerializationMap.register(RNN);
+tfjs_core_1.serialization.registerClass(RNN);
 var RNNCell = (function (_super) {
     __extends(RNNCell, _super);
     function RNNCell() {
@@ -35099,7 +37343,7 @@ var SimpleRNNCell = (function (_super) {
     return SimpleRNNCell;
 }(RNNCell));
 exports.SimpleRNNCell = SimpleRNNCell;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNNCell);
+tfjs_core_1.serialization.registerClass(SimpleRNNCell);
 var SimpleRNN = (function (_super) {
     __extends(SimpleRNN, _super);
     function SimpleRNN(config) {
@@ -35250,7 +37494,7 @@ var SimpleRNN = (function (_super) {
     return SimpleRNN;
 }(RNN));
 exports.SimpleRNN = SimpleRNN;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNN);
+tfjs_core_1.serialization.registerClass(SimpleRNN);
 var GRUCell = (function (_super) {
     __extends(GRUCell, _super);
     function GRUCell(config) {
@@ -35425,7 +37669,7 @@ var GRUCell = (function (_super) {
     return GRUCell;
 }(RNNCell));
 exports.GRUCell = GRUCell;
-tfjs_core_1.serialization.SerializationMap.register(GRUCell);
+tfjs_core_1.serialization.registerClass(GRUCell);
 var GRU = (function (_super) {
     __extends(GRU, _super);
     function GRU(config) {
@@ -35602,7 +37846,7 @@ var GRU = (function (_super) {
     return GRU;
 }(RNN));
 exports.GRU = GRU;
-tfjs_core_1.serialization.SerializationMap.register(GRU);
+tfjs_core_1.serialization.registerClass(GRU);
 var LSTMCell = (function (_super) {
     __extends(LSTMCell, _super);
     function LSTMCell(config) {
@@ -35812,7 +38056,7 @@ var LSTMCell = (function (_super) {
     return LSTMCell;
 }(RNNCell));
 exports.LSTMCell = LSTMCell;
-tfjs_core_1.serialization.SerializationMap.register(LSTMCell);
+tfjs_core_1.serialization.registerClass(LSTMCell);
 var LSTM = (function (_super) {
     __extends(LSTM, _super);
     function LSTM(config) {
@@ -35997,7 +38241,7 @@ var LSTM = (function (_super) {
     return LSTM;
 }(RNN));
 exports.LSTM = LSTM;
-tfjs_core_1.serialization.SerializationMap.register(LSTM);
+tfjs_core_1.serialization.registerClass(LSTM);
 var StackedRNNCells = (function (_super) {
     __extends(StackedRNNCells, _super);
     function StackedRNNCells(config) {
@@ -36161,7 +38405,7 @@ var StackedRNNCells = (function (_super) {
     return StackedRNNCells;
 }(RNNCell));
 exports.StackedRNNCells = StackedRNNCells;
-tfjs_core_1.serialization.SerializationMap.register(StackedRNNCells);
+tfjs_core_1.serialization.registerClass(StackedRNNCells);
 function generateDropoutMask(ones, rate, training, count) {
     if (training === void 0) { training = null; }
     if (count === void 0) { count = 1; }
@@ -36181,7 +38425,7 @@ function generateDropoutMask(ones, rate, training, count) {
     }
 }
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"../variables":244,"./serialization":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"../variables":268,"./serialization":253,"@tensorflow/tfjs-core":68}],253:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -36192,7 +38436,7 @@ function deserialize(config, customObjects) {
 }
 exports.deserialize = deserialize;
 
-},{"../utils/generic_utils":238,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
+},{"../utils/generic_utils":262,"@tensorflow/tfjs-core":68}],254:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36333,10 +38577,10 @@ var TimeDistributed = (function (_super) {
         return tfjs_core_1.tidy(function () {
             inputs = types_utils_1.getExactlyOneTensor(inputs);
             var step = function (inputs, states) {
-                var output = _this.layer.call(inputs, kwargs);
+                var output = types_utils_1.getExactlyOneTensor(_this.layer.call(inputs, kwargs));
                 return [output, []];
             };
-            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, true);
             var y = rnnOutputs[1];
             return y;
         });
@@ -36345,7 +38589,7 @@ var TimeDistributed = (function (_super) {
     return TimeDistributed;
 }(Wrapper));
 exports.TimeDistributed = TimeDistributed;
-tfjs_core_1.serialization.SerializationMap.register(TimeDistributed);
+tfjs_core_1.serialization.registerClass(TimeDistributed);
 exports.VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
 function checkBidirectionalMergeMode(value) {
     generic_utils.checkStringTypeUnionValue(exports.VALID_BIDIRECTIONAL_MERGE_MODES, 'BidirectionalMergeMode', value);
@@ -36516,7 +38760,7 @@ var Bidirectional = (function (_super) {
                 var forwardState = initialState.slice(0, initialState.length / 2);
                 var backwardState = initialState.slice(initialState.length / 2);
                 y = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: forwardState }));
-                yRev = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
+                yRev = _this.backwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
             }
             var states;
             if (_this.returnState) {
@@ -36607,9 +38851,9 @@ var Bidirectional = (function (_super) {
     return Bidirectional;
 }(Wrapper));
 exports.Bidirectional = Bidirectional;
-tfjs_core_1.serialization.SerializationMap.register(Bidirectional);
+tfjs_core_1.serialization.registerClass(Bidirectional);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"./recurrent":228,"./serialization":229,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"./recurrent":252,"./serialization":253,"@tensorflow/tfjs-core":68}],255:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36695,14 +38939,14 @@ function disposeTensorsInLogs(logs) {
 }
 exports.disposeTensorsInLogs = disposeTensorsInLogs;
 
-},{"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],256:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var common_1 = require("./backend/common");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 function l2Normalize(x, axis) {
     return tfjs_core_1.tidy(function () {
@@ -36879,7 +39123,13 @@ function get(identifierOrFn) {
         if (identifierOrFn in lossesMap) {
             return lossesMap[identifierOrFn];
         }
-        throw new errors_1.ValueError("Unknown loss " + identifierOrFn);
+        var errMsg = "Unknown loss " + identifierOrFn;
+        if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+            errMsg = "Unknown loss " + identifierOrFn + ". " +
+                'Use "categoricalCrossentropy" as the string name for ' +
+                'tf.losses.softmaxCrossEntropy';
+        }
+        throw new errors_1.ValueError(errMsg);
     }
     else {
         return identifierOrFn;
@@ -36887,13 +39137,13 @@ function get(identifierOrFn) {
 }
 exports.get = get;
 
-},{"./backend/common":198,"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"@tensorflow/tfjs-core":68}],257:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 var losses_1 = require("./losses");
 var losses_2 = require("./losses");
@@ -36909,6 +39159,54 @@ function categoricalAccuracy(yTrue, yPred) {
     return tfjs_core_1.tidy(function () { return K.cast(tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'); });
 }
 exports.categoricalAccuracy = categoricalAccuracy;
+function truePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function falseNegatives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(zero))
+            .sum()
+            .cast('float32');
+    });
+}
+function falsePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function precision(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fp = falsePositives(yTrue, yPred);
+        var denominator = tp.add(fp);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fn = falseNegatives(yTrue, yPred);
+        var denominator = tp.add(fn);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.recall = recall;
 function binaryCrossentropy(yTrue, yPred) {
     return losses_2.binaryCrossentropy(yTrue, yPred);
 }
@@ -36938,6 +39236,7 @@ function get(identifier) {
     var metricsMap = {
         binaryAccuracy: binaryAccuracy,
         categoricalAccuracy: categoricalAccuracy,
+        precision: precision,
         categoricalCrossentropy: exports.categoricalCrossentropy,
         sparseCategoricalCrossentropy: exports.sparseCategoricalCrossentropy,
         mse: exports.mse,
@@ -36960,7 +39259,7 @@ function get(identifier) {
 }
 exports.get = get;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"./losses":232,"@tensorflow/tfjs-core":68}],234:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"./losses":256,"@tensorflow/tfjs-core":68}],258:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37024,6 +39323,10 @@ function modelFromJSON(modelAndWeightsConfig, customObjects) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
+                    if (!('modelTopology' in modelAndWeightsConfig)) {
+                        modelAndWeightsConfig = { modelTopology: modelAndWeightsConfig };
+                    }
+                    modelAndWeightsConfig = modelAndWeightsConfig;
                     modelTopology = modelAndWeightsConfig.modelTopology;
                     if (modelTopology['model_config'] != null) {
                         modelTopology = modelTopology['model_config'];
@@ -37122,6 +39425,14 @@ var Sequential = (function (_super) {
         }
         return _this;
     }
+    Sequential.prototype.checkShape = function (layer) {
+        var shape = layer.inboundNodes[0].outputTensors[0].shape;
+        if (shape.some(function (x) { return x < 0; })) {
+            throw new errors_1.ValueError('Negative dimension size caused by adding layer ' +
+                (layer.name + " with input shape [") +
+                (layer.inboundNodes[0].inputTensors[0].shape + "]"));
+        }
+    };
     Sequential.prototype.add = function (layer) {
         var isLayerModelInstance = layer instanceof Sequential || layer instanceof training_1.Model;
         var modelLayer;
@@ -37170,6 +39481,7 @@ var Sequential = (function (_super) {
                         'For multi-output layers, ' +
                         'use the functional API.');
                 }
+                this.checkShape(layer);
                 this.outputs = [layer.inboundNodes[0].outputTensors[0]];
                 this.inputs = topology_1.getSourceInputs(this.outputs[0]);
             }
@@ -37195,6 +39507,7 @@ var Sequential = (function (_super) {
                     'For multi-output layers, ' +
                     'use the functional API.');
             }
+            this.checkShape(layer);
             this.outputs = [outputTensor];
             this.inboundNodes[0].outputTensors = this.outputs;
             this.inboundNodes[0].outputShapes = [this.outputs[0].shape];
@@ -37291,6 +39604,16 @@ var Sequential = (function (_super) {
         }
         return this.model.evaluate(x, y, config);
     };
+    Sequential.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before being used.');
+                }
+                return [2, this.model.evaluateDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.prototype.predict = function (x, config) {
         if (config === void 0) { config = {}; }
         if (this.model == null) {
@@ -37325,19 +39648,40 @@ var Sequential = (function (_super) {
             });
         });
     };
+    Sequential.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before ' +
+                        'being used.');
+                }
+                return [2, this.model.fitDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.fromConfig = function (cls, config) {
-        var model = new cls({});
+        var configArray;
+        var extraModelConfig = {};
+        if (config instanceof Array) {
+            if (!(config[0].className != null) ||
+                config[0]['className'] === 'Merge') {
+                throw new errors_1.ValueError('Legacy serialization format not supported yet.');
+            }
+            configArray = config;
+        }
+        else {
+            tfjs_core_1.util.assert(config['layers'] != null, "When the config data for a Sequential model is not an Array, " +
+                "it must be an Object that contains the 'layers' field.");
+            configArray = config['layers'];
+            delete config['layers'];
+            extraModelConfig = config;
+        }
+        var model = new cls(extraModelConfig);
         if (!(model instanceof Sequential)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called on non-Sequential input: " + model);
+            throw new errors_1.NotImplementedError("Sequential.fromConfig called on non-Sequential input: " + model);
         }
-        if (!(config instanceof Array)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called without an array of configs");
-        }
-        if (!(config[0].className != null) || config[0]['className'] === 'Merge') {
-            throw new errors_1.ValueError('Legacy serialization format not supported yet.');
-        }
-        for (var _i = 0, _a = config; _i < _a.length; _i++) {
-            var conf = _a[_i];
+        for (var _i = 0, configArray_1 = configArray; _i < configArray_1.length; _i++) {
+            var conf = configArray_1[_i];
             var layer = serialization_1.deserialize(conf);
             model.add(layer);
         }
@@ -37365,9 +39709,9 @@ var Sequential = (function (_super) {
     return Sequential;
 }(training_1.Model));
 exports.Sequential = Sequential;
-tfjs_core_1.serialization.SerializationMap.register(Sequential);
+tfjs_core_1.serialization.registerClass(Sequential);
 
-},{"./backend/state":199,"./engine/input_layer":207,"./engine/topology":208,"./engine/training":209,"./errors":210,"./layers/serialization":229,"./utils/generic_utils":238,"./utils/serialization_utils":241,"./utils/types_utils":242,"@tensorflow/tfjs-core":68}],235:[function(require,module,exports){
+},{"./backend/state":219,"./engine/input_layer":228,"./engine/topology":229,"./engine/training":230,"./errors":233,"./layers/serialization":253,"./utils/generic_utils":262,"./utils/serialization_utils":265,"./utils/types_utils":266,"@tensorflow/tfjs-core":68}],259:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -37395,7 +39739,7 @@ function getOptimizer(identifier) {
 }
 exports.getOptimizer = getOptimizer;
 
-},{"./backend/common":198,"./errors":210,"@tensorflow/tfjs-core":68}],236:[function(require,module,exports){
+},{"./backend/common":218,"./errors":233,"@tensorflow/tfjs-core":68}],260:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37457,7 +39801,7 @@ var L1L2 = (function (_super) {
     return L1L2;
 }(Regularizer));
 exports.L1L2 = L1L2;
-tfjs_core_1.serialization.SerializationMap.register(L1L2);
+tfjs_core_1.serialization.registerClass(L1L2);
 function l1(config) {
     return new L1L2({ l1: config != null ? config.l1 : null, l2: 0 });
 }
@@ -37498,7 +39842,7 @@ function getRegularizer(identifier) {
 }
 exports.getRegularizer = getRegularizer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],237:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],261:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37558,7 +39902,7 @@ function deconvLength(dimSize, strideSize, kernelSize, padding) {
 }
 exports.deconvLength = deconvLength;
 
-},{"../errors":210,"./generic_utils":238,"./math_utils":240}],238:[function(require,module,exports){
+},{"../errors":233,"./generic_utils":262,"./math_utils":264}],262:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -37827,7 +40171,7 @@ function checkArrayTypeAndLength(x, expectedType, minLength, maxLength) {
 }
 exports.checkArrayTypeAndLength = checkArrayTypeAndLength;
 
-},{"../errors":210}],239:[function(require,module,exports){
+},{"../errors":233}],263:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var variable_utils_1 = require("./variable_utils");
@@ -37987,7 +40331,7 @@ function printLayerSummaryWithConnections(layer, positions, relevantNodes, print
     }
 }
 
-},{"./variable_utils":243}],240:[function(require,module,exports){
+},{"./variable_utils":267}],264:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38059,7 +40403,7 @@ function range(begin, end) {
 }
 exports.range = range;
 
-},{"../errors":210,"@tensorflow/tfjs-core":68}],241:[function(require,module,exports){
+},{"../errors":233,"@tensorflow/tfjs-core":68}],265:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils = require("../utils/generic_utils");
@@ -38153,7 +40497,7 @@ function convertTsToPythonic(tsConfig, key) {
 }
 exports.convertTsToPythonic = convertTsToPythonic;
 
-},{"../utils/generic_utils":238}],242:[function(require,module,exports){
+},{"../utils/generic_utils":262}],266:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -38201,7 +40545,7 @@ function getExactlyOneShape(shapes) {
 }
 exports.getExactlyOneShape = getExactlyOneShape;
 
-},{"../errors":210}],243:[function(require,module,exports){
+},{"../errors":233}],267:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function countParamsInWeights(weights) {
@@ -38219,7 +40563,7 @@ function countParamsInWeights(weights) {
 }
 exports.countParamsInWeights = countParamsInWeights;
 
-},{}],244:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38312,8 +40656,9 @@ function truncatedNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'truncatedNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38322,8 +40667,9 @@ function randomNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'randomNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38358,13 +40704,13 @@ function gradients(lossFn, variables) {
 }
 exports.gradients = gradients;
 
-},{"./backend/state":199,"./common":203,"./errors":210,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
+},{"./backend/state":219,"./common":223,"./errors":233,"@tensorflow/tfjs-core":68}],269:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.7.5';
+var version = '0.8.3';
 exports.version = version;
 
-},{}],246:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -38384,13 +40730,13 @@ exports.version = {
     'tfjs': version_1.version
 };
 
-},{"./version":247,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":217}],247:[function(require,module,exports){
+},{"./version":271,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":241}],271:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.7';
+var version = '0.13.3';
 exports.version = version;
 
-},{}],248:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -38508,7 +40854,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],249:[function(require,module,exports){
+},{}],273:[function(require,module,exports){
 /**
  * Bit twiddling hacks for JavaScript.
  *
@@ -38714,9 +41060,9 @@ exports.nextCombination = function(v) {
 }
 
 
-},{}],250:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 
-},{}],251:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -40454,7 +42800,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":248,"ieee754":259}],252:[function(require,module,exports){
+},{"base64-js":272,"ieee754":283}],276:[function(require,module,exports){
 "use strict"
 
 var createThunk = require("./lib/thunk.js")
@@ -40565,7 +42911,7 @@ function compileCwise(user_args) {
 
 module.exports = compileCwise
 
-},{"./lib/thunk.js":254}],253:[function(require,module,exports){
+},{"./lib/thunk.js":278}],277:[function(require,module,exports){
 "use strict"
 
 var uniq = require("uniq")
@@ -40925,7 +43271,7 @@ function generateCWiseOp(proc, typesig) {
 }
 module.exports = generateCWiseOp
 
-},{"uniq":300}],254:[function(require,module,exports){
+},{"uniq":324}],278:[function(require,module,exports){
 "use strict"
 
 // The function below is called when constructing a cwise function object, and does the following:
@@ -41013,9 +43359,9 @@ function createThunk(proc) {
 
 module.exports = createThunk
 
-},{"./compile.js":253}],255:[function(require,module,exports){
+},{"./compile.js":277}],279:[function(require,module,exports){
 module.exports = require("cwise-compiler")
-},{"cwise-compiler":252}],256:[function(require,module,exports){
+},{"cwise-compiler":276}],280:[function(require,module,exports){
 "use strict"
 
 function dupe_array(count, value, i) {
@@ -41065,7 +43411,7 @@ function dupe(count, value) {
 }
 
 module.exports = dupe
-},{}],257:[function(require,module,exports){
+},{}],281:[function(require,module,exports){
 'use strict';
 
 function FFT(size) {
@@ -41574,7 +43920,7 @@ FFT.prototype._singleRealTransform4 = function _singleRealTransform4(outOff,
   out[outOff + 7] = FDi;
 };
 
-},{}],258:[function(require,module,exports){
+},{}],282:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 1.3.2
@@ -41764,7 +44110,7 @@ if (typeof module !== "undefined" && module.exports) {
   });
 }
 
-},{}],259:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -41850,7 +44196,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],260:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 "use strict"
 
 function iota(n) {
@@ -41862,7 +44208,7 @@ function iota(n) {
 }
 
 module.exports = iota
-},{}],261:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -41885,10 +44231,10 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],262:[function(require,module,exports){
+},{}],286:[function(require,module,exports){
 !function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.MidiConvert=e():t.MidiConvert=e()}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="",e(e.s=7)}([function(t,e,n){"use strict";n.d(e,"a",function(){return r}),n.d(e,"b",function(){return i}),n.d(e,"c",function(){return a});var r=["acoustic grand piano","bright acoustic piano","electric grand piano","honky-tonk piano","electric piano 1","electric piano 2","harpsichord","clavi","celesta","glockenspiel","music box","vibraphone","marimba","xylophone","tubular bells","dulcimer","drawbar organ","percussive organ","rock organ","church organ","reed organ","accordion","harmonica","tango accordion","acoustic guitar (nylon)","acoustic guitar (steel)","electric guitar (jazz)","electric guitar (clean)","electric guitar (muted)","overdriven guitar","distortion guitar","guitar harmonics","acoustic bass","electric bass (finger)","electric bass (pick)","fretless bass","slap bass 1","slap bass 2","synth bass 1","synth bass 2","violin","viola","cello","contrabass","tremolo strings","pizzicato strings","orchestral harp","timpani","string ensemble 1","string ensemble 2","synthstrings 1","synthstrings 2","choir aahs","voice oohs","synth voice","orchestra hit","trumpet","trombone","tuba","muted trumpet","french horn","brass section","synthbrass 1","synthbrass 2","soprano sax","alto sax","tenor sax","baritone sax","oboe","english horn","bassoon","clarinet","piccolo","flute","recorder","pan flute","blown bottle","shakuhachi","whistle","ocarina","lead 1 (square)","lead 2 (sawtooth)","lead 3 (calliope)","lead 4 (chiff)","lead 5 (charang)","lead 6 (voice)","lead 7 (fifths)","lead 8 (bass + lead)","pad 1 (new age)","pad 2 (warm)","pad 3 (polysynth)","pad 4 (choir)","pad 5 (bowed)","pad 6 (metallic)","pad 7 (halo)","pad 8 (sweep)","fx 1 (rain)","fx 2 (soundtrack)","fx 3 (crystal)","fx 4 (atmosphere)","fx 5 (brightness)","fx 6 (goblins)","fx 7 (echoes)","fx 8 (sci-fi)","sitar","banjo","shamisen","koto","kalimba","bag pipe","fiddle","shanai","tinkle bell","agogo","steel drums","woodblock","taiko drum","melodic tom","synth drum","reverse cymbal","guitar fret noise","breath noise","seashore","bird tweet","telephone ring","helicopter","applause","gunshot"],i=["piano","chromatic percussion","organ","guitar","bass","strings","ensemble","brass","reed","pipe","synth lead","synth pad","synth effects","ethnic","percussive","sound effects"],a={0:"standard kit",8:"room kit",16:"power kit",24:"electronic kit",25:"tr-808 kit",32:"jazz kit",40:"brush kit",48:"orchestra kit",56:"sound fx kit"}},function(t,e,n){"use strict";function r(t){return t.replace(/\u0000/g,"")}function i(t,e){return 60/e.bpm*(t/e.PPQ)}function a(t){return"number"==typeof t}function o(t){return"string"==typeof t}function s(t){return["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"][t%12]+(Math.floor(t/12)-1)}e.b=r,e.a=i,e.c=a,n.d(e,"d",function(){return u}),e.e=s,n.d(e,"f",function(){return c});var u=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i;return function(e){return o(e)&&t.test(e)}}(),c=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,e={cbb:-2,cb:-1,c:0,"c#":1,cx:2,dbb:0,db:1,d:2,"d#":3,dx:4,ebb:2,eb:3,e:4,"e#":5,ex:6,fbb:3,fb:4,f:5,"f#":6,fx:7,gbb:5,gb:6,g:7,"g#":8,gx:9,abb:7,ab:8,a:9,"a#":10,ax:11,bbb:9,bb:10,b:11,"b#":12,bx:13};return function(n){var r=t.exec(n),i=r[1],a=r[2];return e[i.toLowerCase()]+12*(parseInt(a)+1)}}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(11),a=(n.n(i),n(10)),o=(n.n(a),n(1)),s=n(9),u=n(5),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(){r(this,t),this.header={bpm:120,timeSignature:[4,4],PPQ:480},this.tracks=[]}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t;return n.header=e.header,e.tracks.forEach(function(t){var e=s.a.fromJSON(t);n.tracks.push(e)}),n}}]),c(t,[{key:"load",value:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:null,r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"GET";return new Promise(function(i,a){var o=new XMLHttpRequest;o.open(r,t),o.responseType="arraybuffer",o.addEventListener("load",function(){4===o.readyState&&200===o.status?i(e.decode(o.response)):a(o.status)}),o.addEventListener("error",a),o.send(n)}).catch(function(t){console.log(t)})}},{key:"decode",value:function(t){var e=this;if(t instanceof ArrayBuffer){var r=new Uint8Array(t);t=String.fromCharCode.apply(null,r)}var a=i(t);return this.header=n.i(u.a)(a),this.tracks=[],a.tracks.forEach(function(t,n){var r=new s.a;r.id=n,e.tracks.push(r);var i=0;t.forEach(function(t){i+=o.a(t.deltaTime,e.header),"meta"===t.type&&"trackName"===t.subtype?r.name=o.b(t.text):"noteOn"===t.subtype?(r.noteOn(t.noteNumber,i,t.velocity/127),-1===r.channelNumber&&(r.channelNumber=t.channel)):"noteOff"===t.subtype?r.noteOff(t.noteNumber,i):"controller"===t.subtype&&t.controllerType?r.cc(t.controllerType,i,t.value/127):"meta"===t.type&&"instrumentName"===t.subtype?r.instrument=t.text:"channel"===t.type&&"programChange"===t.subtype&&(r.patch(t.programNumber),r.channelNumber=t.channel)}),e.header.name||r.length||!r.name||(e.header.name=r.name)}),this}},{key:"encode",value:function(){var t=this,e=new a.File({ticks:this.header.PPQ}),n=this.tracks.filter(function(t){return!t.length})[0];if(this.header.name&&(!n||n.name!==this.header.name)){e.addTrack().addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:this.header.name}))}return this.tracks.forEach(function(n){var r=e.addTrack();r.setTempo(t.bpm),n.name&&r.addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:n.name})),n.encode(r,t.header)}),e.toBytes()}},{key:"toArray",value:function(){for(var t=this.encode(),e=new Array(t.length),n=0;n<t.length;n++)e[n]=t.charCodeAt(n);return e}},{key:"toJSON",value:function(){var t={header:this.header,startTime:this.startTime,duration:this.duration,tracks:(this.tracks||[]).map(function(t){return t.toJSON()})};return t.header.name||(t.header.name=""),t}},{key:"track",value:function(t){var e=new s.a(t);return this.tracks.push(e),e}},{key:"get",value:function(t){return o.c(t)?this.tracks[t]:this.tracks.find(function(e){return e.name===t})}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=new t;return r.header=this.header,r.tracks=this.tracks.map(function(t){return t.slice(e,n)}),r}},{key:"startTime",get:function(){var t=this.tracks.map(function(t){return t.startTime});return t.length?Math.min.apply(Math,t)||0:0}},{key:"bpm",get:function(){return this.header.bpm},set:function(t){var e=this.header.bpm;this.header.bpm=t;var n=e/t;this.tracks.forEach(function(t){return t.scale(n)})}},{key:"timeSignature",get:function(){return this.header.timeSignature},set:function(t){this.header.timeSignature=t}},{key:"duration",get:function(){var t=this.tracks.map(function(t){return t.duration});return t.length?Math.max.apply(Math,t)||0:0}}]),t}()},function(t,e,n){"use strict";function r(t,e){var n=0,r=t.length,i=r;if(r>0&&t[r-1].time<=e)return r-1;for(;n<i;){var a=Math.floor(n+(i-n)/2),o=t[a],s=t[a+1];if(o.time===e){for(var u=a;u<t.length;u++){t[u].time===e&&(a=u)}return a}if(o.time<e&&s.time>e)return a;o.time>e?i=a:o.time<e&&(n=a+1)}return-1}function i(t,e){if(t.length){var n=r(t,e.time);t.splice(n+1,0,e)}else t.push(e)}n.d(e,"a",function(){return i})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),a={1:"modulationWheel",2:"breath",4:"footController",5:"portamentoTime",7:"volume",8:"balance",10:"pan",64:"sustain",65:"portamentoTime",66:"sostenuto",67:"softPedal",68:"legatoFootswitch",84:"portamentoContro"},o=function(){function t(e,n,i){r(this,t),this.number=e,this.time=n,this.value=i}return i(t,[{key:"name",get:function(){if(a.hasOwnProperty(this.number))return a[this.number]}}]),t}()},function(t,e,n){"use strict";function r(t){for(var e={PPQ:t.header.ticksPerBeat},n=0;n<t.tracks.length;n++)for(var r=t.tracks[n],i=0;i<r.length;i++){var a=r[i];"meta"===a.type&&("timeSignature"===a.subtype?e.timeSignature=[a.numerator,a.denominator]:"setTempo"===a.subtype&&(e.bpm||(e.bpm=6e7/a.microsecondsPerBeat)))}return e.bpm=e.bpm||120,e}n.d(e,"a",function(){return r})},function(t,e,n){"use strict";function r(t,e){for(var n=0;n<t.length;n++){var r=t[n],i=e[n];if(r.length>i)return!0}return!1}function i(t,e,n){for(var r=0,i=1/0,a=0;a<t.length;a++){var o=t[a],s=e[a];o[s]&&o[s].time<i&&(r=a,i=o[s].time)}n[r](t[r][e[r]]),e[r]+=1}function a(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];for(var a=e.filter(function(t,e){return e%2==0}),o=new Uint32Array(a.length),s=e.filter(function(t,e){return e%2==1});r(a,o);)i(a,o,s)}n.d(e,"a",function(){return a})},function(t,e,n){"use strict";function r(t){return(new s.a).decode(t)}function i(t,e){var n=(new s.a).load(t);return e&&n.then(e),n}function a(){return new s.a}function o(t){return s.a.fromJSON(t)}Object.defineProperty(e,"__esModule",{value:!0}),e.parse=r,e.load=i,e.create=a,e.fromJSON=o;var s=n(2),u=n(0);n.d(e,"instrumentByPatchID",function(){return u.a}),n.d(e,"instrumentFamilyByID",function(){return u.b}),n.d(e,"drumKitByPatchID",function(){return u.c})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=n(1),a=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),o=function(){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1;if(r(this,t),i.c(e))this.midi=e;else{if(!i.d(e))throw new Error("the midi value must either be in Pitch Notation (e.g. C#4) or a midi value");this.name=e}this.time=n,this.duration=a,this.velocity=o}return a(t,null,[{key:"fromJSON",value:function(e){return new t(e.midi,e.time,e.duration,e.velocity)}}]),a(t,[{key:"match",value:function(t){return i.c(t)?this.midi===t:i.d(t)?this.name.toLowerCase()===t.toLowerCase():void 0}},{key:"toJSON",value:function(){return{name:this.name,midi:this.midi,time:this.time,velocity:this.velocity,duration:this.duration}}},{key:"name",get:function(){return i.e(this.midi)},set:function(t){this.midi=i.f(t)}},{key:"noteOn",get:function(){return this.time},set:function(t){this.time=t}},{key:"noteOff",get:function(){return this.time+this.duration},set:function(t){this.duration=t-this.time}}]),t}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(3),a=n(4),o=n(6),s=n(8),u=n(0),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:-1,i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:-1;r(this,t),this.name=e,this.channelNumber=i,this.notes=[],this.controlChanges={},this.instrumentNumber=n}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t(e.name,e.instrumentNumber,e.channelNumber);return n.id=e.id,e.notes&&e.notes.forEach(function(t){var e=s.a.fromJSON(t);n.notes.push(e)}),e.controlChanges&&(n.controlChanges=e.controlChanges),n}}]),c(t,[{key:"note",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,a=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1,o=new s.a(t,e,r,a);return n.i(i.a)(this.notes,o),this}},{key:"noteOn",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:1,a=new s.a(t,e,0,r);return n.i(i.a)(this.notes,a),this}},{key:"noteOff",value:function(t,e){for(var n=0;n<this.notes.length;n++){var r=this.notes[n];if(r.match(t)&&0===r.duration){r.noteOff=e;break}}return this}},{key:"cc",value:function(t,e,r){this.controlChanges.hasOwnProperty(t)||(this.controlChanges[t]=[]);var o=new a.a(t,e,r);return n.i(i.a)(this.controlChanges[t],o),this}},{key:"patch",value:function(t){return this.instrumentNumber=t,this}},{key:"channel",value:function(t){return this.channelNumber=t,this}},{key:"scale",value:function(t){return this.notes.forEach(function(e){e.time*=t,e.duration*=t}),this}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=Math.max(this.notes.findIndex(function(t){return t.time>=e}),0),i=this.notes.findIndex(function(t){return t.noteOff>=n})+1,a=new t(this.name);return a.notes=this.notes.slice(r,i),a.notes.forEach(function(t){return t.time=t.time-e}),a}},{key:"encode",value:function(t,e){function r(t){var e=Math.floor(i*t),n=Math.max(e-a,0);return a=e,n}var i=e.PPQ/(60/e.bpm),a=0,s=Math.max(0,this.channelNumber);-1!==this.instrumentNumber&&t.instrument(s,this.instrumentNumber),n.i(o.a)(this.noteOns.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOn(s,e.name,r(e.time),Math.floor(127*e.velocity))},this.noteOffs.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOff(s,e.name,r(e.time))})}},{key:"toJSON",value:function(){var t={startTime:this.startTime,duration:this.duration,length:this.length,notes:[],controlChanges:{}};return void 0!==this.id&&(t.id=this.id),t.name=this.name,-1!==this.instrumentNumber&&(t.instrumentNumber=this.instrumentNumber,t.instrument=this.instrument,t.instrumentFamily=this.instrumentFamily),-1!==this.channelNumber&&(t.channelNumber=this.channelNumber,t.isPercussion=this.isPercussion),this.notes.length&&(t.notes=this.notes.map(function(t){return t.toJSON()})),Object.keys(this.controlChanges).length&&(t.controlChanges=this.controlChanges),t}},{key:"noteOns",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOn,midi:e.midi,name:e.name,velocity:e.velocity})}),t}},{key:"noteOffs",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOff,midi:e.midi,name:e.name})}),t}},{key:"length",get:function(){return this.notes.length}},{key:"startTime",get:function(){if(this.notes.length){return this.notes[0].noteOn}return 0}},{key:"duration",get:function(){if(this.notes.length){return this.notes[this.notes.length-1].noteOff}return 0}},{key:"instrument",get:function(){return this.isPercussion?u.c[this.instrumentNumber]:u.a[this.instrumentNumber]},set:function(t){var e=u.a.indexOf(t);-1!==e&&(this.instrumentNumber=e)}},{key:"isPercussion",get:function(){return[9,10].includes(this.channelNumber)}},{key:"instrumentFamily",get:function(){return this.isPercussion?"drums":u.b[Math.floor(this.instrumentNumber/8)]}}]),t}()},function(t,e,n){(function(t){var n={};!function(t){var e=t.DEFAULT_VOLUME=90,n=(t.DEFAULT_DURATION=128,t.DEFAULT_CHANNEL=0,{midi_letter_pitches:{a:21,b:23,c:12,d:14,e:16,f:17,g:19},midiPitchFromNote:function(t){var e=/([a-g])(#+|b+)?([0-9]+)$/i.exec(t),r=e[1].toLowerCase(),i=e[2]||"";return 12*parseInt(e[3],10)+n.midi_letter_pitches[r]+("#"==i.substr(0,1)?1:-1)*i.length},ensureMidiPitch:function(t){return"number"!=typeof t&&/[^0-9]/.test(t)?n.midiPitchFromNote(t):parseInt(t,10)},midi_pitches_letter:{12:"c",13:"c#",14:"d",15:"d#",16:"e",17:"f",18:"f#",19:"g",20:"g#",21:"a",22:"a#",23:"b"},midi_flattened_notes:{"a#":"bb","c#":"db","d#":"eb","f#":"gb","g#":"ab"},noteFromMidiPitch:function(t,e){var r,i=0,a=t,e=e||!1;return t>23&&(i=Math.floor(t/12)-1,a=t-12*i),r=n.midi_pitches_letter[a],e&&r.indexOf("#")>0&&(r=n.midi_flattened_notes[r]),r+i},mpqnFromBpm:function(t){var e=Math.floor(6e7/t),n=[];do{n.unshift(255&e),e>>=8}while(e);for(;n.length<3;)n.push(0);return n},bpmFromMpqn:function(t){var e=t;if(void 0!==t[0]){e=0;for(var n=0,r=t.length-1;r>=0;++n,--r)e|=t[n]<<r}return Math.floor(6e7/t)},codes2Str:function(t){return String.fromCharCode.apply(null,t)},str2Bytes:function(t,e){if(e)for(;t.length/2<e;)t="0"+t;for(var n=[],r=t.length-1;r>=0;r-=2){var i=0===r?t[r]:t[r-1]+t[r];n.unshift(parseInt(i,16))}return n},translateTickTime:function(t){for(var e=127&t;t>>=7;)e<<=8,e|=127&t|128;for(var n=[];;){if(n.push(255&e),!(128&e))break;e>>=8}return n}}),r=function(t){if(!this)return new r(t);!t||null===t.type&&void 0===t.type||null===t.channel&&void 0===t.channel||null===t.param1&&void 0===t.param1||(this.setTime(t.time),this.setType(t.type),this.setChannel(t.channel),this.setParam1(t.param1),this.setParam2(t.param2))};r.NOTE_OFF=128,r.NOTE_ON=144,r.AFTER_TOUCH=160,r.CONTROLLER=176,r.PROGRAM_CHANGE=192,r.CHANNEL_AFTERTOUCH=208,r.PITCH_BEND=224,r.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},r.prototype.setType=function(t){if(t<r.NOTE_OFF||t>r.PITCH_BEND)throw new Error("Trying to set an unknown event: "+t);this.type=t},r.prototype.setChannel=function(t){if(t<0||t>15)throw new Error("Channel is out of bounds.");this.channel=t},r.prototype.setParam1=function(t){this.param1=t},r.prototype.setParam2=function(t){this.param2=t},r.prototype.toBytes=function(){var t=[],e=this.type|15&this.channel;return t.push.apply(t,this.time),t.push(e),t.push(this.param1),void 0!==this.param2&&null!==this.param2&&t.push(this.param2),t};var i=function(t){if(!this)return new i(t);this.setTime(t.time),this.setType(t.type),this.setData(t.data)};i.SEQUENCE=0,i.TEXT=1,i.COPYRIGHT=2,i.TRACK_NAME=3,i.INSTRUMENT=4,i.LYRIC=5,i.MARKER=6,i.CUE_POINT=7,i.CHANNEL_PREFIX=32,i.END_OF_TRACK=47,i.TEMPO=81,i.SMPTE=84,i.TIME_SIG=88,i.KEY_SIG=89,i.SEQ_EVENT=127,i.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},i.prototype.setType=function(t){this.type=t},i.prototype.setData=function(t){this.data=t},i.prototype.toBytes=function(){if(!this.type)throw new Error("Type for meta-event not specified.");var t=[];if(t.push.apply(t,this.time),t.push(255,this.type),Array.isArray(this.data))t.push(this.data.length),t.push.apply(t,this.data);else if("number"==typeof this.data)t.push(1,this.data);else if(null!==this.data&&void 0!==this.data){t.push(this.data.length);var e=this.data.split("").map(function(t){return t.charCodeAt(0)});t.push.apply(t,e)}else t.push(0);return t};var a=function(t){if(!this)return new a(t);var e=t||{};this.events=e.events||[]};a.START_BYTES=[77,84,114,107],a.END_BYTES=[0,255,47,0],a.prototype.addEvent=function(t){return this.events.push(t),this},a.prototype.addNoteOn=a.prototype.noteOn=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_ON,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNoteOff=a.prototype.noteOff=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_OFF,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNote=a.prototype.note=function(t,e,n,r,i){return this.noteOn(t,e,r,i),n&&this.noteOff(t,e,n,i),this},a.prototype.addChord=a.prototype.chord=function(t,e,n,r){if(!Array.isArray(e)&&!e.length)throw new Error("Chord must be an array of pitches");return e.forEach(function(e){this.noteOn(t,e,0,r)},this),e.forEach(function(e,r){0===r?this.noteOff(t,e,n):this.noteOff(t,e)},this),this},a.prototype.setInstrument=a.prototype.instrument=function(t,e,n){return this.events.push(new r({type:r.PROGRAM_CHANGE,channel:t,param1:e,time:n||0})),this},a.prototype.setTempo=a.prototype.tempo=function(t,e){return this.events.push(new i({type:i.TEMPO,data:n.mpqnFromBpm(t),time:e||0})),this},a.prototype.toBytes=function(){var t=0,e=[],r=a.START_BYTES,i=a.END_BYTES,o=function(n){var r=n.toBytes();t+=r.length,e.push.apply(e,r)};this.events.forEach(o),t+=i.length;var s=n.str2Bytes(t.toString(16),4);return r.concat(s,e,i)};var o=function(t){if(!this)return new o(t);var e=t||{};if(e.ticks){if("number"!=typeof e.ticks)throw new Error("Ticks per beat must be a number!");if(e.ticks<=0||e.ticks>=32768||e.ticks%1!=0)throw new Error("Ticks per beat must be an integer between 1 and 32767!")}this.ticks=e.ticks||128,this.tracks=e.tracks||[]};o.HDR_CHUNKID="MThd",o.HDR_CHUNK_SIZE="\0\0\0",o.HDR_TYPE0="\0\0",o.HDR_TYPE1="\0",o.prototype.addTrack=function(t){return t?(this.tracks.push(t),this):(t=new a,this.tracks.push(t),t)},o.prototype.toBytes=function(){var t=this.tracks.length.toString(16),e=o.HDR_CHUNKID+o.HDR_CHUNK_SIZE;return parseInt(t,16)>1?e+=o.HDR_TYPE1:e+=o.HDR_TYPE0,e+=n.codes2Str(n.str2Bytes(t,2)),e+=String.fromCharCode(this.ticks/256,this.ticks%256),this.tracks.forEach(function(t){e+=n.codes2Str(t.toBytes())}),e},t.Util=n,t.File=o,t.Track=a,t.Event=r,t.MetaEvent=i}(n),void 0!==t&&null!==t?t.exports=n:void 0!==e&&null!==e?e=n:this.Midi=n}).call(e,n(12)(t))},function(t,e){function n(t){function e(t){var e=t.read(4),n=t.readInt32();return{id:e,length:n,data:t.read(n)}}var n;stream=r(t);var i=e(stream);if("MThd"!=i.id||6!=i.length)throw"Bad .mid file - header not found";var a=r(i.data),o=a.readInt16(),s=a.readInt16(),u=a.readInt16();if(32768&u)throw"Expressing time division in SMTPE frames is not supported yet";ticksPerBeat=u;for(var c={formatType:o,trackCount:s,ticksPerBeat:ticksPerBeat},h=[],f=0;f<c.trackCount;f++){h[f]=[];var d=e(stream);if("MTrk"!=d.id)throw"Unexpected chunk - expected MTrk, got "+d.id;for(var l=r(d.data);!l.eof();){var p=function(t){var e={};e.deltaTime=t.readVarInt();var r=t.readInt8();if(240==(240&r)){if(255==r){e.type="meta";var i=t.readInt8(),a=t.readVarInt();switch(i){case 0:if(e.subtype="sequenceNumber",2!=a)throw"Expected length for sequenceNumber event is 2, got "+a;return e.number=t.readInt16(),e;case 1:return e.subtype="text",e.text=t.read(a),e;case 2:return e.subtype="copyrightNotice",e.text=t.read(a),e;case 3:return e.subtype="trackName",e.text=t.read(a),e;case 4:return e.subtype="instrumentName",e.text=t.read(a),e;case 5:return e.subtype="lyrics",e.text=t.read(a),e;case 6:return e.subtype="marker",e.text=t.read(a),e;case 7:return e.subtype="cuePoint",e.text=t.read(a),e;case 32:if(e.subtype="midiChannelPrefix",1!=a)throw"Expected length for midiChannelPrefix event is 1, got "+a;return e.channel=t.readInt8(),e;case 47:if(e.subtype="endOfTrack",0!=a)throw"Expected length for endOfTrack event is 0, got "+a;return e;case 81:if(e.subtype="setTempo",3!=a)throw"Expected length for setTempo event is 3, got "+a;return e.microsecondsPerBeat=(t.readInt8()<<16)+(t.readInt8()<<8)+t.readInt8(),e;case 84:if(e.subtype="smpteOffset",5!=a)throw"Expected length for smpteOffset event is 5, got "+a;var o=t.readInt8();return e.frameRate={0:24,32:25,64:29,96:30}[96&o],e.hour=31&o,e.min=t.readInt8(),e.sec=t.readInt8(),e.frame=t.readInt8(),e.subframe=t.readInt8(),e;case 88:if(e.subtype="timeSignature",4!=a)throw"Expected length for timeSignature event is 4, got "+a;return e.numerator=t.readInt8(),e.denominator=Math.pow(2,t.readInt8()),e.metronome=t.readInt8(),e.thirtyseconds=t.readInt8(),e;case 89:if(e.subtype="keySignature",2!=a)throw"Expected length for keySignature event is 2, got "+a;return e.key=t.readInt8(!0),e.scale=t.readInt8(),e;case 127:return e.subtype="sequencerSpecific",e.data=t.read(a),e;default:return e.subtype="unknown",e.data=t.read(a),e}return e.data=t.read(a),e}if(240==r){e.type="sysEx";var a=t.readVarInt();return e.data=t.read(a),e}if(247==r){e.type="dividedSysEx";var a=t.readVarInt();return e.data=t.read(a),e}throw"Unrecognised MIDI event type byte: "+r}var s;0==(128&r)?(s=r,r=n):(s=t.readInt8(),n=r);var u=r>>4;switch(e.channel=15&r,e.type="channel",u){case 8:return e.subtype="noteOff",e.noteNumber=s,e.velocity=t.readInt8(),e;case 9:return e.noteNumber=s,e.velocity=t.readInt8(),0==e.velocity?e.subtype="noteOff":e.subtype="noteOn",e;case 10:return e.subtype="noteAftertouch",e.noteNumber=s,e.amount=t.readInt8(),e;case 11:return e.subtype="controller",e.controllerType=s,e.value=t.readInt8(),e;case 12:return e.subtype="programChange",e.programNumber=s,e;case 13:return e.subtype="channelAftertouch",e.amount=s,e;case 14:return e.subtype="pitchBend",e.value=s+(t.readInt8()<<7),e;default:throw"Unrecognised MIDI event type: "+u}}(l);h[f].push(p)}}return{header:c,tracks:h}}function r(t){function e(e){var n=t.substr(s,e);return s+=e,n}function n(){var e=(t.charCodeAt(s)<<24)+(t.charCodeAt(s+1)<<16)+(t.charCodeAt(s+2)<<8)+t.charCodeAt(s+3);return s+=4,e}function r(){var e=(t.charCodeAt(s)<<8)+t.charCodeAt(s+1);return s+=2,e}function i(e){var n=t.charCodeAt(s);return e&&n>127&&(n-=256),s+=1,n}function a(){return s>=t.length}function o(){for(var t=0;;){var e=i();if(!(128&e))return t+e;t+=127&e,t<<=7}}var s=0;return{eof:a,read:e,readInt32:n,readInt16:r,readInt8:i,readVarInt:o}}t.exports=function(t){return n(t)}},function(t,e){t.exports=function(t){return t.webpackPolyfill||(t.deprecate=function(){},t.paths=[],t.children||(t.children=[]),Object.defineProperty(t,"loaded",{enumerable:!0,get:function(){return t.l}}),Object.defineProperty(t,"id",{enumerable:!0,get:function(){return t.i}}),t.webpackPolyfill=1),t}}])});
 
-},{}],263:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 'use strict'
 
 var ops = require('ndarray-ops')
@@ -41971,7 +44317,7 @@ function ndfft(dir, x, y) {
 }
 
 module.exports = ndfft
-},{"./lib/fft-matrix.js":264,"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],264:[function(require,module,exports){
+},{"./lib/fft-matrix.js":288,"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],288:[function(require,module,exports){
 var bits = require('bit-twiddle')
 
 function fft(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
@@ -42190,7 +44536,7 @@ function fftBluestein(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
   }
 }
 
-},{"bit-twiddle":249}],265:[function(require,module,exports){
+},{"bit-twiddle":273}],289:[function(require,module,exports){
 "use strict"
 
 var compile = require("cwise-compiler")
@@ -42653,7 +44999,7 @@ exports.equals = compile({
 
 
 
-},{"cwise-compiler":252}],266:[function(require,module,exports){
+},{"cwise-compiler":276}],290:[function(require,module,exports){
 "use strict"
 
 var fft = require("ndarray-fft")
@@ -42757,7 +45103,7 @@ function resample(out, inp, clamp_lo, clamp_hi) {
 }
 
 module.exports = resample
-},{"cwise/lib/wrapper":255,"ndarray-fft":263,"ndarray-ops":265,"ndarray-scratch":267}],267:[function(require,module,exports){
+},{"cwise/lib/wrapper":279,"ndarray-fft":287,"ndarray-ops":289,"ndarray-scratch":291}],291:[function(require,module,exports){
 "use strict"
 
 var ndarray = require("ndarray")
@@ -42865,7 +45211,7 @@ function eye(shape, dtype) {
 }
 exports.eye = eye
 
-},{"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],268:[function(require,module,exports){
+},{"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],292:[function(require,module,exports){
 var iota = require("iota-array")
 var isBuffer = require("is-buffer")
 
@@ -43210,7 +45556,7 @@ function wrappedNDArrayCtor(data, shape, stride, offset) {
 
 module.exports = wrappedNDArrayCtor
 
-},{"iota-array":260,"is-buffer":261}],269:[function(require,module,exports){
+},{"iota-array":284,"is-buffer":285}],293:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -43396,9 +45742,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],270:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 arguments[4][50][0].apply(exports,arguments)
-},{"./src/index-minimal":271,"dup":50}],271:[function(require,module,exports){
+},{"./src/index-minimal":295,"dup":50}],295:[function(require,module,exports){
 "use strict";
 var protobuf = exports;
 
@@ -43436,7 +45782,7 @@ function configure() {
 protobuf.Writer._configure(protobuf.BufferWriter);
 configure();
 
-},{"./reader":272,"./reader_buffer":273,"./roots":274,"./rpc":275,"./util/minimal":278,"./writer":279,"./writer_buffer":280}],272:[function(require,module,exports){
+},{"./reader":296,"./reader_buffer":297,"./roots":298,"./rpc":299,"./util/minimal":302,"./writer":303,"./writer_buffer":304}],296:[function(require,module,exports){
 "use strict";
 module.exports = Reader;
 
@@ -43845,17 +46191,17 @@ Reader._configure = function(BufferReader_) {
     });
 };
 
-},{"./util/minimal":278}],273:[function(require,module,exports){
+},{"./util/minimal":302}],297:[function(require,module,exports){
 arguments[4][53][0].apply(exports,arguments)
-},{"./reader":272,"./util/minimal":278,"dup":53}],274:[function(require,module,exports){
+},{"./reader":296,"./util/minimal":302,"dup":53}],298:[function(require,module,exports){
 arguments[4][54][0].apply(exports,arguments)
-},{"dup":54}],275:[function(require,module,exports){
+},{"dup":54}],299:[function(require,module,exports){
 arguments[4][55][0].apply(exports,arguments)
-},{"./rpc/service":276,"dup":55}],276:[function(require,module,exports){
+},{"./rpc/service":300,"dup":55}],300:[function(require,module,exports){
 arguments[4][56][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":56}],277:[function(require,module,exports){
+},{"../util/minimal":302,"dup":56}],301:[function(require,module,exports){
 arguments[4][57][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":57}],278:[function(require,module,exports){
+},{"../util/minimal":302,"dup":57}],302:[function(require,module,exports){
 (function (global){
 "use strict";
 var util = exports;
@@ -44264,11 +46610,11 @@ util._configure = function() {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./longbits":277,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],279:[function(require,module,exports){
+},{"./longbits":301,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],303:[function(require,module,exports){
 arguments[4][59][0].apply(exports,arguments)
-},{"./util/minimal":278,"dup":59}],280:[function(require,module,exports){
+},{"./util/minimal":302,"dup":59}],304:[function(require,module,exports){
 arguments[4][60][0].apply(exports,arguments)
-},{"./util/minimal":278,"./writer":279,"dup":60}],281:[function(require,module,exports){
+},{"./util/minimal":302,"./writer":303,"dup":60}],305:[function(require,module,exports){
 // A library of seedable RNGs implemented in Javascript.
 //
 // Usage:
@@ -44330,7 +46676,7 @@ sr.tychei = tychei;
 
 module.exports = sr;
 
-},{"./lib/alea":282,"./lib/tychei":283,"./lib/xor128":284,"./lib/xor4096":285,"./lib/xorshift7":286,"./lib/xorwow":287,"./seedrandom":288}],282:[function(require,module,exports){
+},{"./lib/alea":306,"./lib/tychei":307,"./lib/xor128":308,"./lib/xor4096":309,"./lib/xorshift7":310,"./lib/xorwow":311,"./seedrandom":312}],306:[function(require,module,exports){
 // A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
 // http://baagoe.com/en/RandomMusings/javascript/
 // https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
@@ -44446,7 +46792,7 @@ if (module && module.exports) {
 
 
 
-},{}],283:[function(require,module,exports){
+},{}],307:[function(require,module,exports){
 // A Javascript implementaion of the "Tyche-i" prng algorithm by
 // Samuel Neves and Filipe Araujo.
 // See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
@@ -44551,7 +46897,7 @@ if (module && module.exports) {
 
 
 
-},{}],284:[function(require,module,exports){
+},{}],308:[function(require,module,exports){
 // A Javascript implementaion of the "xor128" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44634,7 +46980,7 @@ if (module && module.exports) {
 
 
 
-},{}],285:[function(require,module,exports){
+},{}],309:[function(require,module,exports){
 // A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
 //
 // This fast non-cryptographic random number generator is designed for
@@ -44782,7 +47128,7 @@ if (module && module.exports) {
   (typeof define) == 'function' && define   // present with an AMD loader
 );
 
-},{}],286:[function(require,module,exports){
+},{}],310:[function(require,module,exports){
 // A Javascript implementaion of the "xorshift7" algorithm by
 // François Panneton and Pierre L'ecuyer:
 // "On the Xorgshift Random Number Generators"
@@ -44881,7 +47227,7 @@ if (module && module.exports) {
 );
 
 
-},{}],287:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 // A Javascript implementaion of the "xorwow" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44969,7 +47315,7 @@ if (module && module.exports) {
 
 
 
-},{}],288:[function(require,module,exports){
+},{}],312:[function(require,module,exports){
 /*
 Copyright 2014 David Bau.
 
@@ -45218,7 +47564,7 @@ if ((typeof module) == 'object' && module.exports) {
   Math    // math: package containing random, pow, and seedrandom
 );
 
-},{"crypto":250}],289:[function(require,module,exports){
+},{"crypto":274}],313:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45374,7 +47720,7 @@ exports.unique = unique;
 exports.shuffle = shuffle;
 exports.permutations = permutations;
 
-},{"tonal-note":294}],290:[function(require,module,exports){
+},{"tonal-note":318}],314:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45566,7 +47912,7 @@ exports.supersets = supersets;
 exports.subsets = subsets;
 exports.tokenize = tokenize$1;
 
-},{"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],291:[function(require,module,exports){
+},{"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],315:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45938,7 +48284,7 @@ exports.scale = scale;
 exports.chord = chord;
 exports.pcset = pcset;
 
-},{"tonal-pcset":295}],292:[function(require,module,exports){
+},{"tonal-pcset":319}],316:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46217,7 +48563,7 @@ exports.subtract = subtract;
 exports.interval = interval;
 exports.semitones = semitones;
 
-},{"tonal-interval":293,"tonal-note":294}],293:[function(require,module,exports){
+},{"tonal-interval":317,"tonal-note":318}],317:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46558,7 +48904,7 @@ exports.simplify = simplify;
 exports.invert = invert;
 exports.fromSemitones = fromSemitones;
 
-},{}],294:[function(require,module,exports){
+},{}],318:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46973,7 +49319,7 @@ exports.fromMidi = fromMidi;
 exports.simplify = simplify;
 exports.enharmonic = enharmonic;
 
-},{}],295:[function(require,module,exports){
+},{}],319:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47202,7 +49548,7 @@ exports.isSupersetOf = isSupersetOf;
 exports.includes = includes;
 exports.filter = filter;
 
-},{"tonal-array":289,"tonal-interval":293,"tonal-note":294}],296:[function(require,module,exports){
+},{"tonal-array":313,"tonal-interval":317,"tonal-note":318}],320:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47439,7 +49785,7 @@ exports.toScale = toScale;
 exports.supersets = supersets;
 exports.subsets = subsets;
 
-},{"tonal-array":289,"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],297:[function(require,module,exports){
+},{"tonal-array":313,"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],321:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47577,7 +49923,7 @@ exports.freq = freq$1;
 exports.chord = chord$1;
 exports.scale = scale$1;
 
-},{"tonal-array":289,"tonal-chord":290,"tonal-dictionary":291,"tonal-distance":292,"tonal-interval":293,"tonal-note":294,"tonal-pcset":295,"tonal-scale":296}],298:[function(require,module,exports){
+},{"tonal-array":313,"tonal-chord":314,"tonal-dictionary":315,"tonal-distance":316,"tonal-interval":317,"tonal-note":318,"tonal-pcset":319,"tonal-scale":320}],322:[function(require,module,exports){
 (function(root, factory){
 
 	//UMD
@@ -71960,7 +74306,7 @@ exports.scale = scale$1;
 	
 	return Tone;
 }));
-},{}],299:[function(require,module,exports){
+},{}],323:[function(require,module,exports){
 (function (global,Buffer){
 'use strict'
 
@@ -72177,7 +74523,7 @@ exports.clearCache = function clearCache() {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"bit-twiddle":249,"buffer":251,"dup":256}],300:[function(require,module,exports){
+},{"bit-twiddle":273,"buffer":275,"dup":280}],324:[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -72236,7 +74582,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],301:[function(require,module,exports){
+},{}],325:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72284,7 +74630,7 @@ var BinaryCounter = (function (_super) {
 }(AuxiliaryInput));
 exports.BinaryCounter = BinaryCounter;
 
-},{"@tensorflow/tfjs-core":68}],302:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],326:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72478,7 +74824,7 @@ var PitchChordEncoder = (function (_super) {
 }(ChordEncoder));
 exports.PitchChordEncoder = PitchChordEncoder;
 
-},{"./constants":303,"@tensorflow/tfjs-core":68,"tonal":297}],303:[function(require,module,exports){
+},{"./constants":327,"@tensorflow/tfjs-core":68,"tonal":321}],327:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 null;
@@ -72506,7 +74852,7 @@ exports.HI_CLICK_PITCH = 90;
 exports.LO_CLICK_CLASS = 9;
 exports.HI_CLICK_CLASS = 10;
 
-},{}],304:[function(require,module,exports){
+},{}],328:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73078,7 +75424,7 @@ var MultitrackConverter = (function (_super) {
 }(DataConverter));
 exports.MultitrackConverter = MultitrackConverter;
 
-},{"../protobuf/index":320,"./constants":303,"./performance":308,"./sequences":311,"@tensorflow/tfjs-core":68}],305:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./performance":332,"./sequences":335,"@tensorflow/tfjs-core":68}],329:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -73103,7 +75449,7 @@ __export(require("./player"));
 __export(require("./recorder"));
 __export(require("./visualizer"));
 
-},{"./aux_inputs":301,"./chords":302,"./constants":303,"./data":304,"./logging":306,"./midi_io":307,"./performance":308,"./player":309,"./recorder":310,"./sequences":311,"./visualizer":313}],306:[function(require,module,exports){
+},{"./aux_inputs":325,"./chords":326,"./constants":327,"./data":328,"./logging":330,"./midi_io":331,"./performance":332,"./player":333,"./recorder":334,"./sequences":335,"./visualizer":337}],330:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Level;
@@ -73134,7 +75480,7 @@ function logWithDuration(msg, startTime, prefix, level) {
 }
 exports.logWithDuration = logWithDuration;
 
-},{}],307:[function(require,module,exports){
+},{}],331:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73280,7 +75626,7 @@ function sequenceProtoToMidi(ns) {
 }
 exports.sequenceProtoToMidi = sequenceProtoToMidi;
 
-},{"../protobuf":320,"./constants":303,"./sequences":311,"midiconvert":262}],308:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"./sequences":335,"midiconvert":286}],332:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var index_1 = require("../protobuf/index");
@@ -73483,7 +75829,7 @@ var Performance = (function () {
 }());
 exports.Performance = Performance;
 
-},{"../protobuf/index":320,"./constants":303,"./sequences":311}],309:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./sequences":335}],333:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73895,7 +76241,7 @@ var PlayerWithClick = (function (_super) {
 }(Player));
 exports.PlayerWithClick = PlayerWithClick;
 
-},{".":305,"./constants":303,"./data":304,"./soundfont":312,"tone":298}],310:[function(require,module,exports){
+},{".":329,"./constants":327,"./data":328,"./soundfont":336,"tone":322}],334:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74121,7 +76467,7 @@ var Recorder = (function () {
 }());
 exports.Recorder = Recorder;
 
-},{"../protobuf":320,"./constants":303,"tone":298}],311:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"tone":322}],335:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74392,7 +76738,7 @@ function mergeInstruments(ns) {
 }
 exports.mergeInstruments = mergeInstruments;
 
-},{"../protobuf/index":320,"./constants":303}],312:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327}],336:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74650,7 +76996,7 @@ var SoundFont = (function () {
 }());
 exports.SoundFont = SoundFont;
 
-},{"./constants":303,"tone":298}],313:[function(require,module,exports){
+},{"./constants":327,"tone":322}],337:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require(".");
@@ -74742,7 +77088,7 @@ var Visualizer = (function () {
 }());
 exports.Visualizer = Visualizer;
 
-},{".":305,"./constants":303}],314:[function(require,module,exports){
+},{".":329,"./constants":327}],338:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -74756,7 +77102,7 @@ __export(require("./music_vae"));
 __export(require("./protobuf"));
 __export(require("./transcription"));
 
-},{"./core":305,"./music_rnn":316,"./music_vae":318,"./protobuf":320,"./transcription":324,"@tensorflow/tfjs":246}],315:[function(require,module,exports){
+},{"./core":329,"./music_rnn":340,"./music_vae":342,"./protobuf":344,"./transcription":348,"@tensorflow/tfjs":270}],339:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tf = require("@tensorflow/tfjs-core");
@@ -74820,13 +77166,13 @@ var AttentionWrapper = (function () {
 }());
 exports.AttentionWrapper = AttentionWrapper;
 
-},{"@tensorflow/tfjs-core":68}],316:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],340:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.MusicRNN = model_1.MusicRNN;
 
-},{"./model":317}],317:[function(require,module,exports){
+},{"./model":341}],341:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -75125,7 +77471,7 @@ var MusicRNN = (function () {
 }());
 exports.MusicRNN = MusicRNN;
 
-},{"../core/aux_inputs":301,"../core/chords":302,"../core/data":304,"../core/logging":306,"../core/sequences":311,"./attention":315,"@tensorflow/tfjs-core":68}],318:[function(require,module,exports){
+},{"../core/aux_inputs":325,"../core/chords":326,"../core/data":328,"../core/logging":330,"../core/sequences":335,"./attention":339,"@tensorflow/tfjs-core":68}],342:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
@@ -75133,7 +77479,7 @@ exports.Decoder = model_1.Decoder;
 exports.Encoder = model_1.Encoder;
 exports.MusicVAE = model_1.MusicVAE;
 
-},{"./model":319}],319:[function(require,module,exports){
+},{"./model":343}],343:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -75877,14 +78223,14 @@ var MusicVAE = (function () {
 }());
 exports.MusicVAE = MusicVAE;
 
-},{"../core/chords":302,"../core/constants":303,"../core/data":304,"../core/logging":306,"@tensorflow/tfjs-core":68}],320:[function(require,module,exports){
+},{"../core/chords":326,"../core/constants":327,"../core/data":328,"../core/logging":330,"@tensorflow/tfjs-core":68}],344:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var proto_1 = require("./proto");
 var NoteSequence = proto_1.tensorflow.magenta.NoteSequence;
 exports.NoteSequence = NoteSequence;
 
-},{"./proto":321}],321:[function(require,module,exports){
+},{"./proto":345}],345:[function(require,module,exports){
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
@@ -81595,7 +83941,7 @@ $root.tensorflow = (function() {
 
 module.exports = $root;
 
-},{"protobufjs/minimal":270}],322:[function(require,module,exports){
+},{"protobufjs/minimal":294}],346:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -81974,7 +84320,7 @@ function max(arr) {
     return arr.reduce(function (a, b) { return Math.max(a, b); });
 }
 
-},{"../core/logging":306,"./constants":323,"fft.js":257,"ndarray":268,"ndarray-resample":266}],323:[function(require,module,exports){
+},{"../core/logging":330,"./constants":347,"fft.js":281,"ndarray":292,"ndarray-resample":290}],347:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SAMPLE_RATE = 16000;
@@ -81985,13 +84331,13 @@ exports.MIN_MIDI_PITCH = 21;
 exports.MAX_MIDI_PITCH = 108;
 exports.MIDI_PITCHES = exports.MAX_MIDI_PITCH - exports.MIN_MIDI_PITCH + 1;
 
-},{}],324:[function(require,module,exports){
+},{}],348:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.OnsetsAndFrames = model_1.OnsetsAndFrames;
 
-},{"./model":325}],325:[function(require,module,exports){
+},{"./model":349}],349:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82357,7 +84703,7 @@ var Lstm = (function () {
     return Lstm;
 }());
 
-},{"../core/logging":306,"./audio_utils":322,"./constants":323,"./transcription_utils":326,"@tensorflow/tfjs":246}],326:[function(require,module,exports){
+},{"../core/logging":330,"./audio_utils":346,"./constants":347,"./transcription_utils":350,"@tensorflow/tfjs":270}],350:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82527,4 +84873,4 @@ function pianorollToNoteSequence(frameProbs, onsetProbs, velocityValues, onsetTh
 }
 exports.pianorollToNoteSequence = pianorollToNoteSequence;
 
-},{"../protobuf":320,"./constants":323,"@tensorflow/tfjs":246}]},{},[1]);
+},{"../protobuf":344,"./constants":347,"@tensorflow/tfjs":270}]},{},[1]);

--- a/docs/music/demos/music_rnn_bundle.js
+++ b/docs/music/demos/music_rnn_bundle.js
@@ -418,7 +418,7 @@ function notesMatch(aNotes, bNotes) {
 }
 exports.notesMatch = notesMatch;
 
-},{"../src/index":314,"file-saver":258}],2:[function(require,module,exports){
+},{"../src/index":338,"file-saver":282}],2:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -633,7 +633,7 @@ catch (err) {
     console.error(err);
 }
 
-},{"../src/index":314,"./common":1,"@tensorflow/tfjs-core":68}],3:[function(require,module,exports){
+},{"../src/index":338,"./common":1,"@tensorflow/tfjs-core":68}],3:[function(require,module,exports){
 "use strict";
 module.exports = asPromise;
 
@@ -3383,7 +3383,7 @@ var FrozenModel = (function () {
         });
     };
     FrozenModel.prototype.predict = function (inputs, config) {
-        return this.execute(inputs, this.outputNodes);
+        return this.execute_(inputs, true, this.outputNodes);
     };
     FrozenModel.prototype.constructTensorMap = function (inputs) {
         var inputArray = inputs instanceof tfc.Tensor ? [inputs] : inputs;
@@ -3398,6 +3398,10 @@ var FrozenModel = (function () {
         }, {});
     };
     FrozenModel.prototype.execute = function (inputs, outputs) {
+        return this.execute_(inputs, false, outputs);
+    };
+    FrozenModel.prototype.execute_ = function (inputs, strictInputCheck, outputs) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         outputs = outputs || this.outputNodes;
         if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
             inputs = this.constructTensorMap(inputs);
@@ -3406,7 +3410,7 @@ var FrozenModel = (function () {
             throw new Error('The model contains control flow or dynamic shape ops, ' +
                 'please use executeAsync method');
         }
-        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), outputs);
+        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
         var keys = Object.keys(result);
         return (Array.isArray(outputs) && outputs.length > 1) ?
             outputs.map(function (node) { return result[node]; }) :
@@ -3520,8 +3524,9 @@ var execution_context_1 = require("./execution_context");
 var GraphExecutor = (function () {
     function GraphExecutor(graph) {
         this.graph = graph;
-        this.compiledOrder = [];
+        this.compiledMap = new Map();
         this._weightMap = {};
+        this.SEPERATOR = ',';
         this.placeholders = graph.placeholders;
         this._outputs = graph.outputs;
         this.compile();
@@ -3596,16 +3601,23 @@ var GraphExecutor = (function () {
         enumerable: true,
         configurable: true
     });
-    GraphExecutor.prototype.compile = function () {
+    GraphExecutor.prototype.compile = function (startNodes) {
         if (this.graph.withControlFlow || this.graph.withDynamicShape) {
             return;
         }
-        var stack = this.graph.inputs.slice();
+        var compiledOrder = [];
+        var inputs = startNodes || this.graph.placeholders;
+        var sortedNodeNames = inputs.map(function (node) { return node.name; }).sort();
+        var nameKey = sortedNodeNames.join(this.SEPERATOR);
+        if (this.compiledMap.get(nameKey)) {
+            return;
+        }
+        var stack = inputs.concat(this.graph.weights);
         var visited = {};
         while (stack.length > 0) {
             var node = stack.pop();
             visited[node.name] = true;
-            this.compiledOrder.push(node);
+            compiledOrder.push(node);
             node.children.forEach(function (childNode) {
                 if (!visited[childNode.name] && childNode.inputNames.every(function (name) {
                     var nodeName = utils_1.getNodeNameAndIndex(name)[0];
@@ -3615,19 +3627,33 @@ var GraphExecutor = (function () {
                 }
             });
         }
+        this.compiledMap.set(nameKey, compiledOrder);
     };
-    GraphExecutor.prototype.execute = function (inputs, outputs) {
+    GraphExecutor.prototype.execute = function (inputs, strictInputCheck, outputs) {
         var _this = this;
-        this.checkInput(inputs);
-        this.checkInputShapeAndType(inputs);
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
+        var names = Object.keys(inputs).sort();
+        this.checkInput(inputs, strictInputCheck);
+        this.checkInputShapeAndType(inputs, strictInputCheck);
+        this.compile(names.map(function (name) { return _this.graph.nodes[name]; }));
+        var outputNames = this.calculateOutputs(outputs);
+        this.checkOutput(this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
         var tensorArrayMap = {};
         var result = tfjs_core_1.tidy(function () {
             var context = new execution_context_1.ExecutionContext(_this._weightMap, tensorArrayMap);
-            var tensors = _this.compiledOrder.reduce(function (map, node) {
-                map[node.name] = operation_executor_1.executeOp(node, map, context);
-                return map;
-            }, __assign({}, _this.weightMap, inputs));
-            return _this.findOutputs(tensors, context, outputs);
+            var tensorMap = __assign({}, _this.weightMap, inputs);
+            var compiledNodes = _this.compiledMap.get(names.join(_this.SEPERATOR));
+            for (var i = 0; i < compiledNodes.length; i++) {
+                var node = compiledNodes[i];
+                if (!tensorMap[node.name]) {
+                    tensorMap[node.name] =
+                        operation_executor_1.executeOp(node, tensorMap, context);
+                }
+                if (outputNames.every(function (name) { return !!tensorMap[name]; })) {
+                    break;
+                }
+            }
+            return _this.findOutputs(tensorMap, context, outputNames);
         });
         return result;
     };
@@ -3638,8 +3664,8 @@ var GraphExecutor = (function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        this.checkInput(inputs);
-                        this.checkInputShapeAndType(inputs);
+                        this.checkInput(inputs, false);
+                        this.checkInputShapeAndType(inputs, false);
                         tensorArrayMap = {};
                         context = new execution_context_1.ExecutionContext(this._weightMap, tensorArrayMap);
                         return [4, this.executeWithControlFlow(inputs, context)];
@@ -3666,11 +3692,14 @@ var GraphExecutor = (function () {
     };
     GraphExecutor.prototype.executeWithControlFlow = function (inputs, context) {
         return __awaiter(this, void 0, void 0, function () {
-            var stack, tensorMap, added, promises;
+            var _this = this;
+            var names, inputNodes, stack, tensorMap, added, promises;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        stack = this.graph.inputs.map(function (node) {
+                        names = Object.keys(inputs);
+                        inputNodes = names.map(function (name) { return _this.graph.nodes[name]; });
+                        stack = inputNodes.concat(this.graph.weights).map(function (node) {
                             return { node: node, contexts: context.currentContext };
                         });
                         tensorMap = __assign({}, this.weightMap, inputs);
@@ -3678,7 +3707,7 @@ var GraphExecutor = (function () {
                         _a.label = 1;
                     case 1:
                         if (!(stack.length > 0)) return [3, 3];
-                        promises = this.processStack(stack, context, tensorMap, added);
+                        promises = this.processStack(inputNodes, stack, context, tensorMap, added);
                         return [4, Promise.all(promises)];
                     case 2:
                         _a.sent();
@@ -3688,7 +3717,7 @@ var GraphExecutor = (function () {
             });
         });
     };
-    GraphExecutor.prototype.processStack = function (stack, context, tensorMap, added) {
+    GraphExecutor.prototype.processStack = function (inputNodes, stack, context, tensorMap, added) {
         var _this = this;
         var promises = [];
         var _loop_1 = function () {
@@ -3699,21 +3728,26 @@ var GraphExecutor = (function () {
                 utils_1.getParamValue('isConstant', item.node, tensorMap, context)) {
                 nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
             }
-            var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
-            if (!nodeName) {
-                nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
-            }
-            var currentContext = context.currentContext;
-            if (tensors instanceof Promise) {
-                promises.push(tensors.then(function (t) {
-                    tensorMap[nodeName] = t;
-                    context.currentContext = currentContext;
-                    _this.processChildNodes(item.node, stack, context, tensorMap, added);
-                    return t;
-                }));
+            if (inputNodes.indexOf(item.node) === -1) {
+                var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
+                if (!nodeName) {
+                    nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
+                }
+                var currentContext_1 = context.currentContext;
+                if (tensors instanceof Promise) {
+                    promises.push(tensors.then(function (t) {
+                        tensorMap[nodeName] = t;
+                        context.currentContext = currentContext_1;
+                        _this.processChildNodes(item.node, stack, context, tensorMap, added);
+                        return t;
+                    }));
+                }
+                else {
+                    tensorMap[nodeName] = tensors;
+                    this_1.processChildNodes(item.node, stack, context, tensorMap, added);
+                }
             }
             else {
-                tensorMap[nodeName] = tensors;
                 this_1.processChildNodes(item.node, stack, context, tensorMap, added);
             }
         };
@@ -3744,11 +3778,14 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+    GraphExecutor.prototype.calculateOutputs = function (outputs) {
         if (outputs && !(outputs instanceof Array)) {
             outputs = [outputs];
         }
-        var requestedOutputs = (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+        return (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+    };
+    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+        var requestedOutputs = this.calculateOutputs(outputs);
         return requestedOutputs.reduce(function (map, name) {
             map[name] = utils_1.getTensor(name, tensorMap, context);
             return map;
@@ -3759,9 +3796,14 @@ var GraphExecutor = (function () {
         Object.keys(this.weightMap)
             .forEach(function (key) { return _this.weightMap[key].forEach(function (tensor) { return tensor.dispose(); }); });
     };
-    GraphExecutor.prototype.checkInputShapeAndType = function (inputs) {
+    GraphExecutor.prototype.checkInputShapeAndType = function (inputs, strictInputCheck) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         this.placeholders.forEach(function (node) {
-            var input = inputs[node.name][0];
+            var inputTensors = inputs[node.name];
+            if (!strictInputCheck && !inputTensors) {
+                return;
+            }
+            var input = inputTensors[0];
             if (node.params['shape'] && node.params['shape'].value) {
                 var shape_1 = node.params['shape'].value;
                 var match = shape_1.length === input.shape.length &&
@@ -3773,8 +3815,9 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.checkInput = function (inputs) {
+    GraphExecutor.prototype.checkInput = function (inputs, strictInputCheck) {
         var _this = this;
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         var inputKeys = Object.keys(inputs);
         var missing = [];
         var extra = [];
@@ -3786,14 +3829,31 @@ var GraphExecutor = (function () {
             if (_this.inputNodes.indexOf(name) === -1)
                 extra.push(name);
         });
-        if (missing.length > 0) {
+        var notInGraph = extra.filter(function (name) { return !_this.graph.nodes[name]; });
+        if (missing.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has the keys " +
                 ("[" + inputKeys + "], but is missing the required keys: [" + missing + "]."));
         }
-        if (extra.length > 0) {
+        if (extra.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has " +
                 ("unused keys: [" + extra + "]. Please provide only the following keys: ") +
                 ("[" + this.inputNodes + "]."));
+        }
+        if (notInGraph.length > 0) {
+            throw new Error("The dict provided in model.execute(dict) has " +
+                ("keys: [" + notInGraph + "] not part of model graph."));
+        }
+    };
+    GraphExecutor.prototype.checkOutput = function (compiledNodes, outputs) {
+        var compiledNodeNames = compiledNodes.map(function (node) { return node.name; });
+        var extra = [];
+        outputs.forEach(function (name) {
+            if (compiledNodeNames.indexOf(name) === -1)
+                extra.push(name);
+        });
+        if (extra.length > 0) {
+            throw new Error("The following outputs are not be generated by the execution: " +
+                ("[" + extra + "]."));
         }
     };
     return GraphExecutor;
@@ -4509,6 +4569,9 @@ exports.executeOp = function (node, tensorMap, context) {
             return [snapshot.clone()];
         case 'shape':
             return [tfc.tensor1d(utils_1.getParamValue('x', node, tensorMap, context).shape, 'int32')];
+        case 'shapeN':
+            return utils_1.getParamValue('x', node, tensorMap, context)
+                .map(function (t) { return tfc.tensor1d(t.shape); });
         case 'size':
             return [tfc.scalar(utils_1.getParamValue('x', node, tensorMap, context).size, 'int32')];
         case 'rank':
@@ -4551,6 +4614,15 @@ exports.executeOp = function (node, tensorMap, context) {
             var size = utils_1.getParamValue('size', node, tensorMap, context);
             var alignCorners = utils_1.getParamValue('alignCorners', node, tensorMap, context);
             return [tfc.image.resizeNearestNeighbor(images, [size[0], size[1]], alignCorners)];
+        }
+        case 'cropAndResize': {
+            var image = utils_1.getParamValue('image', node, tensorMap, context);
+            var boxes = utils_1.getParamValue('boxes', node, tensorMap, context);
+            var boxInd = utils_1.getParamValue('boxInd', node, tensorMap, context);
+            var cropSize = utils_1.getParamValue('cropSize', node, tensorMap, context);
+            var method = utils_1.getParamValue('method', node, tensorMap, context);
+            var extrapolationValue = utils_1.getParamValue('extrapolationValue', node, tensorMap, context);
+            return [tfc.image.cropAndResize(image, boxes, boxInd, cropSize, method, extrapolationValue)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4684,6 +4756,11 @@ exports.executeOp = function (node, tensorMap, context) {
         case 'argMin': {
             var axis = utils_1.getParamValue('axis', node, tensorMap, context);
             return [tfc.argMin(utils_1.getParamValue('x', node, tensorMap, context), axis)];
+        }
+        case 'prod': {
+            var axis = utils_1.getParamValue('axis', node, tensorMap, context);
+            var keepDims = utils_1.getParamValue('keepDims', node, tensorMap, context);
+            return [tfc.prod(utils_1.getParamValue('x', node, tensorMap, context), axis, keepDims)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -5040,6 +5117,20 @@ exports.json = [
     },
     {
         'tfOpName': 'Mod',
+        'dlOpName': 'mod',
+        'category': 'arithmetic',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'FloorMod',
         'dlOpName': 'mod',
         'category': 'arithmetic',
         'params': [
@@ -6199,6 +6290,17 @@ exports.json = [
         'params': [{ 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' }]
     },
     {
+        'tfOpName': 'ShapeN',
+        'dlOpName': 'shapeN',
+        'category': 'graph',
+        'params': [{
+                'tfInputIndex': 0,
+                'tfInputParamLength': 0,
+                'dlParamName': 'x',
+                'type': 'tensors'
+            }]
+    },
+    {
         'tfOpName': 'Print',
         'dlOpName': 'print',
         'category': 'graph',
@@ -6280,6 +6382,22 @@ exports.json = [
                 'dlParamName': 'dtype',
                 'type': 'dtype',
                 'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'CropAndResize',
+        'dlOpName': 'cropAndResize',
+        'category': 'image',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'image', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'boxes', 'type': 'tensor' },
+            { 'tfInputIndex': 2, 'dlParamName': 'boxInd', 'type': 'tensor' },
+            { 'tfInputIndex': 3, 'dlParamName': 'cropSize', 'type': 'number[]' },
+            { 'tfParamName': 'method', 'dlParamName': 'method', 'type': 'string' }, {
+                'tfParamName': 'extrapolation_value',
+                'dlParamName': 'extrapolationValue',
+                'type': 'number'
             }
         ]
     }
@@ -6449,6 +6567,32 @@ exports.json = [
             },
             {
                 'tfParamName': 'transpose_b',
+                'dlParamName': 'transposeB',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'BatchMatMul',
+        'dlOpName': 'matMul',
+        'category': 'matrices',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'adj_x',
+                'dlParamName': 'transposeA',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'adj_y',
                 'dlParamName': 'transposeB',
                 'type': 'bool',
                 'defaultValue': false
@@ -6646,6 +6790,19 @@ exports.json = [
         'params': [
             { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
             { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number' }
+        ]
+    },
+    {
+        'tfOpName': 'Prod',
+        'dlOpName': 'prod',
+        'category': 'reduction',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number[]' }, {
+                'tfParamName': 'keep_dims',
+                'dlParamName': 'keepDims',
+                'type': 'bool'
+            }
         ]
     }
 ];
@@ -6854,6 +7011,21 @@ exports.json = [
                 'dlParamName': 'numOrSizeSplits',
                 'type': 'number',
                 'defaultValue': 1
+            }
+        ]
+    },
+    {
+        'tfOpName': 'SplitV',
+        'dlOpName': 'split',
+        'category': 'slice_join',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'numOrSizeSplits', 'type': 'number[]' },
+            {
+                'tfInputIndex': 2,
+                'dlParamName': 'axis',
+                'type': 'number',
+                'defaultValue': 0
             }
         ]
     }
@@ -7072,6 +7244,7 @@ var OperationMapper = (function () {
         var withControlFlow = false;
         var withDynamicShape = false;
         var placeholders = [];
+        var weights = [];
         var nodes = tfNodes.reduce(function (map, node) {
             map[node.name] = _this.mapNode(node);
             if (_this.isControlFlow(node))
@@ -7080,6 +7253,8 @@ var OperationMapper = (function () {
                 withDynamicShape = true;
             if (node.op === 'Placeholder')
                 placeholders.push(map[node.name]);
+            if (node.op === 'Const')
+                weights.push(map[node.name]);
             return map;
         }, {});
         var inputs = [];
@@ -7103,6 +7278,7 @@ var OperationMapper = (function () {
             nodes: nodes,
             inputs: inputs,
             outputs: outputs,
+            weights: weights,
             placeholders: placeholders,
             withControlFlow: withControlFlow,
             withDynamicShape: withDynamicShape
@@ -7240,7 +7416,7 @@ exports.OperationMapper = OperationMapper;
 },{"../data/compiled_api":10,"./executors/utils":31,"./op_list/arithmetic":32,"./op_list/basic_math":33,"./op_list/control":34,"./op_list/convolution":35,"./op_list/creation":36,"./op_list/dynamic":37,"./op_list/evaluation":38,"./op_list/graph":39,"./op_list/image":40,"./op_list/logical":41,"./op_list/matrices":42,"./op_list/normalization":43,"./op_list/reduction":44,"./op_list/slice_join":45,"./op_list/transformation":46}],49:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.5.9';
+var version = '0.6.5';
 exports.version = version;
 
 },{}],50:[function(require,module,exports){
@@ -9179,18 +9355,24 @@ var Engine = (function () {
         this.safeMode = safeMode;
         this.debugMode = debugMode;
         this.registeredVariables = {};
-        this.refCounter = new WeakMap();
         this.nextTapeNodeId = 0;
         this.numBytes = 0;
         this.numTensors = 0;
         this.numDataBuffers = 0;
+        this.profiling = false;
         this.gradientScopeCount = 0;
         this.customGradientDepth = 0;
         this.keepTensors = new Set();
+        this.tensorInfo = new WeakMap();
         this.activeScope = { track: [], name: 'default scope' };
         this.scopeStack = [this.activeScope];
         this.profiler = new profiler_1.Profiler(backend);
+        this.activeProfile =
+            { newBytes: 0, newTensors: 0, peakBytes: 0, kernels: [], result: null };
     }
+    Engine.prototype.moveData = function (dataId) {
+        this.write(dataId, this.readSync(dataId));
+    };
     Engine.prototype.tidy = function (nameOrFn, fn, gradMode) {
         var _this = this;
         if (gradMode === void 0) { gradMode = false; }
@@ -9242,6 +9424,8 @@ var Engine = (function () {
             return x;
         };
         var scopeName = this.activeScope.name;
+        var startingBytecount = this.numBytes;
+        var startingNumTensors = this.numTensors;
         this.scopedRun(function () { return _this.customGradientDepth++; }, function () { return _this.customGradientDepth--; }, function () {
             if (!_this.debugMode()) {
                 result = forwardFunc(_this.backend, saveFunc);
@@ -9263,10 +9447,25 @@ var Engine = (function () {
             }
             this.activeTape.push(tapeNode);
         }
+        if (this.profiling) {
+            this.activeProfile.kernels.push({
+                name: scopeName,
+                bytesAdded: this.numBytes - startingBytecount,
+                totalBytesSnapshot: this.numBytes,
+                tensorsAdded: this.numTensors - startingNumTensors,
+                totalTensorsSnapshot: this.numTensors,
+                inputShapes: Object.keys(inputs).map(function (key) { return inputs[key].shape; }),
+                outputShape: Array.isArray(result) ?
+                    result.map(function (item) { return item.shape; }) :
+                    result.shape
+            });
+        }
         return result;
     };
     Engine.prototype.registerTensor = function (a) {
-        var refCount = this.refCounter.has(a.dataId) ? this.refCounter.get(a.dataId) : 0;
+        var refCount = this.tensorInfo.has(a.dataId) ?
+            this.tensorInfo.get(a.dataId).refCount :
+            0;
         this.numTensors++;
         if (refCount === 0) {
             this.numDataBuffers++;
@@ -9274,9 +9473,10 @@ var Engine = (function () {
                 this.numBytes +=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.set(a.dataId, { backend: this.backend, dtype: a.dtype, shape: a.shape, refCount: 0 });
             this.backend.register(a.dataId, a.shape, a.dtype);
         }
-        this.refCounter.set(a.dataId, refCount + 1);
+        this.tensorInfo.get(a.dataId).refCount++;
         if (!(a instanceof tensor_1.Variable)) {
             this.track(a);
         }
@@ -9288,25 +9488,26 @@ var Engine = (function () {
         this.registeredVariables[v.name] = v;
     };
     Engine.prototype.disposeTensor = function (a) {
-        if (!this.refCounter.has(a.dataId)) {
+        if (!this.tensorInfo.has(a.dataId)) {
             return;
         }
         if (this.keepTensors.has(a.id)) {
             this.keepTensors.delete(a.id);
         }
         this.numTensors--;
-        var refCount = this.refCounter.get(a.dataId);
+        var refCount = this.tensorInfo.get(a.dataId).refCount;
         if (refCount <= 1) {
-            this.refCounter.delete(a.dataId);
-            this.backend.disposeData(a.dataId);
+            var info = this.tensorInfo.get(a.dataId);
+            info.backend.disposeData(a.dataId);
             this.numDataBuffers--;
             if (a.dtype !== 'complex64') {
                 this.numBytes -=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.delete(a.dataId);
         }
         else {
-            this.refCounter.set(a.dataId, refCount - 1);
+            this.tensorInfo.get(a.dataId).refCount--;
         }
     };
     Engine.prototype.disposeVariables = function () {
@@ -9322,6 +9523,23 @@ var Engine = (function () {
         info.numDataBuffers = this.numDataBuffers;
         info.numBytes = this.numBytes;
         return info;
+    };
+    Engine.prototype.profile = function (query) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startBytes, startNumTensors;
+            return __generator(this, function (_a) {
+                this.profiling = true;
+                startBytes = this.numBytes;
+                startNumTensors = this.numTensors;
+                this.activeProfile.kernels = [];
+                this.activeProfile.result = query();
+                this.profiling = false;
+                this.activeProfile.peakBytes = Math.max.apply(Math, this.activeProfile.kernels.map(function (d) { return d.totalBytesSnapshot; }));
+                this.activeProfile.newBytes = this.numBytes - startBytes;
+                this.activeProfile.newTensors = this.numTensors - startNumTensors;
+                return [2, this.activeProfile];
+            });
+        });
     };
     Engine.prototype.shouldRecord = function () {
         return this.activeTape != null && this.customGradientDepth === 0;
@@ -9467,13 +9685,21 @@ var Engine = (function () {
         };
     };
     Engine.prototype.write = function (dataId, values) {
+        var info = this.tensorInfo.get(dataId);
+        if (this.backend !== info.backend) {
+            info.backend.disposeData(dataId);
+            info.backend = this.backend;
+            this.backend.register(dataId, info.shape, info.dtype);
+        }
         this.backend.write(dataId, values);
     };
     Engine.prototype.readSync = function (dataId) {
-        return this.backend.readSync(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.readSync(dataId);
     };
     Engine.prototype.read = function (dataId) {
-        return this.backend.read(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.read(dataId);
     };
     Engine.prototype.fromPixels = function (pixels, numChannels) {
         return this.backend.fromPixels(pixels, numChannels);
@@ -9510,7 +9736,7 @@ function ones(shape) {
     return tensor_1.Tensor.make(shape, { values: values });
 }
 
-},{"./profiler":184,"./tape":186,"./tensor":187,"./tensor_util":189,"./util":194}],64:[function(require,module,exports){
+},{"./profiler":204,"./tape":206,"./tensor":207,"./tensor_util":209,"./util":214}],64:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -9526,7 +9752,6 @@ var TEST_EPSILON_FLOAT32 = 1e-3;
 var Environment = (function () {
     function Environment(features) {
         this.features = {};
-        this.engines = {};
         this.registry = {};
         if (features != null) {
             this.features = features;
@@ -9542,10 +9767,11 @@ var Environment = (function () {
         if (!(backendName in exports.ENV.registry)) {
             throw new Error("Backend name '" + backendName + "' not found in registry");
         }
-        exports.ENV.initBackend(backendName, safeMode);
+        exports.ENV.engine.backend = exports.ENV.findBackend(backendName);
+        exports.ENV.backendName = backendName;
     };
     Environment.getBackend = function () {
-        exports.ENV.initDefaultBackend();
+        exports.ENV.initEngine();
         return exports.ENV.backendName;
     };
     Environment.disposeVariables = function () {
@@ -9553,6 +9779,9 @@ var Environment = (function () {
     };
     Environment.memory = function () {
         return exports.ENV.engine.memory();
+    };
+    Environment.profile = function (f) {
+        return exports.ENV.engine.profile(f);
     };
     Environment.tidy = function (nameOrFn, fn, gradMode) {
         if (gradMode === void 0) { gradMode = false; }
@@ -9609,6 +9838,18 @@ var Environment = (function () {
         else if (feature === 'IS_CHROME') {
             return environment_util_1.isChrome();
         }
+        else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+            return false;
+        }
+        else if (feature === 'WEBGL_CONV_IM2COL') {
+            return false;
+        }
+        else if (feature === 'WEBGL_PAGING_ENABLED') {
+            return this.get('IS_BROWSER') && !this.get('PROD');
+        }
+        else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
+            return environment_util_1.getWebGLMaxTextureSize(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+        }
         else if (feature === 'IS_TEST') {
             return false;
         }
@@ -9618,9 +9859,6 @@ var Environment = (function () {
         else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
             var webGLVersion = this.get('WEBGL_VERSION');
             if (webGLVersion === 0) {
-                return 0;
-            }
-            if (webGLVersion > 0) {
                 return 0;
             }
             return environment_util_1.getWebGLDisjointQueryTimerVersion(webGLVersion, this.get('IS_BROWSER'));
@@ -9650,6 +9888,10 @@ var Environment = (function () {
         else if (feature === 'WEBGL_FENCE_API_ENABLED') {
             return environment_util_1.isWebGLFenceEnabled(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
         }
+        else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
+            var useUniforms = this.get('WEBGL_RENDER_FLOAT32_ENABLED');
+            return useUniforms ? 4 : 0;
+        }
         else if (feature === 'TEST_EPSILON') {
             return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
                 TEST_EPSILON_FLOAT16;
@@ -9657,6 +9899,12 @@ var Environment = (function () {
         else if (feature === 'EPSILON') {
             return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
                 EPSILON_FLOAT16;
+        }
+        else if (feature === 'PROD') {
+            return false;
+        }
+        else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
+            return !this.get('PROD');
         }
         throw new Error("Unknown feature " + feature + ".");
     };
@@ -9667,20 +9915,6 @@ var Environment = (function () {
         this.features = environment_util_1.getFeaturesFromURL();
         if (this.globalEngine != null) {
             this.globalEngine = null;
-        }
-    };
-    Environment.prototype.initBackend = function (backendName, safeMode) {
-        var _this = this;
-        if (safeMode === void 0) { safeMode = false; }
-        this.backendName = backendName;
-        if (this.engines[backendName]) {
-            this.globalEngine = this.engines[backendName];
-        }
-        else {
-            var backend = this.findBackend(backendName);
-            this.globalEngine =
-                new engine_1.Engine(backend, safeMode, function () { return _this.get('DEBUG'); });
-            this.engines[backendName] = this.globalEngine;
         }
     };
     Object.defineProperty(Environment.prototype, "backend", {
@@ -9708,6 +9942,7 @@ var Environment = (function () {
         }
         try {
             var backend = factory();
+            backend.setDataMover({ moveData: function (dataId) { return _this.engine.moveData(dataId); } });
             this.registry[name] = { backend: backend, priority: priority };
             return true;
         }
@@ -9723,21 +9958,22 @@ var Environment = (function () {
         }
         this.registry[name].backend.dispose();
         delete this.registry[name];
-        if (name in this.engines) {
-            delete this.engines[name];
-        }
     };
     Object.defineProperty(Environment.prototype, "engine", {
         get: function () {
-            this.initDefaultBackend();
+            this.initEngine();
             return this.globalEngine;
         },
         enumerable: true,
         configurable: true
     });
-    Environment.prototype.initDefaultBackend = function () {
+    Environment.prototype.initEngine = function () {
+        var _this = this;
         if (this.globalEngine == null) {
-            this.initBackend(this.get('BACKEND'), false);
+            this.backendName = this.get('BACKEND');
+            var backend = this.findBackend(this.backendName);
+            this.globalEngine =
+                new engine_1.Engine(backend, false, function () { return _this.get('DEBUG'); });
         }
     };
     return Environment;
@@ -9767,7 +10003,7 @@ function getOrMakeEnvironment() {
 exports.ENV = getOrMakeEnvironment();
 
 }).call(this,require('_process'))
-},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":187,"./tensor_util":189,"_process":269}],65:[function(require,module,exports){
+},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":207,"./tensor_util":209,"_process":293}],65:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Type;
@@ -9777,14 +10013,23 @@ var Type;
     Type[Type["STRING"] = 2] = "STRING";
 })(Type = exports.Type || (exports.Type = {}));
 exports.URL_PROPERTIES = [
-    { name: 'DEBUG', type: Type.BOOLEAN }, { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'DEBUG', type: Type.BOOLEAN },
+    { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN },
+    { name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN },
+    { name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER },
+    { name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN },
     { name: 'WEBGL_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_RENDER_FLOAT32_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DOWNLOAD_FLOAT_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_FENCE_API_ENABLED', type: Type.BOOLEAN },
-    { name: 'BACKEND', type: Type.STRING }, { name: 'EPSILON', type: Type.NUMBER }
+    { name: 'WEBGL_SIZE_UPLOAD_UNIFORM', type: Type.NUMBER },
+    { name: 'BACKEND', type: Type.STRING },
+    { name: 'EPSILON', type: Type.NUMBER },
+    { name: 'PROD', type: Type.BOOLEAN },
+    { name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN },
 ];
 function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     var gl;
@@ -9801,6 +10046,15 @@ function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     return false;
 }
 exports.isWebGLVersionEnabled = isWebGLVersionEnabled;
+var MAX_TEXTURE_SIZE;
+function getWebGLMaxTextureSize(webGLVersion, isBrowser) {
+    if (MAX_TEXTURE_SIZE == null) {
+        var gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+        MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    }
+    return MAX_TEXTURE_SIZE;
+}
+exports.getWebGLMaxTextureSize = getWebGLMaxTextureSize;
 function getWebGLDisjointQueryTimerVersion(webGLVersion, isBrowser) {
     if (webGLVersion === 0) {
         return 0;
@@ -9989,6 +10243,7 @@ exports.tidy = environment_1.Environment.tidy;
 exports.keep = environment_1.Environment.keep;
 exports.dispose = environment_1.Environment.dispose;
 exports.time = environment_1.Environment.time;
+exports.profile = environment_1.Environment.profile;
 
 },{"./environment":64,"./gradients":67}],67:[function(require,module,exports){
 "use strict";
@@ -10103,7 +10358,7 @@ function checkGrads(grads) {
     }
 }
 
-},{"./environment":64,"./tensor":187,"./util":194}],68:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],68:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -10118,6 +10373,8 @@ exports.environment = environment;
 var environment_1 = require("./environment");
 var io = require("./io/io");
 exports.io = io;
+var math = require("./math");
+exports.math = math;
 var serialization = require("./serialization");
 exports.serialization = serialization;
 var tensor_1 = require("./tensor");
@@ -10164,10 +10421,12 @@ exports.setBackend = environment_1.Environment.setBackend;
 exports.getBackend = environment_1.Environment.getBackend;
 exports.disposeVariables = environment_1.Environment.disposeVariables;
 exports.memory = environment_1.Environment.memory;
+var backend_1 = require("./kernels/backend");
+exports.DataStorage = backend_1.DataStorage;
 var ops = require("./ops/ops");
 tensor_1.setOpHandler(ops);
 
-},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend_cpu":80,"./kernels/backend_webgl":82,"./ops/loss_ops":150,"./ops/ops":157,"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer":180,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183,"./serialization":185,"./tensor":187,"./test_util":191,"./train":192,"./types":193,"./util":194,"./version":195,"./webgl":196}],69:[function(require,module,exports){
+},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend":80,"./kernels/backend_cpu":81,"./kernels/backend_webgl":83,"./math":145,"./ops/loss_ops":165,"./ops/ops":172,"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer":200,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203,"./serialization":205,"./tensor":207,"./test_util":211,"./train":212,"./types":213,"./util":214,"./version":215,"./webgl":216}],69:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10659,7 +10918,7 @@ function browserHTTPRequest(path, requestInit) {
 }
 exports.browserHTTPRequest = browserHTTPRequest;
 
-},{"../util":194,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11240,7 +11499,7 @@ function getModelArtifactsInfoForJSON(modelArtifacts) {
 exports.getModelArtifactsInfoForJSON = getModelArtifactsInfoForJSON;
 
 }).call(this,require("buffer").Buffer)
-},{"../ops/tensor_ops":171,"../util":194,"./types":78,"buffer":251}],74:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214,"./types":78,"buffer":275}],74:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11488,7 +11747,7 @@ if (environment_1.ENV.get('IS_BROWSER')) {
     }
 }
 
-},{"../environment":64,"../util":194,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
+},{"../environment":64,"../util":214,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11692,7 +11951,7 @@ function moveModel(sourceURL, destURL) {
 }
 exports.moveModel = moveModel;
 
-},{"../util":194,"./router_registry":77}],76:[function(require,module,exports){
+},{"../util":214,"./router_registry":77}],76:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -12001,7 +12260,34 @@ function loadWeights(manifest, filePathPrefix, weightNames, requestOptions) {
 }
 exports.loadWeights = loadWeights;
 
-},{"../util":194,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var DataStorage = (function () {
+    function DataStorage(dataMover) {
+        this.dataMover = dataMover;
+        this.data = new WeakMap();
+    }
+    DataStorage.prototype.get = function (dataId) {
+        if (!this.data.has(dataId)) {
+            this.dataMover.moveData(dataId);
+        }
+        return this.data.get(dataId);
+    };
+    DataStorage.prototype.set = function (dataId, value) {
+        this.data.set(dataId, value);
+    };
+    DataStorage.prototype.has = function (dataId) {
+        return this.data.has(dataId);
+    };
+    DataStorage.prototype.delete = function (dataId) {
+        return this.data.delete(dataId);
+    };
+    return DataStorage;
+}());
+exports.DataStorage = DataStorage;
+
+},{}],81:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -12047,14 +12333,17 @@ var axis_util = require("../ops/axis_util");
 var broadcast_util = require("../ops/broadcast_util");
 var concat_util = require("../ops/concat_util");
 var erf_util = require("../ops/erf_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var ops = require("../ops/ops");
 var ops_1 = require("../ops/ops");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var selu_util = require("../ops/selu_util");
 var slice_util_1 = require("../ops/slice_util");
 var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -12064,12 +12353,14 @@ var where_impl_1 = require("./where_impl");
 var MathBackendCPU = (function () {
     function MathBackendCPU() {
         this.blockSize = 48;
-        this.data = new WeakMap();
         this.firstUse = true;
         if (environment_1.ENV.get('IS_BROWSER')) {
             this.canvas = document.createElement('canvas');
         }
     }
+    MathBackendCPU.prototype.setDataMover = function (dataMover) {
+        this.data = new backend_1.DataStorage(dataMover);
+    };
     MathBackendCPU.prototype.register = function (dataId, shape, dtype) {
         if (this.firstUse) {
             this.firstUse = false;
@@ -12095,7 +12386,6 @@ var MathBackendCPU = (function () {
         if (values == null) {
             throw new Error('MathBackendCPU.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         this.data.get(dataId).values = values;
     };
     MathBackendCPU.prototype.fromPixels = function (pixels, numChannels) {
@@ -12158,7 +12448,6 @@ var MathBackendCPU = (function () {
         });
     };
     MathBackendCPU.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var _a = this.data.get(dataId), dtype = _a.dtype, complexTensors = _a.complexTensors;
         if (dtype === 'complex64') {
             var realValues = complexTensors.real.dataSync();
@@ -12192,13 +12481,6 @@ var MathBackendCPU = (function () {
         return {
             unreliable: true
         };
-    };
-    MathBackendCPU.prototype.throwIfNoData = function (dataId) {
-        if (!this.data.has(dataId)) {
-            throw new Error("CPU backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
     };
     MathBackendCPU.prototype.complex = function (real, imag) {
         var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
@@ -12419,6 +12701,24 @@ var MathBackendCPU = (function () {
                 sum += aVals[offset + j];
             }
             vals[i] = sum;
+        }
+        return result;
+    };
+    MathBackendCPU.prototype.prod = function (x, axes) {
+        this.assertNotComplex(x, 'sum');
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var resultDtype = types_1.upcastType(x.dtype, 'int32');
+        var result = ops.zeros(outShape, resultDtype);
+        var reduceSize = util.sizeFromShape(reduceShape);
+        var vals = result.dataSync();
+        var aVals = x.dataSync();
+        for (var i = 0; i < vals.length; ++i) {
+            var offset = i * reduceSize;
+            var prod = 1;
+            for (var j = 0; j < reduceSize; ++j) {
+                prod *= aVals[offset + j];
+            }
+            vals[i] = prod;
         }
         return result;
     };
@@ -12915,11 +13215,19 @@ var MathBackendCPU = (function () {
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
     MathBackendCPU.prototype.abs = function (x) {
-        this.assertNotComplex(x, 'abs');
         var resultValues = new Float32Array(x.size);
         var values = x.dataSync();
-        for (var i = 0; i < values.length; ++i) {
-            resultValues[i] = Math.abs(values[i]);
+        if (x.dtype === 'complex64') {
+            for (var i = 0; i < x.size; ++i) {
+                var real = values[i * 2];
+                var imag = values[i * 2 + 1];
+                resultValues[i] = Math.sqrt(real * real + imag * imag);
+            }
+        }
+        else {
+            for (var i = 0; i < values.length; ++i) {
+                resultValues[i] = Math.abs(values[i]);
+            }
         }
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
@@ -13478,8 +13786,10 @@ var MathBackendCPU = (function () {
         this.assertNotComplex(x, 'pool');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var y = ops.buffer(convInfo.outShape, 'float32');
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
@@ -13490,16 +13800,16 @@ var MathBackendCPU = (function () {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
                     var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
                         var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var minMaxValue = initialValue;
                         var avgValue = 0;
                         var count = 0;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var pixel = x.get(b, xR, xC, d);
                                 if ((poolType === 'max' && pixel > minMaxValue)) {
                                     minMaxValue = pixel;
@@ -13527,30 +13837,38 @@ var MathBackendCPU = (function () {
         var maxPositions = ops.buffer(convInfo.outShape, 'int32');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
-                    var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMin = xRCorner;
+                    while (xRMin < 0) {
+                        xRMin += dilationHeight;
+                    }
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
-                        var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMin = xCCorner;
+                        while (xCMin < 0) {
+                            xCMin += dilationWidth;
+                        }
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var maxValue = Number.NEGATIVE_INFINITY;
                         var maxPosition = -1;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
                             var wR = xR - xRCorner;
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var wC = xC - xCCorner;
                                 var pixel = x.get(b, xR, xC, d);
                                 if (pixel > maxValue) {
                                     maxValue = pixel;
-                                    maxPosition = wR * filterWidth + wC;
+                                    maxPosition = wR * effectiveFilterWidth + wC;
                                 }
                             }
                         }
@@ -13566,10 +13884,12 @@ var MathBackendCPU = (function () {
         var maxPositions = this.maxPoolPositions(x, convInfo);
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
@@ -13578,21 +13898,21 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
                                     continue;
                                 }
-                                var maxPos = filterHeight * filterWidth - 1 -
-                                    maxPositions.get(b, dyR, dyC, d);
-                                var curPos = wR * filterWidth + wC;
+                                var maxPos = effectiveFilterHeight * effectiveFilterWidth -
+                                    1 - maxPositions.get(b, dyR, dyC, d);
+                                var curPos = wR * effectiveFilterWidth + wC;
                                 var mask = maxPos === curPos ? 1 : 0;
                                 if (mask === 0) {
                                     continue;
@@ -13614,8 +13934,12 @@ var MathBackendCPU = (function () {
         var strideWidth = convInfo.strideWidth;
         var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         var avgMultiplier = 1 / (filterHeight * filterWidth);
         for (var b = 0; b < convInfo.batchSize; ++b) {
@@ -13625,13 +13949,13 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
@@ -13661,7 +13985,8 @@ var MathBackendCPU = (function () {
     MathBackendCPU.prototype.resizeBilinear = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeBilinear');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var result = new Float32Array(util.sizeFromShape([batch, newHeight, newWidth, numChannels]));
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13670,37 +13995,46 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var outputIdx = 0;
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
         for (var b = 0; b < batch; b++) {
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceRowFloor = Math.floor(sourceFracRow);
+                var rowFrac = sourceFracRow - sourceRowFloor;
+                var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
+                var topRowOffset = b * x.strides[0] + sourceRowFloor * x.strides[1];
+                var botRowOffset = b * x.strides[0] + sourceRowCeil * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceColFloor = Math.floor(sourceFracCol);
+                    var colFrac = sourceFracCol - sourceColFloor;
+                    var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
+                    var topLeftOffest = topRowOffset + sourceColFloor * x.strides[2];
+                    var botLeftOffset = botRowOffset + sourceColFloor * x.strides[2];
+                    var topRightOffset = topRowOffset + +sourceColCeil * x.strides[2];
+                    var botRightOffest = botRowOffset + sourceColCeil * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceRowFloor = Math.floor(sourceFracRow);
-                        var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
-                        var sourceColFloor = Math.floor(sourceFracCol);
-                        var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
-                        var topLeft = x.get(b, sourceRowFloor, sourceColFloor, d);
-                        var bottomLeft = x.get(b, sourceRowCeil, sourceColFloor, d);
-                        var topRight = x.get(b, sourceRowFloor, sourceColCeil, d);
-                        var bottomRight = x.get(b, sourceRowCeil, sourceColCeil, d);
-                        var rowFrac = sourceFracRow - sourceRowFloor;
-                        var colFrac = sourceFracCol - sourceColFloor;
+                        var topLeft = xValues[topLeftOffest + d];
+                        var bottomLeft = xValues[botLeftOffset + d];
+                        var topRight = xValues[topRightOffset + d];
+                        var bottomRight = xValues[botRightOffest + d];
                         var top_1 = topLeft + (topRight - topLeft) * colFrac;
                         var bottom = bottomLeft + (bottomRight - bottomLeft) * colFrac;
                         var newValue = top_1 + (bottom - top_1) * rowFrac;
-                        output.set(newValue, b, r, c, d);
+                        result[outputIdx++] = newValue;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(result, [batch, newHeight, newWidth, numChannels]);
     };
     MathBackendCPU.prototype.resizeBilinearBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeBilinearBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13711,11 +14045,16 @@ var MathBackendCPU = (function () {
         ];
         var heightScale = effectiveXSize[0] / effectiveYSize[0];
         var widthScale = effectiveXSize[1] / effectiveYSize[1];
+        var dyValues = dy.dataSync();
+        var offset = 0;
         for (var b = 0; b < batch; b++) {
+            var bOffset = b * x.strides[0];
             for (var r = 0; r < yHeight; r++) {
                 var dxR = r * heightScale;
                 var topDxRIndex = Math.floor(dxR);
                 var bottomDxRIndex = Math.min(Math.ceil(dxR), xHeight - 1);
+                var topDxROffset = bOffset + topDxRIndex * x.strides[1];
+                var bottomDxROffset = bOffset + bottomDxRIndex * x.strides[1];
                 var dxRLerp = dxR - topDxRIndex;
                 var inverseDxRLerp = 1.0 - dxRLerp;
                 for (var c = 0; c < yWidth; c++) {
@@ -13724,30 +14063,33 @@ var MathBackendCPU = (function () {
                     var rightDxCIndex = Math.min(Math.ceil(dxC), xWidth - 1);
                     var dxCLerp = dxC - leftDxCIndex;
                     var inverseDxCLerp = 1.0 - dxCLerp;
+                    var topLeftRCOffset = topDxROffset + leftDxCIndex * x.strides[2];
+                    var topRightRCOffset = topDxROffset + rightDxCIndex * x.strides[2];
+                    var bottomLeftRCOffset = bottomDxROffset + leftDxCIndex * x.strides[2];
+                    var bottomRightRCOffset = bottomDxROffset + rightDxCIndex * x.strides[2];
+                    var inverseDxRLerpTimesInverseDxCLerp = inverseDxRLerp * inverseDxCLerp;
+                    var inverseDxRLerpTimesDxCLerp = inverseDxRLerp * dxCLerp;
+                    var dxRLerpTimesInverseDxCLerp = dxRLerp * inverseDxCLerp;
+                    var dxRLerpTimesDxCLerp = dxRLerp * dxCLerp;
                     for (var d = 0; d < depth; d++) {
-                        var dyVal = dy.get(b, r, c, d);
-                        var topLeft = output.get(b, topDxRIndex, leftDxCIndex, d);
-                        topLeft += dyVal * inverseDxRLerp * inverseDxCLerp;
-                        output.set(topLeft, b, topDxRIndex, leftDxCIndex, d);
-                        var topRight = output.get(b, topDxRIndex, rightDxCIndex, d);
-                        topRight += dyVal * inverseDxRLerp * dxCLerp;
-                        output.set(topRight, b, topDxRIndex, rightDxCIndex, d);
-                        var bottomLeft = output.get(b, bottomDxRIndex, leftDxCIndex, d);
-                        bottomLeft += dyVal * dxRLerp * inverseDxCLerp;
-                        output.set(bottomLeft, b, bottomDxRIndex, leftDxCIndex, d);
-                        var bottomRight = output.get(b, bottomDxRIndex, rightDxCIndex, d);
-                        bottomRight += dyVal * dxRLerp * dxCLerp;
-                        output.set(bottomRight, b, bottomDxRIndex, rightDxCIndex, d);
+                        var dyVal = dyValues[offset++];
+                        output[topLeftRCOffset + d] +=
+                            dyVal * inverseDxRLerpTimesInverseDxCLerp;
+                        output[topRightRCOffset + d] += dyVal * inverseDxRLerpTimesDxCLerp;
+                        output[bottomLeftRCOffset + d] +=
+                            dyVal * dxRLerpTimesInverseDxCLerp;
+                        output[bottomRightRCOffset + d] += dyVal * dxRLerpTimesDxCLerp;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, [batch, xWidth, xHeight, depth], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighbor = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeNearestNeighbor');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var output = new Float32Array(batch * newHeight * newWidth * numChannels);
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13756,29 +14098,36 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
+        var outputOffset = 0;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                    Math.floor(sourceFracRow));
+                var rowOffset = batchOffset + sourceNearestRow * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
+                        Math.floor(sourceFracCol));
+                    var colOffset = rowOffset + sourceNearestCol * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                            Math.floor(sourceFracRow));
-                        var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
-                            Math.floor(sourceFracCol));
-                        var newValue = x.get(b, sourceNearestRow, sourceNearestCol, d);
-                        output.set(newValue, b, r, c, d);
+                        var newVal = xValues[colOffset + d];
+                        output[outputOffset++] = newVal;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(output, [batch, newHeight, newWidth, numChannels], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighborBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeNearestNeighborBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
+        var dyValues = dy.dataSync();
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13794,41 +14143,49 @@ var MathBackendCPU = (function () {
         var winHeight = (Math.ceil(invHeightScale) * 2) + 2;
         var winWidth = (Math.ceil(invWidthScale) * 2) + 2;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < xHeight; r++) {
+                var rowOffset = batchOffset + r * x.strides[1];
+                var startRLerp = Math.floor(r * invHeightScale);
+                var startDyR = Math.floor(startRLerp - (winHeight / 2));
                 for (var c = 0; c < xWidth; c++) {
-                    var startRLerp = Math.floor(r * invHeightScale);
-                    var startDyR = Math.floor(startRLerp - (winHeight / 2));
+                    var colOffset = rowOffset + c * x.strides[2];
                     var startCLerp = Math.floor(c * invWidthScale);
                     var startDyC = Math.floor(startCLerp - (winWidth / 2));
                     for (var d = 0; d < depth; d++) {
                         var accum = 0;
-                        for (var dyROffset = 0; dyROffset < winHeight; dyROffset++) {
-                            var dyR = dyROffset + startDyR;
+                        for (var dyRIndex = 0; dyRIndex < winHeight; dyRIndex++) {
+                            var dyR = dyRIndex + startDyR;
                             if (dyR < 0 || dyR >= yHeight) {
                                 continue;
                             }
-                            for (var dyCOffSet = 0; dyCOffSet < winWidth; dyCOffSet++) {
-                                var dyC = dyCOffSet + startDyC;
+                            var dyROffset = batchOffset + dyR * dy.strides[1];
+                            var sourceFracRow = dyR * heightScale;
+                            var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                                Math.floor(sourceFracRow));
+                            if (r !== sourceNearestRow) {
+                                continue;
+                            }
+                            for (var dyCIndex = 0; dyCIndex < winWidth; dyCIndex++) {
+                                var dyC = dyCIndex + startDyC;
                                 if (dyC < 0 || dyC >= yWidth) {
                                     continue;
                                 }
-                                var sourceFracRow = effectiveXSize[0] * (dyR / effectiveYSize[0]);
-                                var sourceFracCol = effectiveXSize[1] * (dyC / effectiveYSize[1]);
-                                var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                                    Math.floor(sourceFracRow));
+                                var dyCOffset = dyROffset + dyC * dy.strides[2];
+                                var sourceFracCol = dyC * widthScale;
                                 var sourceNearestCol = Math.min(xWidth - 1, alignCorners ? Math.round(sourceFracCol) :
                                     Math.floor(sourceFracCol));
-                                if (r === sourceNearestRow && c === sourceNearestCol) {
-                                    accum += dy.get(b, dyR, dyC, d);
+                                if (c === sourceNearestCol) {
+                                    accum += dyValues[dyCOffset + d];
                                 }
                             }
                         }
-                        output.set(accum, b, r, c, d);
+                        output[colOffset + d] = accum;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, x.shape, x.dtype);
     };
     MathBackendCPU.prototype.batchNormalization = function (x, mean, variance, varianceEpsilon, scale, offset) {
         this.assertNotComplex([x, mean, variance, scale, offset], 'batchNormalization');
@@ -13968,6 +14325,61 @@ var MathBackendCPU = (function () {
         var scoresVals = scores.dataSync();
         return non_max_suppression_impl_1.nonMaxSuppressionImpl(boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
     };
+    MathBackendCPU.prototype.fft = function (input) {
+        if (input.shape[0] !== 1) {
+            throw new Error("tf.fft() on CPU only supports vectors.");
+        }
+        var input1D = input.as1D();
+        var n = input1D.size;
+        if (this.isExponentOf2(n)) {
+            return this.fftRadix2(input1D, n).as2D(input.shape[0], input.shape[1]);
+        }
+        else {
+            var data = input.dataSync();
+            var rawOutput = this.fourierTransformByMatmul(data, n);
+            var output = complex_util.splitRealAndImagArrays(rawOutput);
+            return ops.complex(output.real, output.imag)
+                .as2D(input.shape[0], input.shape[1]);
+        }
+    };
+    MathBackendCPU.prototype.isExponentOf2 = function (size) {
+        return (size & size - 1) === 0;
+    };
+    MathBackendCPU.prototype.fftRadix2 = function (input, size) {
+        if (size === 1) {
+            return input;
+        }
+        var data = input.dataSync();
+        var half = size / 2;
+        var evenComplex = complex_util.complexWithEvenIndex(data);
+        var evenTensor = ops.complex(evenComplex.real, evenComplex.imag).as1D();
+        var oddComplex = complex_util.complexWithOddIndex(data);
+        var oddTensor = ops.complex(oddComplex.real, oddComplex.imag).as1D();
+        evenTensor = this.fftRadix2(evenTensor, half);
+        oddTensor = this.fftRadix2(oddTensor, half);
+        var e = complex_util.exponents(size);
+        var exponent = ops.complex(e.real, e.imag).mul(oddTensor);
+        var addPart = evenTensor.add(exponent);
+        var subPart = evenTensor.sub(exponent);
+        var realTensor = ops.real(addPart).concat(ops.real(subPart));
+        var imagTensor = ops.imag(addPart).concat(ops.imag(subPart));
+        return ops.complex(realTensor, imagTensor).as1D();
+    };
+    MathBackendCPU.prototype.fourierTransformByMatmul = function (data, size) {
+        var ret = new Float32Array(size * 2);
+        for (var r = 0; r < size; r++) {
+            var real = 0.0;
+            var imag = 0.0;
+            for (var c = 0; c < size; c++) {
+                var e = complex_util.exponent(r * c, size);
+                var term = complex_util.getComplexWithIndex(data, c);
+                real += term.real * e.real - term.imag * e.imag;
+                imag += term.real * e.imag + term.imag * e.real;
+            }
+            complex_util.assignToTypedArray(ret, real, imag, r);
+        }
+        return ret;
+    };
     MathBackendCPU.prototype.depthToSpace = function (x, blockSize, dataFormat) {
         util.assert(dataFormat === 'NHWC', "Only NHWC dataFormat supported on CPU for depthToSpace. Got " + dataFormat);
         util.assert(blockSize > 1, "blockSize should be > 1 for depthToSpace, but was: " + blockSize);
@@ -14101,9 +14513,7 @@ var MathBackendCPU = (function () {
             var heightScale = (cropHeight > 1) ?
                 (y2 - y1) * (imageHeight - 1) / (cropHeight - 1) :
                 0;
-            var widthScale = (cropWidth > 1) ?
-                (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) :
-                0;
+            var widthScale = (cropWidth > 1) ? (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) : 0;
             for (var y = 0; y < cropHeight; y++) {
                 var yInd = (cropHeight > 1) ?
                     y1 * (imageHeight - 1) + y * (heightScale) :
@@ -14111,8 +14521,7 @@ var MathBackendCPU = (function () {
                 if (yInd < 0 || yInd > imageHeight - 1) {
                     for (var x = 0; x < cropWidth; x++) {
                         for (var c = 0; c < numChannels; c++) {
-                            var ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = extrapolationValue;
                         }
                     }
@@ -14128,8 +14537,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14152,8 +14560,7 @@ var MathBackendCPU = (function () {
                             var bottomRight = imageVals[ind];
                             var top_2 = topLeft + (topRight - topLeft) * xLerp;
                             var bottom = bottomLeft + (bottomRight - bottomLeft) * xLerp;
-                            ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = top_2 + ((bottom - top_2) * yLerp);
                         }
                     }
@@ -14165,8 +14572,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14174,10 +14580,9 @@ var MathBackendCPU = (function () {
                         var closestX = Math.round(xInd);
                         var closestY = Math.round(yInd);
                         for (var c = 0; c < numChannels; c++) {
-                            var inInd = c + closestX * inStride[2]
-                                + closestY * inStride[1] + bInd * inStride[0];
-                            var outInd = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var inInd = c + closestX * inStride[2] +
+                                closestY * inStride[1] + bInd * inStride[0];
+                            var outInd = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[outInd] = imageVals[inInd];
                         }
                     }
@@ -14186,12 +14591,84 @@ var MathBackendCPU = (function () {
         }
         return output.toTensor();
     };
+    MathBackendCPU.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        return this.scatter(sparseIndices, sparseValues, outputShape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        if (numSlices === 0) {
+            return ops_1.tensor([], resultShape, x.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer([numSlices, sliceSize], x.dtype);
+        var indicesData = indices.dataSync();
+        var xData = x.dataSync();
+        for (var i = 0; i < numSlices; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                flattenIndex += dim * strides[j];
+                index.push(dim);
+            }
+            if (flattenIndex < 0 || flattenIndex >= x.size / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + x.shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                buffer.values[i * sliceSize + k] = xData[flattenIndex * sliceSize + k];
+            }
+        }
+        return buffer.toTensor().reshape(resultShape);
+    };
+    MathBackendCPU.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var defaultValue = ops_1.scalar(0);
+        var sumDupeIndices = true;
+        return this.scatter(indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.scatter = function (indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices) {
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var indicesData = indices.dataSync();
+        var updatesData = updates.dataSync();
+        if (outputSize === 0) {
+            return ops_1.tensor([], shape, updates.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer(flattenShape, updates.dtype);
+        buffer.values.fill(defaultValue.dataSync()[0]);
+        for (var i = 0; i < numUpdates; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                index.push(dim);
+                flattenIndex += dim * strides[j];
+            }
+            if (flattenIndex < 0 || flattenIndex >= outputSize / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                if (sumDupeIndices) {
+                    buffer.values[flattenIndex * sliceSize + k] +=
+                        updatesData[i * sliceSize + k];
+                }
+                else {
+                    buffer.values[flattenIndex * sliceSize + k] = updates.rank === 0 ?
+                        updatesData[0] :
+                        updatesData[i * sliceSize + k];
+                }
+            }
+        }
+        return buffer.toTensor().reshape(shape);
+    };
     return MathBackendCPU;
 }());
 exports.MathBackendCPU = MathBackendCPU;
 environment_1.ENV.registerBackend('cpu', function () { return new MathBackendCPU(); }, 1, tensor_1.setTensorTracker);
 
-},{"../environment":64,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/broadcast_util":139,"../ops/concat_util":143,"../ops/erf_util":146,"../ops/ops":157,"../ops/selu_util":166,"../ops/slice_util":168,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./where_impl":132,"seedrandom":281}],81:[function(require,module,exports){
+},{"../environment":64,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/broadcast_util":151,"../ops/concat_util":155,"../ops/erf_util":159,"../ops/gather_nd_util":161,"../ops/ops":172,"../ops/scatter_nd_util":180,"../ops/selu_util":183,"../ops/slice_util":185,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./where_impl":143,"seedrandom":305}],82:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -14237,7 +14714,7 @@ function reshapeTensor(x, shape) {
 }
 exports.reshapeTensor = reshapeTensor;
 
-},{"../ops/tensor_ops":171,"../tensor":187,"../util":194}],82:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../tensor":207,"../util":214}],83:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14281,7 +14758,9 @@ var log_1 = require("../log");
 var array_ops_util = require("../ops/array_ops_util");
 var axis_util = require("../ops/axis_util");
 var concat_util_1 = require("../ops/concat_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var reduce_util = require("../ops/reduce_util");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var segment_util = require("../ops/segment_util");
 var slice_util_1 = require("../ops/slice_util");
 var softmax_1 = require("../ops/softmax");
@@ -14290,6 +14769,7 @@ var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util_1 = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -14298,31 +14778,39 @@ var topk_impl_1 = require("./topk_impl");
 var argminmax_gpu_1 = require("./webgl/argminmax_gpu");
 var avg_pool_backprop_gpu_1 = require("./webgl/avg_pool_backprop_gpu");
 var batchnorm_gpu_1 = require("./webgl/batchnorm_gpu");
+var batchnorm_packed_gpu_1 = require("./webgl/batchnorm_packed_gpu");
 var binaryop_complex_gpu = require("./webgl/binaryop_complex_gpu");
 var binaryop_complex_gpu_1 = require("./webgl/binaryop_complex_gpu");
 var binaryop_gpu = require("./webgl/binaryop_gpu");
 var binaryop_gpu_1 = require("./webgl/binaryop_gpu");
 var clip_gpu_1 = require("./webgl/clip_gpu");
+var complex_abs_gpu_1 = require("./webgl/complex_abs_gpu");
 var concat_gpu_1 = require("./webgl/concat_gpu");
 var conv_backprop_gpu_1 = require("./webgl/conv_backprop_gpu");
 var conv_backprop_gpu_depthwise_1 = require("./webgl/conv_backprop_gpu_depthwise");
 var conv_gpu_1 = require("./webgl/conv_gpu");
-var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var conv_gpu_depthwise_1 = require("./webgl/conv_gpu_depthwise");
+var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var cumsum_gpu_1 = require("./webgl/cumsum_gpu");
 var depth_to_space_gpu_1 = require("./webgl/depth_to_space_gpu");
 var encode_float_gpu_1 = require("./webgl/encode_float_gpu");
+var fft_gpu = require("./webgl/fft_gpu");
+var fft_gpu_1 = require("./webgl/fft_gpu");
 var from_pixels_gpu_1 = require("./webgl/from_pixels_gpu");
 var gather_gpu_1 = require("./webgl/gather_gpu");
+var gather_nd_gpu_1 = require("./webgl/gather_nd_gpu");
 var gpgpu_context_1 = require("./webgl/gpgpu_context");
 var gpgpu_math = require("./webgl/gpgpu_math");
 var gpgpu_util = require("./webgl/gpgpu_util");
+var im2col_gpu_1 = require("./webgl/im2col_gpu");
 var lrn_gpu_1 = require("./webgl/lrn_gpu");
 var lrn_grad_gpu_1 = require("./webgl/lrn_grad_gpu");
 var max_pool_backprop_gpu_1 = require("./webgl/max_pool_backprop_gpu");
 var mulmat_gpu_1 = require("./webgl/mulmat_gpu");
+var mulmat_packed_gpu_1 = require("./webgl/mulmat_packed_gpu");
 var multinomial_gpu_1 = require("./webgl/multinomial_gpu");
 var onehot_gpu_1 = require("./webgl/onehot_gpu");
+var pack_gpu_1 = require("./webgl/pack_gpu");
 var pad_gpu_1 = require("./webgl/pad_gpu");
 var pool_gpu_1 = require("./webgl/pool_gpu");
 var reduce_gpu_1 = require("./webgl/reduce_gpu");
@@ -14331,6 +14819,7 @@ var resize_bilinear_gpu_1 = require("./webgl/resize_bilinear_gpu");
 var resize_nearest_neighbor_backprop_gpu_1 = require("./webgl/resize_nearest_neighbor_backprop_gpu");
 var resize_nearest_neighbor_gpu_1 = require("./webgl/resize_nearest_neighbor_gpu");
 var reverse_gpu_1 = require("./webgl/reverse_gpu");
+var scatter_gpu_1 = require("./webgl/scatter_gpu");
 var segment_gpu_1 = require("./webgl/segment_gpu");
 var select_gpu_1 = require("./webgl/select_gpu");
 var slice_gpu_1 = require("./webgl/slice_gpu");
@@ -14341,16 +14830,16 @@ var tile_gpu_1 = require("./webgl/tile_gpu");
 var transpose_gpu_1 = require("./webgl/transpose_gpu");
 var unary_op = require("./webgl/unaryop_gpu");
 var unaryop_gpu_1 = require("./webgl/unaryop_gpu");
+var unpack_gpu_1 = require("./webgl/unpack_gpu");
 var webgl_util = require("./webgl/webgl_util");
 var where_impl_1 = require("./where_impl");
 var BEFORE_PAGING_CONSTANT = 300;
-exports.SIZE_UPLOAD_UNIFORM = 32;
+exports.SIZE_UPLOAD_UNIFORM = 4;
 var MathBackendWebGL = (function () {
     function MathBackendWebGL(gpgpu, delayedStorage) {
         if (delayedStorage === void 0) { delayedStorage = true; }
         this.gpgpu = gpgpu;
         this.delayedStorage = delayedStorage;
-        this.texData = new WeakMap();
         this.pendingRead = new WeakMap();
         this.pendingDisposal = new WeakSet();
         this.lruDataGPU = [];
@@ -14372,9 +14861,12 @@ var MathBackendWebGL = (function () {
         else {
             this.gpgpuCreatedLocally = false;
         }
-        this.NUM_BYTES_BEFORE_PAGING =
-            (window.screen.height * window.screen.width * window.devicePixelRatio) *
-                BEFORE_PAGING_CONSTANT;
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.NUM_BYTES_BEFORE_PAGING =
+                (window.screen.height * window.screen.width *
+                    window.devicePixelRatio) *
+                    BEFORE_PAGING_CONSTANT;
+        }
         this.textureManager = new texture_manager_1.TextureManager(this.gpgpu);
     }
     MathBackendWebGL.prototype.register = function (dataId, shape, dtype) {
@@ -14388,8 +14880,12 @@ var MathBackendWebGL = (function () {
             texture: null,
             complexTensors: null,
             texShape: null,
-            usage: tex_util_1.TextureUsage.RENDER
+            usage: tex_util_1.TextureUsage.RENDER,
+            isPacked: false
         });
+    };
+    MathBackendWebGL.prototype.setDataMover = function (dataMover) {
+        this.texData = new backend_1.DataStorage(dataMover);
     };
     MathBackendWebGL.prototype.fromPixels = function (pixels, numChannels) {
         if (pixels == null) {
@@ -14422,27 +14918,31 @@ var MathBackendWebGL = (function () {
             this.fromPixelsCanvas.getContext('2d').drawImage(pixels, 0, 0, pixels.width, pixels.height);
             pixels = this.fromPixelsCanvas;
         }
-        var tempPixelArray = tensor_1.Tensor.make(texShape, {}, 'int32');
-        this.texData.get(tempPixelArray.dataId).usage = tex_util_1.TextureUsage.PIXELS;
-        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelArray.dataId), pixels);
+        var tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
+        this.texData.get(tempPixelHandle.dataId).usage = tex_util_1.TextureUsage.PIXELS;
+        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelHandle.dataId), pixels);
         var program = new from_pixels_gpu_1.FromPixelsProgram(outShape);
-        var res = this.compileAndRun(program, [tempPixelArray]);
-        tempPixelArray.dispose();
+        var res = this.compileAndRun(program, [tempPixelHandle]);
+        this.disposeData(tempPixelHandle.dataId);
         return res;
+    };
+    MathBackendWebGL.prototype.makeTensorHandle = function (shape, dtype) {
+        var dataId = {};
+        this.register(dataId, shape, dtype);
+        return { dataId: dataId, shape: shape, dtype: dtype };
     };
     MathBackendWebGL.prototype.write = function (dataId, values) {
         if (values == null) {
             throw new Error('MathBackendWebGL.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype;
+        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype, isPacked = texData.isPacked;
         if (dtype === 'complex64') {
             throw new Error("Cannot write to a complex64 dtype. " +
                 "Please use tf.complex(real, imag).");
         }
         if (texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -14453,9 +14953,8 @@ var MathBackendWebGL = (function () {
         }
     };
     MathBackendWebGL.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype, complexTensors = texData.complexTensors;
+        var values = texData.values, dtype = texData.dtype, complexTensors = texData.complexTensors;
         if (values != null) {
             this.cacheOnCPU(dataId);
             return values;
@@ -14472,8 +14971,7 @@ var MathBackendWebGL = (function () {
             result = complex_util_1.mergeRealAndImagArrays(realValues, imagValues);
         }
         else {
-            result =
-                this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+            result = this.getValuesFromTexture(dataId);
         }
         if (shouldTimeProgram) {
             this.downloadWaitMs += performance.now() - start;
@@ -14483,7 +14981,7 @@ var MathBackendWebGL = (function () {
     };
     MathBackendWebGL.prototype.read = function (dataId) {
         return __awaiter(this, void 0, void 0, function () {
-            var subscribers_1, texData, shape, texture, values, texShape, dtype, bufferOrTexture, vals, subscribers;
+            var subscribers_1, texData, texture, values, texShape, bufferOrTexture, vals, subscribers;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14491,9 +14989,8 @@ var MathBackendWebGL = (function () {
                             subscribers_1 = this.pendingRead.get(dataId);
                             return [2, new Promise(function (resolve) { return subscribers_1.push(resolve); })];
                         }
-                        this.throwIfNoData(dataId);
                         texData = this.texData.get(dataId);
-                        shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype;
+                        texture = texData.texture, values = texData.values, texShape = texData.texShape;
                         if (values != null) {
                             this.cacheOnCPU(dataId);
                             return [2, values];
@@ -14509,7 +15006,7 @@ var MathBackendWebGL = (function () {
                     case 1:
                         _a.sent();
                         if (bufferOrTexture instanceof WebGLTexture) {
-                            vals = this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+                            vals = this.getValuesFromTexture(dataId);
                         }
                         else {
                             vals = this.gpgpu.downloadFloat32MatrixFromBuffer(bufferOrTexture, texShape[0], texShape[1]);
@@ -14527,25 +15024,33 @@ var MathBackendWebGL = (function () {
             });
         });
     };
-    MathBackendWebGL.prototype.getValuesFromTexture = function (texture, dataId, dtype, texShape, shape) {
+    MathBackendWebGL.prototype.getValuesFromTexture = function (dataId) {
+        var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype, texture = _a.texture, texShape = _a.texShape;
         if (environment_1.ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
-            return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            if (this.texData.get(dataId).isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                return this.gpgpu.downloadMatrixFromPackedTexture(texture, batch, rows, cols, texShape[0], texShape[1]);
+            }
+            else {
+                return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            }
         }
-        var tmpTarget = tensor_1.Tensor.make(shape, {});
+        var tmpTarget = this.makeTensorHandle(shape, 'float32');
+        tmpTarget.size = util_1.sizeFromShape(shape);
         this.texData.get(tmpTarget.dataId).usage = tex_util_1.TextureUsage.DOWNLOAD;
-        var tmpInput = tensor_1.Tensor.make(shape, { dataId: dataId }, dtype);
         var program = new encode_float_gpu_1.EncodeFloatProgram(shape);
         var pageToCpu = false;
-        this.compileAndRun(program, [tmpInput], tmpTarget, null, pageToCpu);
+        this.compileAndRun(program, [{ shape: shape, dtype: dtype, dataId: dataId }], tmpTarget, null, pageToCpu);
         var tmpData = this.texData.get(tmpTarget.dataId);
         var vals = this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
-        tmpInput.dispose();
-        tmpTarget.dispose();
+        this.disposeData(tmpTarget.dataId);
         return vals;
     };
     MathBackendWebGL.prototype.time = function (f) {
         return __awaiter(this, void 0, void 0, function () {
-            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimers, kernelMs, res;
+            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimerQueries, flattenedActiveTimerNames, kernelMs, res;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14561,22 +15066,26 @@ var MathBackendWebGL = (function () {
                         }
                         this.activeTimers = newActiveTimers;
                         f();
-                        flattenedActiveTimers = util.flatten(this.activeTimers);
+                        flattenedActiveTimerQueries = util.flatten(this.activeTimers.map(function (d) { return d.query; }))
+                            .filter(function (d) { return d != null; });
+                        flattenedActiveTimerNames = util.flatten(this.activeTimers.map(function (d) { return d.name; }))
+                            .filter(function (d) { return d != null; });
                         this.activeTimers = oldActiveTimers;
                         if (outerMostTime) {
                             this.programTimersStack = null;
                         }
-                        return [4, Promise.all(flattenedActiveTimers).then(function (results) {
-                                var sum = 0;
-                                results.forEach(function (result) { return sum += result; });
-                                return sum;
-                            })];
+                        return [4, Promise.all(flattenedActiveTimerQueries)];
                     case 1:
                         kernelMs = _a.sent();
                         res = {
                             uploadWaitMs: this.uploadWaitMs,
                             downloadWaitMs: this.downloadWaitMs,
-                            kernelMs: kernelMs,
+                            kernelMs: util.sum(kernelMs),
+                            getExtraProfileInfo: function () {
+                                return kernelMs.map(function (d, i) { return ({ name: flattenedActiveTimerNames[i], ms: d }); })
+                                    .map(function (d) { return d.name + ": " + d.ms; })
+                                    .join(', ');
+                            },
                             wallMs: null
                         };
                         this.uploadWaitMs = 0;
@@ -14624,9 +15133,9 @@ var MathBackendWebGL = (function () {
             return;
         }
         if (this.texData.has(dataId)) {
-            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors;
+            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors, isPacked = _a.isPacked;
             if (texture != null) {
-                this.releaseTexture(dataId, texture, texShape, usage);
+                this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             }
             if (complexTensors != null) {
                 complexTensors.real.dispose();
@@ -14646,7 +15155,7 @@ var MathBackendWebGL = (function () {
         return this.canvas;
     };
     MathBackendWebGL.prototype.complex = function (real, imag) {
-        var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
+        var result = this.makeOutputArray(real.shape, 'complex64');
         var resultData = this.texData.get(result.dataId);
         resultData.complexTensors = {
             real: environment_1.ENV.engine.keep(real.clone()),
@@ -14703,8 +15212,18 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.batchMatMul = function (a, b, transposeA, transposeB) {
-        var program = new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-        return this.compileAndRun(program, [a, b]);
+        var outerShapeA = transposeA ? a.shape[2] : a.shape[1];
+        var outerShapeB = transposeB ? b.shape[1] : b.shape[2];
+        if (a.shape[0] === 1 && b.shape[0] === 1) {
+            var aSqueezed = a.as2D(a.shape[1], a.shape[2]);
+            var bSqueezed = b.as2D(b.shape[1], b.shape[2]);
+            var program = new mulmat_packed_gpu_1.MatMulPackedProgram(aSqueezed.shape, bSqueezed.shape, [outerShapeA, outerShapeB], transposeA, transposeB);
+            var result = this.unpackTensor(this.compileAndRun(program, [aSqueezed, bSqueezed], this.makePackedTensor(program.outputShape)));
+            return result.reshape([1, result.shape[0], result.shape[1]]);
+        }
+        else {
+            return this.compileAndRun(new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB), [a, b]);
+        }
     };
     MathBackendWebGL.prototype.multiply = function (a, b) {
         if (a.dtype === 'complex64') {
@@ -14741,8 +15260,14 @@ var MathBackendWebGL = (function () {
             scaleShape = scale.shape;
             inputs.push(scale);
         }
-        var program = new batchnorm_gpu_1.BatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
-        return this.compileAndRun(program, inputs);
+        var output = null;
+        var envSpecificBatchNormProgram = batchnorm_gpu_1.BatchNormProgram;
+        if (environment_1.ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
+            output = this.makePackedTensor(x.shape);
+            envSpecificBatchNormProgram = batchnorm_packed_gpu_1.BatchNormPackedProgram;
+        }
+        var program = new envSpecificBatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
+        return this.compileAndRun(program, inputs, output);
     };
     MathBackendWebGL.prototype.localResponseNormalization4D = function (x, radius, bias, alpha, beta) {
         var program = new lrn_gpu_1.LRNProgram(x.shape, radius, bias, alpha, beta);
@@ -14841,6 +15366,13 @@ var MathBackendWebGL = (function () {
         var a2D = x.as2D(-1, inSize);
         var outputDType = types_1.sumOutType(x.dtype);
         return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+    };
+    MathBackendWebGL.prototype.prod = function (x, axes) {
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var inSize = util.sizeFromShape(reduceShape);
+        var a2D = x.as2D(-1, inSize);
+        var outputDType = types_1.sumOutType(x.dtype);
+        return this.reduce(a2D, 'prod', outputDType).reshape(outShape);
     };
     MathBackendWebGL.prototype.unsortedSegmentSum = function (x, segmentIds, numSegments) {
         var axis = 0;
@@ -15149,6 +15681,15 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.abs = function (x) {
+        if (x.dtype === 'complex64') {
+            var xData = this.texData.get(x.dataId);
+            var program_1 = new complex_abs_gpu_1.ComplexAbsProgram(x.shape);
+            var inputs = [
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+            ];
+            return this.compileAndRun(program_1, inputs);
+        }
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.ABS);
         return this.compileAndRun(program, [x]);
     };
@@ -15222,7 +15763,23 @@ var MathBackendWebGL = (function () {
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.STEP(alpha));
         return this.compileAndRun(program, [x]);
     };
+    MathBackendWebGL.prototype.conv2dWithIm2Row = function (x, filter, convInfo) {
+        var filterWidth = convInfo.filterWidth, filterHeight = convInfo.filterHeight, inChannels = convInfo.inChannels, outWidth = convInfo.outWidth, outHeight = convInfo.outHeight;
+        var sharedDim = filterWidth * filterHeight * inChannels;
+        var numCols = outHeight * outWidth;
+        var x2ColShape = [sharedDim, numCols];
+        var xSqueezed = x.squeeze([0]);
+        var w2Row = filter.reshape([sharedDim, -1]);
+        var im2ColProgram = new im2col_gpu_1.Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
+        var im2Col = this.compileAndRun(im2ColProgram, [xSqueezed], this.makePackedTensor(x2ColShape));
+        var matmulProgram = new mulmat_packed_gpu_1.MatMulPackedProgram(im2Col.shape, w2Row.shape, [numCols, convInfo.outChannels], true, false);
+        var product = this.unpackTensor(this.compileAndRun(matmulProgram, [im2Col, w2Row], this.makePackedTensor(matmulProgram.outputShape)));
+        return product.reshape([1, outHeight, outWidth, convInfo.outChannels]);
+    };
     MathBackendWebGL.prototype.conv2d = function (x, filter, convInfo) {
+        if (environment_1.ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
+            return this.conv2dWithIm2Row(x, filter, convInfo);
+        }
         var program = new conv_gpu_1.Conv2DProgram(convInfo);
         return this.compileAndRun(program, [x, filter]);
     };
@@ -15335,14 +15892,69 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.split = function (x, sizeSplits, axis) {
         return split_shared_1.split(x, sizeSplits, axis);
     };
+    MathBackendWebGL.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var flattenIndices = indices.reshape([numUpdates, sliceRank]);
+        var flattenX = updates.reshape([numUpdates, sliceSize]);
+        if (outputSize === 0) {
+            return backend_util.reshapeTensor(tensor_ops_1.tensor([]), shape);
+        }
+        var defaultValue = tensor_ops_1.scalar(0);
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, flattenIndices.rank, flattenX.rank, strides, flattenShape);
+        return this.compileAndRun(program, [flattenX, flattenIndices, defaultValue])
+            .reshape(shape);
+    };
+    MathBackendWebGL.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, sparseIndices.rank, sparseValues.rank, strides, [outputSize, 1], sumDupeIndices);
+        return this.compileAndRun(program, [sparseValues, sparseIndices, defaultValue])
+            .reshape(outputShape);
+    };
+    MathBackendWebGL.prototype.fft = function (x) {
+        var xData = this.texData.get(x.dataId);
+        var realProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
+        var imagProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+        var inputs = [
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+        ];
+        var real = this.compileAndRun(realProgram, inputs);
+        var imag = this.compileAndRun(imagProgram, inputs);
+        var complex = this.complex(real, imag).as2D(x.shape[0], x.shape[1]);
+        real.dispose();
+        imag.dispose();
+        return complex;
+    };
+    MathBackendWebGL.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        var flattenIndices = indices.reshape([numSlices, sliceRank]);
+        var flattenX = x.reshape([x.size / sliceSize, sliceSize]);
+        var program = new gather_nd_gpu_1.GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+        return this.compileAndRun(program, [flattenX, flattenIndices])
+            .reshape(resultShape);
+    };
     MathBackendWebGL.prototype.makeOutputArray = function (shape, dtype) {
         return tensor_1.Tensor.make(shape, {}, dtype);
+    };
+    MathBackendWebGL.prototype.makePackedTensor = function (shape) {
+        var packedTensor = tensor_1.Tensor.make(shape, {});
+        this.texData.get(packedTensor.dataId).isPacked = true;
+        return packedTensor;
+    };
+    MathBackendWebGL.prototype.unpackTensor = function (input) {
+        var program = new unpack_gpu_1.UnpackProgram(input.shape);
+        return this.compileAndRun(program, [input]);
     };
     MathBackendWebGL.prototype.compileAndRun = function (program, inputs, output, customSetup, pageToCpu) {
         var _this = this;
         if (pageToCpu === void 0) { pageToCpu = true; }
         if (output == null) {
-            output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+            output =
+                this.makeOutputArray(program.outputShape, inputs[0].dtype);
         }
         if (output.size === 0) {
             this.texData.get(output.dataId).values =
@@ -15357,13 +15969,29 @@ var MathBackendWebGL = (function () {
             }
             var texData = _this.texData.get(input.dataId);
             if (texData.texture == null &&
-                util.sizeFromShape(input.shape) <= exports.SIZE_UPLOAD_UNIFORM) {
+                !(!texData.isPacked && program.usesPackedTextures) &&
+                util.sizeFromShape(input.shape) <=
+                    environment_1.ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
                 return {
                     shape: input.shape,
                     texData: null,
                     isUniform: true,
                     uniformValues: _this.readSync(input.dataId)
                 };
+            }
+            if (texData.isPacked !== !!program.usesPackedTextures) {
+                var preProcessProgram = void 0;
+                var processedInput = void 0;
+                if (texData.isPacked) {
+                    preProcessProgram = new unpack_gpu_1.UnpackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input]);
+                }
+                else {
+                    preProcessProgram = new pack_gpu_1.PackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input], _this.makePackedTensor(input.shape));
+                }
+                texData = _this.texData.get(processedInput.dataId);
+                input = processedInput;
             }
             _this.uploadToGPU(input.dataId);
             return { shape: input.shape, texData: texData, isUniform: false };
@@ -15384,7 +16012,8 @@ var MathBackendWebGL = (function () {
             query = this.startTimer();
         }
         gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-        if (pageToCpu && this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED') && pageToCpu &&
+            this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
             var numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
             while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
                 var dataId = this.lruDataGPU.shift();
@@ -15395,7 +16024,7 @@ var MathBackendWebGL = (function () {
         }
         if (shouldTimeProgram) {
             query = this.endTimer(query);
-            this.activeTimers.push(this.getQueryTime(query));
+            this.activeTimers.push({ name: program.constructor.name, query: this.getQueryTime(query) });
         }
         return output;
     };
@@ -15434,22 +16063,16 @@ var MathBackendWebGL = (function () {
             return 16;
         });
     };
-    MathBackendWebGL.prototype.throwIfNoData = function (dataId) {
-        if (!this.texData.has(dataId)) {
-            throw new Error("WebGL backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
-    };
     MathBackendWebGL.prototype.uploadToGPU = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage;
+        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (texture != null) {
-            var index = this.lruDataGPU.indexOf(dataId);
-            if (index >= 0) {
-                this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
-                this.lruDataGPU.push(dataId);
+            if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+                var index = this.lruDataGPU.indexOf(dataId);
+                if (index >= 0) {
+                    this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
+                    this.lruDataGPU.push(dataId);
+                }
             }
             return;
         }
@@ -15458,12 +16081,20 @@ var MathBackendWebGL = (function () {
         if (shouldTimeProgram) {
             start = performance.now();
         }
-        var texShape = webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        var texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
         texData.texShape = texShape;
-        var newTexture = this.acquireTexture(dataId, texShape, usage);
+        var newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
         texData.texture = newTexture;
         if (values != null) {
-            this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            if (isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                this.gpgpu.uploadMatrixToPackedTexture(newTexture, batch, rows, cols, typedArrayToFloat32(values, dtype));
+            }
+            else {
+                this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            }
             texData.values = null;
             if (shouldTimeProgram) {
                 this.uploadWaitMs += performance.now() - start;
@@ -15473,9 +16104,9 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.cacheOnCPU = function (dataId, float32Values) {
         var dontKeepCopyOnGPU = this.delayedStorage;
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage;
+        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (dontKeepCopyOnGPU && texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -15484,20 +16115,24 @@ var MathBackendWebGL = (function () {
             texData.values = float32ToTypedArray(float32Values, dtype);
         }
     };
-    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType) {
+    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        var idx = this.lruDataGPU.indexOf(dataId);
-        if (idx >= 0) {
-            this.lruDataGPU.splice(idx, 1);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            var idx = this.lruDataGPU.indexOf(dataId);
+            if (idx >= 0) {
+                this.lruDataGPU.splice(idx, 1);
+            }
         }
         this.numBytesInGPU -= this.computeBytes(shape, dtype);
-        this.textureManager.releaseTexture(texture, texShape, texType);
+        this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
     };
-    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType) {
+    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        this.lruDataGPU.push(dataId);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.lruDataGPU.push(dataId);
+        }
         this.numBytesInGPU += this.computeBytes(shape, dtype);
-        return this.textureManager.acquireTexture(texShape, texType);
+        return this.textureManager.acquireTexture(texShape, texType, isPacked);
     };
     MathBackendWebGL.prototype.computeBytes = function (shape, dtype) {
         return util.sizeFromShape(shape) * util.bytesPerElement(dtype);
@@ -15528,7 +16163,7 @@ function typedArrayToFloat32(a, dtype) {
     return (a instanceof Float32Array) ? a : new Float32Array(a);
 }
 
-},{"../environment":64,"../globals":66,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/concat_util":143,"../ops/reduce_util":160,"../ops/segment_util":165,"../ops/slice_util":168,"../ops/softmax":169,"../ops/tensor_ops":171,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./webgl/argminmax_gpu":87,"./webgl/avg_pool_backprop_gpu":88,"./webgl/batchnorm_gpu":89,"./webgl/binaryop_complex_gpu":90,"./webgl/binaryop_gpu":91,"./webgl/clip_gpu":92,"./webgl/concat_gpu":93,"./webgl/conv_backprop_gpu":94,"./webgl/conv_backprop_gpu_depthwise":95,"./webgl/conv_gpu":96,"./webgl/conv_gpu_depthwise":97,"./webgl/crop_and_resize_gpu":98,"./webgl/cumsum_gpu":99,"./webgl/depth_to_space_gpu":100,"./webgl/encode_float_gpu":101,"./webgl/from_pixels_gpu":102,"./webgl/gather_gpu":103,"./webgl/gpgpu_context":104,"./webgl/gpgpu_math":105,"./webgl/gpgpu_util":106,"./webgl/lrn_gpu":107,"./webgl/lrn_grad_gpu":108,"./webgl/max_pool_backprop_gpu":109,"./webgl/mulmat_gpu":110,"./webgl/multinomial_gpu":111,"./webgl/onehot_gpu":112,"./webgl/pad_gpu":113,"./webgl/pool_gpu":114,"./webgl/reduce_gpu":115,"./webgl/resize_bilinear_backprop_gpu":116,"./webgl/resize_bilinear_gpu":117,"./webgl/resize_nearest_neighbor_backprop_gpu":118,"./webgl/resize_nearest_neighbor_gpu":119,"./webgl/reverse_gpu":120,"./webgl/segment_gpu":121,"./webgl/select_gpu":122,"./webgl/slice_gpu":124,"./webgl/strided_slice_gpu":125,"./webgl/tex_util":126,"./webgl/texture_manager":127,"./webgl/tile_gpu":128,"./webgl/transpose_gpu":129,"./webgl/unaryop_gpu":130,"./webgl/webgl_util":131,"./where_impl":132}],83:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/concat_util":155,"../ops/gather_nd_util":161,"../ops/reduce_util":175,"../ops/scatter_nd_util":180,"../ops/segment_util":182,"../ops/slice_util":185,"../ops/softmax":186,"../ops/tensor_ops":191,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./webgl/argminmax_gpu":89,"./webgl/avg_pool_backprop_gpu":90,"./webgl/batchnorm_gpu":91,"./webgl/batchnorm_packed_gpu":92,"./webgl/binaryop_complex_gpu":93,"./webgl/binaryop_gpu":94,"./webgl/clip_gpu":95,"./webgl/complex_abs_gpu":96,"./webgl/concat_gpu":97,"./webgl/conv_backprop_gpu":98,"./webgl/conv_backprop_gpu_depthwise":99,"./webgl/conv_gpu":100,"./webgl/conv_gpu_depthwise":101,"./webgl/crop_and_resize_gpu":102,"./webgl/cumsum_gpu":103,"./webgl/depth_to_space_gpu":104,"./webgl/encode_float_gpu":105,"./webgl/fft_gpu":106,"./webgl/from_pixels_gpu":107,"./webgl/gather_gpu":108,"./webgl/gather_nd_gpu":109,"./webgl/gpgpu_context":110,"./webgl/gpgpu_math":111,"./webgl/gpgpu_util":112,"./webgl/im2col_gpu":113,"./webgl/lrn_gpu":114,"./webgl/lrn_grad_gpu":115,"./webgl/max_pool_backprop_gpu":116,"./webgl/mulmat_gpu":117,"./webgl/mulmat_packed_gpu":118,"./webgl/multinomial_gpu":119,"./webgl/onehot_gpu":120,"./webgl/pack_gpu":121,"./webgl/pad_gpu":122,"./webgl/pool_gpu":123,"./webgl/reduce_gpu":124,"./webgl/resize_bilinear_backprop_gpu":125,"./webgl/resize_bilinear_gpu":126,"./webgl/resize_nearest_neighbor_backprop_gpu":127,"./webgl/resize_nearest_neighbor_gpu":128,"./webgl/reverse_gpu":129,"./webgl/scatter_gpu":130,"./webgl/segment_gpu":131,"./webgl/select_gpu":132,"./webgl/slice_gpu":134,"./webgl/strided_slice_gpu":135,"./webgl/tex_util":136,"./webgl/texture_manager":137,"./webgl/tile_gpu":138,"./webgl/transpose_gpu":139,"./webgl/unaryop_gpu":140,"./webgl/unpack_gpu":141,"./webgl/webgl_util":142,"./where_impl":143}],84:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function mergeRealAndImagArrays(real, imag) {
@@ -15554,8 +16189,59 @@ function splitRealAndImagArrays(complex) {
     return { real: real, imag: imag };
 }
 exports.splitRealAndImagArrays = splitRealAndImagArrays;
+function complexWithEvenIndex(complex) {
+    var len = Math.ceil(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 0; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithEvenIndex = complexWithEvenIndex;
+function complexWithOddIndex(complex) {
+    var len = Math.floor(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 2; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithOddIndex = complexWithOddIndex;
+function getComplexWithIndex(complex, index) {
+    var real = complex[index * 2];
+    var imag = complex[index * 2 + 1];
+    return { real: real, imag: imag };
+}
+exports.getComplexWithIndex = getComplexWithIndex;
+function assignToTypedArray(data, real, imag, index) {
+    data[index * 2] = real;
+    data[index * 2 + 1] = imag;
+}
+exports.assignToTypedArray = assignToTypedArray;
+function exponents(n) {
+    var real = new Float32Array(n / 2);
+    var imag = new Float32Array(n / 2);
+    for (var i = 0; i < Math.ceil(n / 2); i++) {
+        var x = -2 * Math.PI * (i / n);
+        real[i] = Math.cos(x);
+        imag[i] = Math.sin(x);
+    }
+    return { real: real, imag: imag };
+}
+exports.exponents = exponents;
+function exponent(k, n) {
+    var x = -2 * Math.PI * (k / n);
+    var real = Math.cos(x);
+    var imag = Math.sin(x);
+    return { real: real, imag: imag };
+}
+exports.exponent = exponent;
 
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15613,7 +16299,33 @@ function intersectionOverUnion(boxes, i, j) {
     return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 
-},{"../ops/tensor_ops":171}],85:[function(require,module,exports){
+},{"../ops/tensor_ops":191}],86:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function getChannels(name) {
+    return ['x', 'y', 'z', 'w'].map(function (d) { return name + "." + d; });
+}
+exports.getChannels = getChannels;
+function getInnerDims(rank, dims) {
+    return dims.slice(0, rank).slice(-2);
+}
+exports.getInnerDims = getInnerDims;
+function getSourceCoords(rank, dims) {
+    if (rank === 1) {
+        return 'rc';
+    }
+    var coords = '';
+    for (var i = 0; i < rank; i++) {
+        coords += dims[i];
+        if (i < rank - 1) {
+            coords += ',';
+        }
+    }
+    return coords;
+}
+exports.getSourceCoords = getSourceCoords;
+
+},{}],87:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function split(x, sizeSplits, axis) {
@@ -15628,7 +16340,7 @@ function split(x, sizeSplits, axis) {
 }
 exports.split = split;
 
-},{}],86:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15663,7 +16375,7 @@ function topkImpl(x, xShape, xDtype, k, sorted) {
 }
 exports.topkImpl = topkImpl;
 
-},{"../ops/tensor_ops":171,"../util":194}],87:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214}],89:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ArgMinMaxProgram = (function () {
@@ -15681,13 +16393,13 @@ var ArgMinMaxProgram = (function () {
         var indexSnippet = firstPass ?
             'inOffset + i;' :
             'round(getBestIndicesA(batch, inOffset + i));';
-        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = 0;\n        float bestValue = getA(batch, inOffset);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
+        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = inOffset;\n        float bestValue = getA(batch, bestIndex);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
     }
     return ArgMinMaxProgram;
 }());
 exports.ArgMinMaxProgram = ArgMinMaxProgram;
 
-},{}],88:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var AvgPool2DBackpropProgram = (function () {
@@ -15698,16 +16410,20 @@ var AvgPool2DBackpropProgram = (function () {
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
         var avgMultiplier = 1 / (filterHeight * filterWidth);
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + ";\n            wC+= " + dilationWidth + ") {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return AvgPool2DBackpropProgram;
 }());
 exports.AvgPool2DBackpropProgram = AvgPool2DBackpropProgram;
 
-},{}],89:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15731,13 +16447,52 @@ var BatchNormProgram = (function () {
             scaleSnippet = 'getScaleAtOutCoords()';
         }
         this.outputShape = xShape;
-        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput(dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));\n      }\n    ";
     }
     return BatchNormProgram;
 }());
 exports.BatchNormProgram = BatchNormProgram;
 
-},{"../../ops/broadcast_util":139}],90:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],92:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var broadcast_util = require("../../ops/broadcast_util");
+var BatchNormPackedProgram = (function () {
+    function BatchNormPackedProgram(xShape, meanShape, varianceShape, offsetShape, scaleShape, varianceEpsilon) {
+        this.supportsBroadcasting = true;
+        this.usesPackedTextures = true;
+        this.variableNames = ['x', 'mean', 'variance'];
+        broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+        broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+        var meanSnippet = broadcastSample('mean', meanShape.length);
+        var varianceSnippet = broadcastSample('variance', varianceShape.length);
+        var offsetSnippet = 'vec4 offset = vec4(0.0)';
+        if (offsetShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+            this.variableNames.push('offset');
+            offsetSnippet = broadcastSample('offset', offsetShape.length);
+        }
+        var scaleSnippet = 'vec4 scale = vec4(1.0)';
+        if (scaleShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+            this.variableNames.push('scale');
+            scaleSnippet = broadcastSample('scale', scaleShape.length);
+        }
+        this.outputShape = xShape;
+        this.userCode = "\n      void main() {\n        ivec4 rc = getOutputCoords();\n\n        " + offsetSnippet + ";\n        " + scaleSnippet + ";\n\n        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);\n        " + meanSnippet + ";\n        " + varianceSnippet + ";\n\n        vec4 inv = scale * inversesqrt(variance + vec4(" + varianceEpsilon + "));\n\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+    }
+    return BatchNormPackedProgram;
+}());
+exports.BatchNormPackedProgram = BatchNormPackedProgram;
+function broadcastSample(texName, rank) {
+    var texSampler = "get" + texName.charAt(0).toUpperCase() + texName.slice(1);
+    if (rank === 1) {
+        return "\n      vec4 " + texName + "Sample = " + texSampler + "(rc.w);\n      vec4 " + texName + " = vec4(" + texName + "Sample.xy, " + texName + "Sample.xy);\n    ";
+    }
+    return "vec4 " + texName + " = " + texSampler + "(rc.x, rc.y, rc.z, rc.w)";
+}
+
+},{"../../ops/broadcast_util":151}],93:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15757,7 +16512,7 @@ var BinaryOpComplexProgram = (function () {
 }());
 exports.BinaryOpComplexProgram = BinaryOpComplexProgram;
 
-},{"../../ops/broadcast_util":139}],91:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],94:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15806,7 +16561,7 @@ var BinaryOpProgram = (function () {
 }());
 exports.BinaryOpProgram = BinaryOpProgram;
 
-},{"../../ops/broadcast_util":139}],92:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],95:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ClipProgram = (function () {
@@ -15819,7 +16574,20 @@ var ClipProgram = (function () {
 }());
 exports.ClipProgram = ClipProgram;
 
-},{}],93:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var ComplexAbsProgram = (function () {
+    function ComplexAbsProgram(shape) {
+        this.variableNames = ['real', 'imag'];
+        this.outputShape = shape;
+        this.userCode = "\n      void main() {\n        float real = getRealAtOutCoords();\n        float imag = getImagAtOutCoords();\n        vec2 v = vec2(real, imag);\n\n        setOutput(sqrt(dot(v, v)));\n      }\n    ";
+    }
+    return ComplexAbsProgram;
+}());
+exports.ComplexAbsProgram = ComplexAbsProgram;
+
+},{}],97:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var concat_util = require("../../ops/concat_util");
@@ -15835,7 +16603,7 @@ var ConcatProgram = (function () {
 }());
 exports.ConcatProgram = ConcatProgram;
 
-},{"../../ops/concat_util":143}],94:[function(require,module,exports){
+},{"../../ops/concat_util":155}],98:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DDerFilterProgram = (function () {
@@ -15867,7 +16635,7 @@ var Conv2DDerInputProgram = (function () {
 }());
 exports.Conv2DDerInputProgram = Conv2DDerInputProgram;
 
-},{}],95:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DDerFilterProgram = (function () {
@@ -15901,7 +16669,7 @@ var DepthwiseConv2DDerInputProgram = (function () {
 }());
 exports.DepthwiseConv2DDerInputProgram = DepthwiseConv2DDerInputProgram;
 
-},{}],96:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DProgram = (function () {
@@ -15924,7 +16692,7 @@ var Conv2DProgram = (function () {
 }());
 exports.Conv2DProgram = Conv2DProgram;
 
-},{}],97:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DProgram = (function () {
@@ -15948,7 +16716,7 @@ var DepthwiseConv2DProgram = (function () {
 }());
 exports.DepthwiseConv2DProgram = DepthwiseConv2DProgram;
 
-},{}],98:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var CropAndResizeProgram = (function () {
@@ -15989,7 +16757,7 @@ var CropAndResizeProgram = (function () {
 }());
 exports.CropAndResizeProgram = CropAndResizeProgram;
 
-},{}],99:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16040,7 +16808,7 @@ function getFinalCoord(rank, name) {
     }
 }
 
-},{"./shader_compiler":123}],100:[function(require,module,exports){
+},{"./shader_compiler":133}],104:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthToSpaceProgram = (function () {
@@ -16096,7 +16864,7 @@ var DepthToSpaceProgram = (function () {
 }());
 exports.DepthToSpaceProgram = DepthToSpaceProgram;
 
-},{}],101:[function(require,module,exports){
+},{}],105:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var EncodeFloatProgram = (function () {
@@ -16109,7 +16877,25 @@ var EncodeFloatProgram = (function () {
 }());
 exports.EncodeFloatProgram = EncodeFloatProgram;
 
-},{}],102:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COMPLEX_FFT = {
+    REAL: 'return real * expR - imag * expI;',
+    IMAG: 'return real * expI + imag * expR;'
+};
+var FFTProgram = (function () {
+    function FFTProgram(op, inputShape) {
+        this.variableNames = ['real', 'imag'];
+        var innerDim = inputShape[1];
+        this.outputShape = inputShape;
+        this.userCode = "\n      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;\n\n      float unaryOpComplex(float real, float expR, float imag, float expI) {\n        " + op + "\n      }\n\n      float mulMatDFT(int batch, int index) {\n        float indexRatio = float(index) / float(" + innerDim + ");\n        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;\n\n        float result = 0.0;\n\n        for (int i = 0; i < " + innerDim + "; i++) {\n          // x = (-2 * PI / N) * index * i;\n          float x = negativeTwoPiTimesIndexRatio * float(i);\n          float expR = cos(x);\n          float expI = sin(x);\n          float real = getReal(batch, i);\n          float imag = getImag(batch, i);\n\n          result += unaryOpComplex(real, expR, imag, expI);\n        }\n\n        return result;\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        setOutput(mulMatDFT(coords[0], coords[1]));\n      }\n    ";
+    }
+    return FFTProgram;
+}());
+exports.FFTProgram = FFTProgram;
+
+},{}],107:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var FromPixelsProgram = (function () {
@@ -16123,7 +16909,7 @@ var FromPixelsProgram = (function () {
 }());
 exports.FromPixelsProgram = FromPixelsProgram;
 
-},{}],103:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16162,7 +16948,26 @@ function getSourceCoords(aShape, axis) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],104:[function(require,module,exports){
+},{"./shader_compiler":133}],109:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var GatherNDProgram = (function () {
+    function GatherNDProgram(sliceDim, strides, shape) {
+        this.sliceDim = sliceDim;
+        this.strides = strides;
+        this.variableNames = ['x', 'indices'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + this.strides + ");\n         void main() {\n          " + dtype + " coords = getOutputCoords();\n          int flattenIndex = 0;\n          for (int j = 0; j < " + this.sliceDim + "; j++) {\n            int index = round(getIndices(coords[0], j));\n            flattenIndex += index * " + strideString + ";\n          }\n          setOutput(getX(flattenIndex, coords[1]));\n        }\n      ";
+    }
+    return GatherNDProgram;
+}());
+exports.GatherNDProgram = GatherNDProgram;
+
+},{"./shader_compiler":133}],110:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16290,6 +17095,10 @@ var GPGPUContext = (function () {
         this.throwIfDisposed();
         gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
     };
+    GPGPUContext.prototype.createFloat16PackedMatrixTexture = function (rows, columns) {
+        this.throwIfDisposed();
+        return gpgpu_util.createFloat16PackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
+    };
     GPGPUContext.prototype.createPackedMatrixTexture = function (rows, columns) {
         this.throwIfDisposed();
         return gpgpu_util.createPackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
@@ -16308,9 +17117,9 @@ var GPGPUContext = (function () {
         var numChannels = webgl_util.getNumChannels();
         return gpgpu_util.uploadMatrixToTexture(this.gl, texture, rows, columns, matrix, numChannels, this.textureConfig);
     };
-    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, rows, columns, matrix) {
+    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, batch, rows, columns, matrix) {
         this.throwIfDisposed();
-        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, rows, columns, matrix, this.textureConfig);
+        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, batch, rows, columns, matrix, this.textureConfig);
     };
     GPGPUContext.prototype.downloadFloat32MatrixFromOutputTexture = function (texture, rows, columns) {
         var _this = this;
@@ -16358,9 +17167,9 @@ var GPGPUContext = (function () {
         }
         return { query: query, isFencePassed: isFencePassed };
     };
-    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, rows, columns) {
+    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, batch, rows, columns, physicalRows, physicalCols) {
         var _this = this;
-        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, rows, columns, _this.textureConfig); });
+        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, batch, rows, columns, physicalRows, physicalCols, _this.textureConfig); });
     };
     GPGPUContext.prototype.createProgram = function (fragmentShaderSource) {
         this.throwIfDisposed();
@@ -16642,7 +17451,7 @@ function binSearchLastTrue(arr) {
 }
 exports.binSearchLastTrue = binSearchLastTrue;
 
-},{"../../environment":64,"../../util":194,"./gpgpu_util":106,"./tex_util":126,"./webgl_util":131}],105:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./gpgpu_util":112,"./tex_util":136,"./webgl_util":142}],111:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../../util");
@@ -16653,7 +17462,8 @@ function compileProgram(gpgpu, program, inputs, output) {
         var shapeInfo = {
             logicalShape: input.shape,
             texShape: input.isUniform ? null : input.texData.texShape,
-            isUniform: input.isUniform
+            isUniform: input.isUniform,
+            isPacked: input.isUniform ? false : input.texData.isPacked
         };
         return { name: program.variableNames[i], shapeInfo: shapeInfo };
     });
@@ -16661,7 +17471,8 @@ function compileProgram(gpgpu, program, inputs, output) {
     var outShapeInfo = {
         logicalShape: output.shape,
         texShape: output.texData.texShape,
-        isUniform: false
+        isUniform: false,
+        isPacked: output.texData.isPacked
     };
     var source = shader_compiler.makeShader(inputInfos, outShapeInfo, userCode, program.supportsBroadcasting === true);
     var webGLProgram = gpgpu.createProgram(source);
@@ -16713,7 +17524,12 @@ function runProgram(binary, inputs, output, customSetup) {
     var outTex = output.texData.texture;
     var outTexShape = output.texData.texShape;
     var gpgpu = binary.gpgpu;
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    if (output.texData.isPacked) {
+        gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
+    else {
+        gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
     gpgpu.setProgram(binary.webGLProgram);
     inputs.forEach(function (input, i) {
         var variableName = binary.program.variableNames[i];
@@ -16755,10 +17571,11 @@ function makeShaderKey(program, inputs, output) {
 }
 exports.makeShaderKey = makeShaderKey;
 
-},{"../../util":194,"./shader_compiler":123}],106:[function(require,module,exports){
+},{"../../util":214,"./shader_compiler":133}],112:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 var tex_util = require("./tex_util");
 var webgl_util = require("./webgl_util");
 function getWebGLContextAttributes() {
@@ -16853,7 +17670,7 @@ function getTextureConfig(gl, textureHalfFloatExtension) {
 }
 exports.getTextureConfig = getTextureConfig;
 function createAndConfigureTexture(gl, width, height, internalFormat, textureFormat, textureType) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     var texture = webgl_util.createTexture(gl);
     var tex2d = gl.TEXTURE_2D;
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(tex2d, texture); });
@@ -16885,6 +17702,11 @@ function createPackedMatrixTexture(gl, rows, columns, textureConfig) {
     return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatPackedFloat, gl.RGBA, gl.FLOAT);
 }
 exports.createPackedMatrixTexture = createPackedMatrixTexture;
+function createFloat16PackedMatrixTexture(gl, rows, columns, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), width = _a[0], height = _a[1];
+    return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA, textureConfig.textureTypeHalfFloat);
+}
+exports.createFloat16PackedMatrixTexture = createFloat16PackedMatrixTexture;
 function bindVertexProgramAttributeStreams(gl, program, vertexBuffer) {
     var posOffset = 0;
     var uvOffset = 3 * 4;
@@ -16902,7 +17724,7 @@ function uploadPixelDataToTexture(gl, texture, pixels) {
 }
 exports.uploadPixelDataToTexture = uploadPixelDataToTexture;
 function uploadDataToTexture(gl, texture, width, height, data, textureFormat) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, texture); });
     webgl_util.callAndCheck(gl, function () { return gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, textureFormat, gl.FLOAT, data); });
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, null); });
@@ -16921,10 +17743,10 @@ function uploadMatrixToTexture(gl, texture, rows, columns, matrix, numChannels, 
     uploadDataToTexture(gl, texture, w, h, unpackedArray, textureConfig.textureFormatFloat);
 }
 exports.uploadMatrixToTexture = uploadMatrixToTexture;
-function uploadMatrixToPackedTexture(gl, texture, rows, columns, matrix, textureConfig) {
+function uploadMatrixToPackedTexture(gl, texture, batch, rows, columns, matrix, textureConfig) {
     var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
     var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
-    tex_util.encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA);
+    tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
     uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }
 exports.uploadMatrixToPackedTexture = uploadMatrixToPackedTexture;
@@ -16973,16 +17795,32 @@ function downloadByteEncodedFloatMatrixFromOutputTexture(gl, rows, columns, text
     return new Float32Array(downloadTarget.buffer);
 }
 exports.downloadByteEncodedFloatMatrixFromOutputTexture = downloadByteEncodedFloatMatrixFromOutputTexture;
-function downloadMatrixFromPackedOutputTexture(gl, rows, columns, textureConfig) {
-    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
-    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+function downloadMatrixFromPackedOutputTexture(gl, batch, rows, cols, physicalRows, physicalCols, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(physicalRows, physicalCols), w = _a[0], h = _a[1];
+    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
     webgl_util.callAndCheck(gl, function () { return gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, packedRGBA); });
-    var matrix = new Float32Array(rows * columns);
-    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix);
+    var matrix = new Float32Array(util.sizeFromShape([batch, rows, cols]));
+    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, batch, rows, cols, matrix);
 }
 exports.downloadMatrixFromPackedOutputTexture = downloadMatrixFromPackedOutputTexture;
 
-},{"../../environment":64,"./tex_util":126,"./webgl_util":131}],107:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./tex_util":136,"./webgl_util":142}],113:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Im2ColProgram = (function () {
+    function Im2ColProgram(outputShape, inputShape, convInfo) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var filterWidth = convInfo.filterWidth, inChannels = convInfo.inChannels, strideWidth = convInfo.strideWidth, strideHeight = convInfo.strideHeight, padInfo = convInfo.padInfo, outWidth = convInfo.outWidth, dilationWidth = convInfo.dilationWidth, dilationHeight = convInfo.dilationHeight;
+        var left = padInfo.left, top = padInfo.top;
+        var itemsPerBlockRow = inChannels * filterWidth;
+        this.userCode = "\n      void main() {\n        ivec2 rc = getOutputCoords();\n\n        vec4 result = vec4(0);\n\n        for(int row=0; row<=1; row++) {\n          for(int col=0; col<=1; col++) {\n            int blockIndex = rc.y + col;\n            int pos = rc.x + row;\n\n            if(blockIndex >= " + outputShape[1] + " || pos >= " + outputShape[0] + ") continue;\n\n            int offsetY = int(blockIndex / (" + outWidth + ")) * " + strideHeight + " - " + top + ";\n            int d0 = offsetY + " + dilationHeight + " * (pos / " + itemsPerBlockRow + ");\n\n            if(d0 >= " + inputShape[0] + " || d0 < 0) continue;\n\n            int offsetX = int(mod(float(blockIndex), " + outWidth + ".) * " + strideWidth + ". - " + left + ".);\n            int d1 = offsetX + " + dilationWidth + " * (int(mod(float(pos), " + itemsPerBlockRow + ".) / " + inChannels + ".));\n\n            if(d1 >= " + inputShape[1] + " || d1 < 0) continue;\n\n            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), " + inChannels + ".)));\n          }\n        }\n\n        gl_FragColor = result;\n      }\n    ";
+    }
+    return Im2ColProgram;
+}());
+exports.Im2ColProgram = Im2ColProgram;
+
+},{}],114:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNProgram = (function () {
@@ -17009,7 +17847,7 @@ var LRNProgram = (function () {
 }());
 exports.LRNProgram = LRNProgram;
 
-},{}],108:[function(require,module,exports){
+},{}],115:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNGradProgram = (function () {
@@ -17028,27 +17866,28 @@ var LRNGradProgram = (function () {
 }());
 exports.LRNGradProgram = LRNGradProgram;
 
-},{}],109:[function(require,module,exports){
+},{}],116:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MaxPool2DBackpropProgram = (function () {
     function MaxPool2DBackpropProgram(convInfo) {
         this.variableNames = ['dy', 'maxPos'];
         this.outputShape = convInfo.inShape;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var lastIndex = filterHeight * filterWidth - 1;
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + filterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        var dilationHeight = convInfo.dilationHeight;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var lastIndex = effectiveFilterHeight * effectiveFilterWidth - 1;
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n          wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + effectiveFilterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return MaxPool2DBackpropProgram;
 }());
 exports.MaxPool2DBackpropProgram = MaxPool2DBackpropProgram;
 
-},{}],110:[function(require,module,exports){
+},{}],117:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MatMulProgram = (function () {
@@ -17077,7 +17916,29 @@ var MatMulProgram = (function () {
 }());
 exports.MatMulProgram = MatMulProgram;
 
-},{}],111:[function(require,module,exports){
+},{}],118:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var MatMulPackedProgram = (function () {
+    function MatMulPackedProgram(aShape, bShape, outputShape, transposeA, transposeB) {
+        if (transposeA === void 0) { transposeA = false; }
+        if (transposeB === void 0) { transposeB = false; }
+        this.variableNames = ['matrixA', 'matrixB'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var sharedDim = transposeA ? aShape[0] : aShape[1];
+        var sharedDimensionPacked = Math.ceil(sharedDim / 2);
+        var aSample = transposeA ? 'i * 2, rc.x' : 'rc.x, i * 2';
+        var bSample = transposeB ? 'rc.y, i * 2' : 'i * 2, rc.y';
+        var aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
+        var bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
+        this.userCode = "\n      const float sharedDimension = " + sharedDimensionPacked + ".0;\n\n      vec4 dot2x2ARowBCol(ivec2 rc) {\n        vec4 result = vec4(0);\n        for (int i = 0; i < " + sharedDimensionPacked + "; i++) {\n          vec4 a = getMatrixA(" + aSample + ");\n          vec4 b = getMatrixB(" + bSample + ");\n\n          result += (" + aSwizzle[0] + " * " + bSwizzle[0] + ") + (" + aSwizzle[1] + " * " + bSwizzle[1] + ");\n        }\n        return result;\n      }\n\n      void main() {\n        ivec2 rc = getOutputCoords();\n        setOutput(dot2x2ARowBCol(rc));\n      }\n    ";
+    }
+    return MatMulPackedProgram;
+}());
+exports.MatMulPackedProgram = MatMulPackedProgram;
+
+},{}],119:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MultinomialProgram = (function () {
@@ -17099,7 +17960,7 @@ var MultinomialProgram = (function () {
 }());
 exports.MultinomialProgram = MultinomialProgram;
 
-},{}],112:[function(require,module,exports){
+},{}],120:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var OneHotProgram = (function () {
@@ -17112,7 +17973,69 @@ var OneHotProgram = (function () {
 }());
 exports.OneHotProgram = OneHotProgram;
 
-},{}],113:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var PackProgram = (function () {
+    function PackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var outOfBoundsCondition = getOutOfBoundsCondition(rank, outputShape, channels);
+        var setup = getSetup(rank, outputShape[outputShape.length - 1], outputShape[outputShape.length - 2], channels);
+        var output = getOutput(outputShape, channels);
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n\n        if(" + outOfBoundsCondition + ") {\n          gl_FragColor = vec4(0);\n        } else {\n          " + setup + "\n\n          setOutput(vec4(" + output + "));\n        }\n      }\n    ";
+    }
+    return PackProgram;
+}());
+exports.PackProgram = PackProgram;
+function getSourceCoordsArr(rank, dims) {
+    var coords = [];
+    for (var row = 0; row <= 1; row++) {
+        for (var col = 0; col <= 1; col++) {
+            var coord = (row === 0 ? 'r' : 'rp1') + ", " + (col === 0 ? 'c' : 'cp1');
+            for (var d = 2; d < rank; d++) {
+                coord = dims[dims.length - 1 - d] + "," + coord;
+            }
+            coords.push(coord);
+        }
+    }
+    return coords;
+}
+function getOutOfBoundsCondition(rank, shape, dims) {
+    if (rank === 1) {
+        return "rc > " + shape[0];
+    }
+    var cond = '';
+    for (var i = 0; i < rank; i++) {
+        cond += dims[i] + " >= " + shape[i];
+        if (i < rank - 1) {
+            cond += '||';
+        }
+    }
+    return cond;
+}
+function getSetup(rank, cols, rows, dims) {
+    if (rank === 1) {
+        return '';
+    }
+    var innerDims = packing_util_1.getInnerDims(rank, dims);
+    return "\n    int r = " + innerDims[0] + ";\n    int c = " + innerDims[1] + ";\n    int rp1 = r + 1;\n    int cp1 = c + 1;\n\n    bool cEdge = cp1 >= " + cols + ";\n    bool rEdge = rp1 >= " + rows + ";\n  ";
+}
+function getOutput(shape, dims) {
+    var rank = shape.length;
+    var sourceCoords = getSourceCoordsArr(rank, dims);
+    if (rank === 1) {
+        return "getA(rc),\n            rc + 1 >= " + shape[0] + " ? 0. : getA(rc + 1),\n            0, 0";
+    }
+    return "getA(" + sourceCoords[0] + "),\n          cEdge ? 0. : getA(" + sourceCoords[1] + "),\n          rEdge ? 0. : getA(" + sourceCoords[2] + "),\n          rEdge || cEdge ? 0. : getA(" + sourceCoords[3] + ")";
+}
+
+},{"../packing_util":86,"./shader_compiler":133}],122:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17135,7 +18058,7 @@ var PadProgram = (function () {
 }());
 exports.PadProgram = PadProgram;
 
-},{"./shader_compiler":123}],114:[function(require,module,exports){
+},{"./shader_compiler":133}],123:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Pool2DProgram = (function () {
@@ -17144,10 +18067,13 @@ var Pool2DProgram = (function () {
         if (poolType === 'avg' && computePositions) {
             throw new Error('Cannot compute positions for average pool.');
         }
-        var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         this.outputShape = convInfo.outShape;
@@ -17158,7 +18084,7 @@ var Pool2DProgram = (function () {
         }
         if (computePositions) {
             var compareOp_1 = '>=';
-            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + filterHeight + "; wR++) {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + filterWidth + "; wC++) {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + filterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
+            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + effectiveFilterHeight + ";\n              wR += " + dilationHeight + ") {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + effectiveFilterWidth + ";\n                wC += " + dilationWidth + ") {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + effectiveFilterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
             return;
         }
         var compareOp = 'max';
@@ -17170,13 +18096,13 @@ var Pool2DProgram = (function () {
         var filterWidthNearestVec4 = Math.floor(filterWidth / 4) * 4;
         var filterWidthVec4Remainder = filterWidth % 4;
         var updateSnippet = "\n      if (" + isAvgPool + ") {\n        avgValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
-        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC;\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              getValue(batch, xR, xC + 3, d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC * " + dilationWidth + ";\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 3 * " + dilationWidth + ", d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return Pool2DProgram;
 }());
 exports.Pool2DProgram = Pool2DProgram;
 
-},{}],115:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ReduceProgram = (function () {
@@ -17189,7 +18115,10 @@ var ReduceProgram = (function () {
         this.outputShape = [batchSize, outSize];
         var initializationValue = '0.0';
         var compareOp = "";
-        if (reduceType === 'min') {
+        if (reduceType === 'prod') {
+            initializationValue = '1.0';
+        }
+        else if (reduceType === 'min') {
             initializationValue = '1.0 / 0.0';
             compareOp = "min";
         }
@@ -17202,6 +18131,9 @@ var ReduceProgram = (function () {
         if (reduceType === 'sum') {
             returnValue = "sumValue";
         }
+        else if (reduceType === 'prod') {
+            returnValue = "prodValue";
+        }
         else if (reduceType === 'all') {
             returnValue = "allValue";
         }
@@ -17210,7 +18142,7 @@ var ReduceProgram = (function () {
         }
         var windowSizeNearestVec4 = Math.floor(windowSize / 4) * 4;
         var windowSizeVec4Remainder = windowSize % 4;
-        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
+        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else if (" + (reduceType === 'prod') + ") {\n        vec2 tmp = vec2(values[0], values[1]) * vec2(values[2], values[3]);\n        prodValue *= tmp[0] * tmp[1];\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
         var vecType = "vec4";
         if (reduceType === 'all') {
             initializationValue = '1.0';
@@ -17226,13 +18158,13 @@ var ReduceProgram = (function () {
         if (inSize % windowSize > 0) {
             checkOutOfBounds = "\n        if (inIdx < 0 || inIdx >= " + inSize + ") {\n          return initializationValue;\n        }\n      ";
         }
-        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float prodValue = 1.0;\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return ReduceProgram;
 }());
 exports.ReduceProgram = ReduceProgram;
 
-},{}],116:[function(require,module,exports){
+},{}],125:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearBackpropProgram = (function () {
@@ -17262,7 +18194,7 @@ var ResizeBilinearBackpropProgram = (function () {
 }());
 exports.ResizeBilinearBackpropProgram = ResizeBilinearBackpropProgram;
 
-},{}],117:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearProgram = (function () {
@@ -17285,7 +18217,7 @@ var ResizeBilinearProgram = (function () {
 }());
 exports.ResizeBilinearProgram = ResizeBilinearProgram;
 
-},{}],118:[function(require,module,exports){
+},{}],127:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeigborBackpropProgram = (function () {
@@ -17315,7 +18247,7 @@ var ResizeNearestNeigborBackpropProgram = (function () {
 }());
 exports.ResizeNearestNeigborBackpropProgram = ResizeNearestNeigborBackpropProgram;
 
-},{}],119:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeighborProgram = (function () {
@@ -17339,7 +18271,7 @@ var ResizeNearestNeighborProgram = (function () {
 }());
 exports.ResizeNearestNeighborProgram = ResizeNearestNeighborProgram;
 
-},{}],120:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17369,7 +18301,41 @@ var ReverseProgram = (function () {
 }());
 exports.ReverseProgram = ReverseProgram;
 
-},{"./shader_compiler":123}],121:[function(require,module,exports){
+},{"./shader_compiler":133}],130:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var ScatterProgram = (function () {
+    function ScatterProgram(updateSize, sliceDim, indicesRank, updatesRank, strides, shape, summingDupeIndex) {
+        if (summingDupeIndex === void 0) { summingDupeIndex = true; }
+        this.variableNames = ['updates', 'indices', 'defaultValue'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var indicesString = '';
+        if (indicesRank === 1) {
+            indicesString = 'i';
+        }
+        else if (indicesRank === 2) {
+            indicesString = 'i, j';
+        }
+        var indicesSnippet = "getIndices(" + indicesString + ")";
+        var updatesString = '';
+        if (updatesRank === 1) {
+            updatesString = 'i';
+        }
+        else if (updatesRank === 2) {
+            updatesString = 'i, coords[1]';
+        }
+        var updatesSnippet = "getUpdates(" + updatesString + ")";
+        var strideString = sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + strides + ");\n\n        void main() {\n          " + dtype + " coords = getOutputCoords();\n          float sum = 0.0;\n          bool found = false;\n          for (int i = 0; i < " + updateSize + "; i++) {\n            int flattenedIndex = 0;\n            for (int j = 0; j < " + sliceDim + "; j++) {\n              int index = round(" + indicesSnippet + ");\n              flattenedIndex += index * " + strideString + ";\n            }\n            if (flattenedIndex == coords[0]) {\n              sum += " + updatesSnippet + ";\n              found = true;\n            }\n          }\n          setOutput(mix(getDefaultValue(), sum, float(found)));\n        }\n      ";
+    }
+    return ScatterProgram;
+}());
+exports.ScatterProgram = ScatterProgram;
+
+},{"./shader_compiler":133}],131:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var SegmentOpProgram = (function () {
@@ -17400,7 +18366,7 @@ var SegmentOpProgram = (function () {
 }());
 exports.SegmentOpProgram = SegmentOpProgram;
 
-},{}],122:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17437,7 +18403,7 @@ var SelectProgram = (function () {
 }());
 exports.SelectProgram = SelectProgram;
 
-},{"./shader_compiler":123}],123:[function(require,module,exports){
+},{"./shader_compiler":133}],133:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -17454,11 +18420,21 @@ function makeShader(inputsInfo, outputShape, userCode, broadcast) {
     var inputSamplingSnippet = inputsInfo.map(function (x) { return getInputSamplingSnippet(x, outputShape, broadcast); })
         .join('\n');
     var outTexShape = outputShape.texShape;
-    var outputSamplingSnippet = getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    var outputSamplingSnippet;
+    var floatTextureSetOutputSnippet;
+    if (outputShape.isPacked) {
+        outputSamplingSnippet =
+            getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    }
+    else {
+        outputSamplingSnippet =
+            getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    }
     var source = [
-        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-        FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-        inputSamplingSnippet, userCode
+        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+        inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
     ].join('\n');
     return source;
 }
@@ -17485,14 +18461,47 @@ function getSamplerFromInInfo(inInfo) {
                 " is not yet supported");
     }
 }
+function getPackedSamplerFromInInfo(inInfo) {
+    var shape = inInfo.shapeInfo.logicalShape;
+    switch (shape.length) {
+        case 1:
+            return getPackedSampler1D(inInfo);
+        case 2:
+            return getPackedSampler2D(inInfo);
+        case 4:
+            return getPackedSampler4D(inInfo);
+        default:
+            throw new Error("Packed " + shape.length + "-D input sampling" +
+                " is not yet supported");
+    }
+}
 function getInputSamplingSnippet(inInfo, outShapeInfo, broadcast) {
     var res = getSamplerFlat(inInfo);
-    res += getSamplerFromInInfo(inInfo);
+    if (inInfo.shapeInfo.isPacked) {
+        res += getPackedSamplerFromInInfo(inInfo);
+    }
+    else {
+        res += getSamplerFromInInfo(inInfo);
+    }
     if (broadcast ||
         util.arraysEqual(inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
         res += getSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     }
     return res;
+}
+function getPackedOutputSamplingSnippet(outShape, outTexShape) {
+    switch (outShape.length) {
+        case 0:
+            return getOutputScalarCoords();
+        case 1:
+            return getOutputPacked1DCoords(outShape, outTexShape);
+        case 2:
+            return getOutputPacked2DCoords(outShape, outTexShape);
+        case 4:
+            return getOutputPacked4DCoords(outShape, outTexShape);
+        default:
+            throw new Error(outShape.length + "-D output packed sampling is not yet supported");
+    }
 }
 function getOutputSamplingSnippet(outShape, outTexShape) {
     switch (outShape.length) {
@@ -17514,17 +18523,28 @@ function getOutputSamplingSnippet(outShape, outTexShape) {
             throw new Error(outShape.length + "-D output sampling is not yet supported");
     }
 }
-var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom1D(int texNumR, int texNumC, int index) {\n  int texelIndex = index / 2;\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom2D(int texelsInLogicalRow, int texNumR,\n  int texNumC, int row, int col) {\n  int texelIndex = (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_3D_SNIPPET = "\nvec2 UVfrom3D(int texNumR, int texNumC, int stride0,\n    int stride1, int row, int col, int depth) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,\n    int texelsInBatch, int texelsInLogicalRow, int b2, int b,\n    int row, int col) {\n  int index = b2 * texelsInBatch2 + b * texelsInBatch +\n    (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_5D_SNIPPET = "\nvec2 UVfrom5D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int row, int col, int depth,\n    int depth2, int depth3) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 +\n              depth * stride2 + depth2 * stride3 + depth3;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_6D_SNIPPET = "\nvec2 UVfrom6D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int stride4,\n    int row, int col, int depth, int depth2, int depth3, int depth4) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2 *\n    stride3 + depth3 * stride4 + depth4;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var FLOAT_TEXTURE_SAMPLE_SNIPPET = "\n  float sampleTexture(sampler2D textureSampler, vec2 uv) {\n    return texture2D(textureSampler, uv).r;\n  }\n";
-var FLOAT_TEXTURE_SETOUTPUT_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
-var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
+var FLOAT_TEXTURE_SET_R_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
+var FLOAT_TEXTURE_SET_RGBA_SNIPPET = "\n  void setOutput(vec4 val) {\n    gl_FragColor = val;\n  }\n";
+var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
 function getOutputScalarCoords() {
     return "\n    int getOutputCoords() {\n      return 0;\n    }\n  ";
+}
+function getOutputPacked1DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (texShape[0] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.x * " + packedTexShape[1] + ".0);\n      }\n    ";
+    }
+    if (texShape[1] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.y * " + packedTexShape[0] + ".0);\n      }\n    ";
+    }
+    return "\n    int getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      return resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n    }\n  ";
 }
 function getOutput1DCoords(shape, texShape) {
     if (texShape[0] === 1) {
@@ -17539,6 +18559,13 @@ function getOutput3DCoords(shape, texShape) {
     var stride0 = shape[1] * shape[2];
     var stride1 = shape[2];
     return "\n    ivec3 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n      int c = index / " + stride1 + ";\n      int d = index - c * " + stride1 + ";\n      return ivec3(r, c, d);\n    }\n  ";
+}
+function getOutputPacked4DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texelsInLogicalRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    ivec4 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n\n      int b2 = index / " + texelsInBatch2 + ";\n      index -= b2 * " + texelsInBatch2 + ";\n\n      int b = index / " + texelsInBatch + ";\n      index -= b * " + texelsInBatch + ";\n\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = int(mod(float(index), " + texelsInLogicalRow + ".)) * 2;\n\n      return ivec4(b2, b, r, c);\n    }\n  ";
 }
 function getOutput4DCoords(shape, texShape) {
     var stride2 = shape[3];
@@ -17561,6 +18588,14 @@ function getOutput6DCoords(shape, texShape) {
     var stride0 = shape[1] * stride1;
     return "\n    ivec6 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n        vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n\n      int c = index / " + stride1 + ";\n      index -= c * " + stride1 + ";\n\n      int d = index / " + stride2 + ";\n      index -= d * " + stride2 + ";\n\n      int d2 = index / " + stride3 + ";\n      index -= d2 * " + stride3 + ";\n\n      int d3 = index / " + stride4 + ";\n      int d4 = index - d3 * " + stride4 + ";\n\n      ivec6 result = ivec6(r, c, d, d2, d3, d4);\n      return result;\n    }\n  ";
 }
+function getOutputPacked2DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (util.arraysEqual(shape, texShape)) {
+        return "\n      ivec2 getOutputCoords() {\n        return 2 * ivec2(resultUV.yx * vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      }\n    ";
+    }
+    var texelsInLogicalRow = Math.ceil(shape[1] / 2);
+    return "\n    ivec2 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = imod(index, " + texelsInLogicalRow + ") * 2;\n\n      return ivec2(r, c);\n    }\n  ";
+}
 function getOutput2DCoords(shape, texShape) {
     if (util.arraysEqual(shape, texShape)) {
         return "\n      ivec2 getOutputCoords() {\n        return ivec2(resultUV.yx * vec2(" + texShape[0] + ", " + texShape[1] + "));\n      }\n    ";
@@ -17581,10 +18616,31 @@ function getSamplerScalar(inputInfo) {
     }
     return "\n    float " + funcName + "() {\n      return sampleTexture(" + texName + ", halfCR);\n    }\n  ";
 }
+function getPackedSampler1D(inputInfo) {
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    return "\n    vec4 " + funcName + "(int index) {\n      vec2 uv = packedUVfrom1D(\n        " + packedTexShape[0] + ", " + packedTexShape[1] + ", index);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
+}
 function getSampler1D(inputInfo) {
     var texName = inputInfo.name;
     var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
     return "\n    float " + funcName + "(int index) {\n      return " + funcName + "Flat(index);\n    }\n  ";
+}
+function getPackedSampler2D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var texNumR = texShape[0];
+    var texNumC = texShape[1];
+    if (texShape != null && util.arraysEqual(shape, texShape)) {
+        return "\n      vec4 " + funcName + "(int row, int col) {\n        vec2 uv = (vec2(col, row) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n\n        return texture2D(" + texName + ", uv);\n      }\n    ";
+    }
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var valuesPerRow = Math.ceil(shape[1] / 2);
+    return "\n    vec4 " + funcName + "(int row, int col) {\n      vec2 uv = packedUVfrom2D(" + valuesPerRow + ", " + packedTexShape[0] + ", " + packedTexShape[1] + ", row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler2D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17604,15 +18660,15 @@ function getSampler2D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col) {\n        int index = row * " + shape[1] + " + col;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col) {\n        float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2(0.5, (float(index) + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2(0.5, (index + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     if (texNumR === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2((float(index) + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2((index + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n  float " + funcName + "(int row, int col) {\n    vec2 uv = UVfrom2D(" + texNumR + ", " + texNumC + ", " + shape[1] + ", row, col);\n    return sampleTexture(" + texName + ", uv);\n  }\n";
 }
@@ -17630,18 +18686,31 @@ function getSampler3D(inputInfo) {
         return "\n        " + getSamplerFromInInfo(newInputInfo) + "\n        float " + funcName + "(int row, int col, int depth) {\n          return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n        }\n      ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth) {\n        int index = row * " + stride0 + " + col * " + stride1 + " + depth;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth) {\n        float index = dot(vec3(row, col, depth),\n                          vec3(" + stride0 + ", " + stride1 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n        float " + funcName + "(int row, int col, int depth) {\n          int texR = row;\n          int texC = col * " + stride1 + " + depth;\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
+        return "\n        float " + funcName + "(int row, int col, int depth) {\n          float texR = float(row);\n          float texC = dot(vec2(col, depth), vec2(" + stride1 + ", 1));\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
     }
     if (texNumC === stride1) {
-        return "\n    float " + funcName + "(int row, int col, int depth) {\n      int texR = row * " + shape[1] + " + col;\n      int texC = depth;\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col, int depth) {\n      float texR = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      float texC = float(depth);\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n      float " + funcName + "(int row, int col, int depth) {\n        vec2 uv = UVfrom3D(\n            " + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ", row, col, depth);\n        return sampleTexture(" + texName + ", uv);\n      }\n  ";
+}
+function getPackedSampler4D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texNumR = packedTexShape[0];
+    var texNumC = packedTexShape[1];
+    var valuesPerRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    vec4 " + funcName + "(int b2, int b, int row, int col) {\n      vec2 uv = packedUVfrom4D(\n        " + texNumR + ", " + texNumC + ", " + texelsInBatch2 + ",\n        " + texelsInBatch + ", " + valuesPerRow + ", b2, b, row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler4D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17657,16 +18726,16 @@ function getSampler4D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float index = dot(vec4(row, col, depth, depth2),\n                          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = float(row);\n        float texC =\n            dot(vec3(col, depth, depth2), vec3(" + stride1 + ", " + stride2 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride2) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = dot(vec3(row, col, depth),\n                         vec3(" + shape[1] * shape[2] + ", " + shape[2] + ", 1));\n        float texC = float(depth2);\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2) {\n      vec2 uv = UVfrom4D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", row, col, depth, depth2);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17685,16 +18754,16 @@ function getSampler5D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " +\n                   depth2 * " + stride3 + " + depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride3) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " +\n                   depth * " + shape[3] + " + depth2;\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] + ", " + shape[2] * shape[3] + ",\n            " + shape[3] + ", 1));\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n      vec2 uv = UVfrom5D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", row, col, depth, depth2, depth3);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17714,16 +18783,16 @@ function getSampler6D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3 * " + stride3 + "\n            + depth4\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          dot(\n            vec2(depth3, depth4),\n            vec2(" + stride4 + ", 1));\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", " + stride4 + ")) + depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride4) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] * shape[4] + ",\n               " + shape[2] * shape[3] * shape[4] + ",\n               " + shape[3] * shape[4] + ",\n               " + shape[4] + ")) + depth3;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n      vec2 uv = UVfrom6D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", " + stride4 + "\n          ,row, col, depth, depth2, depth3, depth4);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17852,7 +18921,7 @@ function getSqueezedParams(params, keptDims) {
     return keptDims.map(function (d) { return params[d]; }).join(', ');
 }
 
-},{"../../ops/broadcast_util":139,"../../util":194}],124:[function(require,module,exports){
+},{"../../ops/broadcast_util":151,"../../util":214}],134:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17916,7 +18985,7 @@ function getCoords(rank) {
     }
 }
 
-},{"./shader_compiler":123}],125:[function(require,module,exports){
+},{"./shader_compiler":133}],135:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17954,9 +19023,10 @@ var StridedSliceProgram = (function () {
 }());
 exports.StridedSliceProgram = StridedSliceProgram;
 
-},{"./shader_compiler":123}],126:[function(require,module,exports){
+},{"./shader_compiler":133}],136:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var util = require("../../util");
 var TextureUsage;
 (function (TextureUsage) {
     TextureUsage[TextureUsage["RENDER"] = 0] = "RENDER";
@@ -17966,9 +19036,11 @@ var TextureUsage;
 })(TextureUsage = exports.TextureUsage || (exports.TextureUsage = {}));
 var PhysicalTextureType;
 (function (PhysicalTextureType) {
-    PhysicalTextureType[PhysicalTextureType["FLOAT16"] = 0] = "FLOAT16";
-    PhysicalTextureType[PhysicalTextureType["FLOAT32"] = 1] = "FLOAT32";
-    PhysicalTextureType[PhysicalTextureType["UNSIGNED_BYTE"] = 2] = "UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT16"] = 0] = "UNPACKED_FLOAT16";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT32"] = 1] = "UNPACKED_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_4X1_UNSIGNED_BYTE"] = 2] = "PACKED_4X1_UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT32"] = 3] = "PACKED_2X2_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT16"] = 4] = "PACKED_2X2_FLOAT16";
 })(PhysicalTextureType = exports.PhysicalTextureType || (exports.PhysicalTextureType = {}));
 function getUnpackedMatrixTextureShapeWidthHeight(rows, columns) {
     return [columns, rows];
@@ -18036,118 +19108,130 @@ function getPackedRGBAArraySizeFromMatrixShape(rows, columns) {
     return w * h * 4;
 }
 exports.getPackedRGBAArraySizeFromMatrixShape = getPackedRGBAArraySizeFromMatrixShape;
-function encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA) {
+function encodeMatrixToPackedRGBA(matrix, batches, rows, columns, packedRGBA) {
     var requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
     if (packedRGBA.length < requiredSize) {
-        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >= " + requiredSize);
+        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >=\n        " + requiredSize);
     }
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    {
-        var dstStride = (oddWidth ? 4 : 0);
-        var oneRow = columns;
-        var dst = 0;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            var matrixSrcRow = (blockY * 2 * columns);
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                var matrixSrcCol = blockX * 2;
-                var src = matrixSrcRow + matrixSrcCol;
-                packedRGBA[dst] = matrix[src];
-                packedRGBA[dst + 1] = matrix[src + 1];
-                packedRGBA[dst + 2] = matrix[src + oneRow];
-                packedRGBA[dst + 3] = matrix[src + oneRow + 1];
-                dst += 4;
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var sourceOffset = batch * rows * columns;
+        var batchOffset = batch * flattenedMatrixSize;
+        {
+            var dstStride = (oddWidth ? 4 : 0);
+            var oneRow = columns;
+            var dst = batchOffset;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                var matrixSrcRow = (blockY * 2 * columns);
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    var matrixSrcCol = blockX * 2;
+                    var src = sourceOffset + matrixSrcRow + matrixSrcCol;
+                    packedRGBA[dst] = matrix[src];
+                    packedRGBA[dst + 1] = matrix[src + 1];
+                    packedRGBA[dst + 2] = matrix[src + oneRow];
+                    packedRGBA[dst + 3] = matrix[src + oneRow + 1];
+                    dst += 4;
+                }
+                dst += dstStride;
             }
-            dst += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = columns - 1;
-        var dst = (textureWidth - 1) * 4;
-        var srcStride = 2 * columns;
-        var dstStride = textureWidth * 4;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            packedRGBA[dst] = matrix[src];
-            packedRGBA[dst + 2] = matrix[src + columns];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + columns - 1;
+            var dst = batchOffset + (texelsPerRow - 1) * 4;
+            var srcStride = 2 * columns;
+            var dstStride = texelsPerRow * 4;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                packedRGBA[dst] = matrix[src];
+                packedRGBA[dst + 2] = matrix[src + columns];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (rows - 1) * columns;
-        var dst = (textureHeight - 1) * textureWidth * 4;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            packedRGBA[dst++] = matrix[src++];
-            packedRGBA[dst++] = matrix[src++];
-            dst += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (rows - 1) * columns;
+            var dst = batchOffset + (texelsPerBatch - texelsPerRow) * 4;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                packedRGBA[dst++] = matrix[src++];
+                packedRGBA[dst++] = matrix[src++];
+                dst += 2;
+            }
+            if (oddWidth && oddHeight) {
+                packedRGBA[batchOffset + flattenedMatrixSize - 4] = matrix[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        packedRGBA[packedRGBA.length - 4] = matrix[matrix.length - 1];
     }
     return packedRGBA;
 }
 exports.encodeMatrixToPackedRGBA = encodeMatrixToPackedRGBA;
-function decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix) {
+function decodeMatrixFromPackedRGBA(packedRGBA, batches, rows, columns, matrix) {
     var requiredSize = rows * columns;
-    if (requiredSize < matrix.length) {
+    if (matrix.length < requiredSize) {
         throw new Error("matrix length (" + matrix.length + ") must be >= " + requiredSize);
     }
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
-    {
-        var srcStride = oddWidth ? 4 : 0;
-        var dstStride = columns + (oddWidth ? 1 : 0);
-        var src = 0;
-        var dstRow1 = 0;
-        var dstRow2 = columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var batchOffset = batch * rows * columns;
+        var sourceOffset = batch * flattenedMatrixSize;
+        {
+            var srcStride = oddWidth ? 4 : 0;
+            var dstStride = columns + (oddWidth ? 1 : 0);
+            var src = sourceOffset;
+            var dstRow1 = batchOffset;
+            var dstRow2 = batchOffset + columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                }
+                src += srcStride;
+                dstRow1 += dstStride;
+                dstRow2 += dstStride;
             }
-            src += srcStride;
-            dstRow1 += dstStride;
-            dstRow2 += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = (textureWidth - 1) * 4;
-        var dst = columns - 1;
-        var srcStride = textureWidth * 4;
-        var dstStride = 2 * columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            matrix[dst] = packedRGBA[src];
-            matrix[dst + columns] = packedRGBA[src + 2];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + (texelsPerRow - 1) * 4;
+            var dst = batchOffset + columns - 1;
+            var srcStride = texelsPerRow * 4;
+            var dstStride = 2 * columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                matrix[dst] = packedRGBA[src];
+                matrix[dst + columns] = packedRGBA[src + 2];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (textureHeight - 1) * textureWidth * 4;
-        var dst = (rows - 1) * columns;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            matrix[dst++] = packedRGBA[src++];
-            matrix[dst++] = packedRGBA[src++];
-            src += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (texelsPerBatch - texelsPerRow) * 4;
+            var dst = batchOffset + (rows - 1) * columns;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                matrix[dst++] = packedRGBA[src++];
+                matrix[dst++] = packedRGBA[src++];
+                src += 2;
+            }
+            if (oddWidth) {
+                matrix[batchOffset + (rows * columns) - 1] = packedRGBA[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        matrix[matrix.length - 1] = packedRGBA[packedRGBA.length - 4];
     }
     return matrix;
 }
 exports.decodeMatrixFromPackedRGBA = decodeMatrixFromPackedRGBA;
 
-},{}],127:[function(require,module,exports){
+},{"../../util":214}],137:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
@@ -18161,9 +19245,9 @@ var TextureManager = (function () {
         this.logEnabled = false;
         this.usedTextures = {};
     }
-    TextureManager.prototype.acquireTexture = function (shapeRC, usage) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(usage);
-        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType);
+    TextureManager.prototype.acquireTexture = function (shapeRC, usage, isPacked) {
+        var physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
+        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18181,24 +19265,34 @@ var TextureManager = (function () {
         this.numUsedTextures++;
         this.log();
         var newTexture;
-        if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT32) {
+        if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32) {
+            newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16) {
+            newTexture =
+                this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32) {
             newTexture =
                 this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT16) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16) {
             newTexture =
                 this.gpgpu.createFloat16MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNSIGNED_BYTE) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE) {
             newTexture =
                 this.gpgpu.createUnsignedBytesMatrixTexture(shapeRC[0], shapeRC[1]);
         }
         this.usedTextures[shapeKey].push(newTexture);
         return newTexture;
     };
-    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType);
-        var shapeKey = getKeyFromTextureShape(shape, physicalTexType);
+    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType, isPacked) {
+        if (this.freeTextures == null) {
+            return;
+        }
+        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+        var shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18250,26 +19344,31 @@ var TextureManager = (function () {
     return TextureManager;
 }());
 exports.TextureManager = TextureManager;
-function getPhysicalFromLogicalTextureType(logicalTexType) {
-    if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
+function getPhysicalFromLogicalTextureType(logicalTexType, isPacked) {
+    if (isPacked) {
+        return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32 :
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    else if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
         logicalTexType === tex_util_1.TextureUsage.PIXELS) {
-        return tex_util_1.PhysicalTextureType.UNSIGNED_BYTE;
+        return tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.UPLOAD) {
-        return tex_util_1.PhysicalTextureType.FLOAT32;
+        return tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.RENDER) {
         return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-            tex_util_1.PhysicalTextureType.FLOAT32 :
-            tex_util_1.PhysicalTextureType.FLOAT16;
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32 :
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16;
     }
     throw new Error("Unknown logical texture type " + logicalTexType);
 }
-function getKeyFromTextureShape(shapeRowsCol, physicalTexType) {
-    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType;
+function getKeyFromTextureShape(shapeRowsCol, physicalTexType, isPacked) {
+    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType + "_" + isPacked;
 }
 
-},{"../../environment":64,"./tex_util":126}],128:[function(require,module,exports){
+},{"../../environment":64,"./tex_util":136}],138:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18305,7 +19404,7 @@ function getSourceCoords(aShape) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],129:[function(require,module,exports){
+},{"./shader_compiler":133}],139:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18338,7 +19437,7 @@ function getSwitchedCoords(newDim) {
     return switchedCoords.join();
 }
 
-},{"./shader_compiler":123}],130:[function(require,module,exports){
+},{"./shader_compiler":133}],140:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var erf_util = require("../../ops/erf_util");
@@ -18405,12 +19504,33 @@ exports.RECIPROCAL = "return 1.0 / x;";
 exports.LOGICAL_NOT = "return float(!(x >= 1.0));";
 exports.TO_INT = "return float(int(x));";
 
-},{"../../ops/erf_util":146,"../../ops/selu_util":166}],131:[function(require,module,exports){
+},{"../../ops/erf_util":159,"../../ops/selu_util":183}],141:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var MAX_TEXTURE_SIZE = null;
-var util = require("../../util");
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var UnpackProgram = (function () {
+    function UnpackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var sourceCoords = packing_util_1.getSourceCoords(rank, channels);
+        var innerDims = packing_util_1.getInnerDims(rank, channels);
+        var coords = rank === 1 ? 'rc' : innerDims.join(',');
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n        vec2 modCoord = mod(vec2(" + coords + "), 2.);\n        vec4 packedInput = getA(" + sourceCoords + ");\n\n        setOutput(\n          modCoord.x == 0. ?\n            (modCoord.y == 0. ? packedInput.r : packedInput.g) :\n            (modCoord.y == 0. ? packedInput.b : packedInput.a)\n        );\n      }\n    ";
+    }
+    return UnpackProgram;
+}());
+exports.UnpackProgram = UnpackProgram;
+
+},{"../packing_util":86,"./shader_compiler":133}],142:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 function createWebGLRenderingContext(attributes) {
     var canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -18561,15 +19681,6 @@ function createStaticIndexBuffer(gl, data) {
     return buffer;
 }
 exports.createStaticIndexBuffer = createStaticIndexBuffer;
-function queryMaxTextureSize(gl) {
-    if (MAX_TEXTURE_SIZE != null) {
-        return MAX_TEXTURE_SIZE;
-    }
-    MAX_TEXTURE_SIZE =
-        callAndCheck(gl, function () { return gl.getParameter(gl.MAX_TEXTURE_SIZE); });
-    return MAX_TEXTURE_SIZE;
-}
-exports.queryMaxTextureSize = queryMaxTextureSize;
 function getNumChannels() {
     if (environment_1.ENV.get('WEBGL_VERSION') === 2) {
         return 1;
@@ -18581,8 +19692,8 @@ function createTexture(gl) {
     return throwIfNull(gl, function () { return gl.createTexture(); }, 'Unable to create WebGLTexture.');
 }
 exports.createTexture = createTexture;
-function validateTextureSize(gl, width, height) {
-    var maxTextureSize = queryMaxTextureSize(gl);
+function validateTextureSize(width, height) {
+    var maxTextureSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
     if ((width <= 0) || (height <= 0)) {
         var requested = "[" + width + "x" + height + "]";
         throw new Error('Requested texture size ' + requested + ' is invalid.');
@@ -18688,12 +19799,19 @@ function validateTextureUnit(gl, textureUnit) {
         throw new Error("textureUnit must be in " + textureUnitRange + ".");
     }
 }
-function getTextureShapeFromLogicalShape(gl, logShape) {
+function getTextureShapeFromLogicalShape(logShape, isPacked) {
+    if (isPacked === void 0) { isPacked = false; }
+    var maxTexSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    if (isPacked) {
+        maxTexSize = maxTexSize * 2;
+        logShape = logShape.map(function (d, i) { return i >= logShape.length - 2 ?
+            util.nearestLargerEven(logShape[i]) :
+            logShape[i]; });
+    }
     if (logShape.length !== 2) {
         var squeezeResult = util.squeezeShape(logShape);
         logShape = squeezeResult.newShape;
     }
-    var maxTexSize = queryMaxTextureSize(gl);
     var size = util.sizeFromShape(logShape);
     if (logShape.length <= 1 && size <= maxTexSize) {
         return [size, 1];
@@ -18702,9 +19820,18 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
         logShape[1] <= maxTexSize) {
         return logShape;
     }
+    else if (logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+        logShape[2] <= maxTexSize) {
+        return [logShape[0] * logShape[1], logShape[2]];
+    }
     else if (logShape.length === 3 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] <= maxTexSize) {
         return [logShape[0], logShape[1] * logShape[2]];
+    }
+    else if (logShape.length === 4 &&
+        logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+        logShape[3] <= maxTexSize) {
+        return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
     }
     else if (logShape.length === 4 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
@@ -18716,7 +19843,7 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
 }
 exports.getTextureShapeFromLogicalShape = getTextureShapeFromLogicalShape;
 
-},{"../../environment":64,"../../util":194}],132:[function(require,module,exports){
+},{"../../environment":64,"../../util":214}],143:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var array_ops_1 = require("../ops/array_ops");
@@ -18738,7 +19865,7 @@ function whereImpl(condShape, condVals) {
 }
 exports.whereImpl = whereImpl;
 
-},{"../ops/array_ops":134}],133:[function(require,module,exports){
+},{"../ops/array_ops":146}],144:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -18763,7 +19890,13 @@ function log() {
 }
 exports.log = log;
 
-},{"./environment":64}],134:[function(require,module,exports){
+},{"./environment":64}],145:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var confusion_matrix_1 = require("./ops/confusion_matrix");
+exports.confusionMatrix = confusion_matrix_1.confusionMatrix;
+
+},{"./ops/confusion_matrix":156}],146:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -19162,9 +20295,10 @@ function stack_(tensors, axis) {
 function batchToSpaceND_(x, blockShape, crops) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'batchToSpaceND');
     var prod = blockShape.reduce(function (a, b) { return a * b; });
-    util.assert($x.rank >= 1 + blockShape.length, "input rank should be > than [blockShape] but got " + $x.rank);
-    util.assert(crops.length === blockShape.length, "crops.shape[0] must be equal to [blockShape] but got " + crops.length);
-    util.assert($x.shape[0] % prod === 0, "input tensor batch must be divisible by prod( blockShape )");
+    util.assert($x.rank >= 1 + blockShape.length, "input rank is " + $x.rank + " but should be > than blockShape.length " + blockShape.length);
+    util.assert(crops.length === blockShape.length, "crops.length is " + crops.length + " but should be equal to blockShape.length  " + blockShape.length);
+    util.assert($x.shape[0] % prod === 0, "input tensor batch is " + $x.shape[0] + " but is not divisible by the product of " +
+        ("the elements of blockShape " + blockShape.join(' * ') + " === " + prod));
     var grad = function (dy) {
         return { $x: function () { return dy.spaceToBatchND(blockShape, crops); } };
     };
@@ -19291,7 +20425,7 @@ exports.tile = operation_1.op({ tile_: tile_ });
 exports.truncatedNormal = operation_1.op({ truncatedNormal_: truncatedNormal_ });
 exports.unstack = operation_1.op({ unstack_: unstack_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_split":142,"./operation":156,"./rand":159,"./tensor_ops":171}],135:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_split":154,"./operation":171,"./rand":174,"./tensor_ops":191}],147:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getReshaped(inputShape, blockShape, prod, batchToSpace) {
@@ -19389,7 +20523,7 @@ function getSliceSize(uncroppedShape, crops, blockShape) {
 }
 exports.getSliceSize = getSliceSize;
 
-},{}],136:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -19479,7 +20613,7 @@ function getInnerMostAxes(numAxes, rank) {
 }
 exports.getInnerMostAxes = getInnerMostAxes;
 
-},{"../util":194}],137:[function(require,module,exports){
+},{"../util":214}],149:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19699,7 +20833,7 @@ exports.batchNormalization3d = operation_1.op({ batchNormalization3d_: batchNorm
 exports.batchNormalization4d = operation_1.op({ batchNormalization4d_: batchNormalization4d_ });
 exports.batchNormalization = operation_1.op({ batchNormalization_: batchNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],138:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],150:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20065,7 +21199,7 @@ exports.squaredDifferenceStrict = operation_1.op({ squaredDifferenceStrict_: squ
 exports.sub = operation_1.op({ sub_: sub_ });
 exports.subStrict = operation_1.op({ subStrict_: subStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../types":193,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],139:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../types":213,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],151:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getBroadcastDims(inShape, outShape) {
@@ -20135,7 +21269,7 @@ function assertAndGetBroadcastShape(shapeA, shapeB) {
 }
 exports.assertAndGetBroadcastShape = assertAndGetBroadcastShape;
 
-},{}],140:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20239,7 +21373,7 @@ exports.lessStrict = operation_1.op({ lessStrict_: lessStrict_ });
 exports.notEqual = operation_1.op({ notEqual_: notEqual_ });
 exports.notEqualStrict = operation_1.op({ notEqualStrict_: notEqualStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],141:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],153:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20265,7 +21399,7 @@ exports.complex = operation_1.op({ complex_: complex_ });
 exports.real = operation_1.op({ real_: real_ });
 exports.imag = operation_1.op({ imag_: imag_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],142:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],154:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20291,6 +21425,7 @@ function concat_(tensors, axis) {
     if (axis === void 0) { axis = 0; }
     util_1.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     var $tensors = tensor_util_env_1.convertToTensorArray(tensors, 'tensors', 'concat');
+    axis = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var outShape = concat_util_1.computeOutShape($tensors.map(function (t) { return t.shape; }), axis);
     if (util_1.sizeFromShape(outShape) === 0) {
         return tensor_ops_1.tensor([], outShape);
@@ -20299,16 +21434,15 @@ function concat_(tensors, axis) {
     if ($tensors.length === 1) {
         return $tensors[0];
     }
-    var axes = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var shapes = $tensors.map(function (t) { return t.shape; });
-    concat_util_1.assertParamsConsistent(shapes, axes);
+    concat_util_1.assertParamsConsistent(shapes, axis);
     var der = function (dy) {
         var sizeSplits = shapes.map(function (s) { return s[axis]; });
         var derTensors = exports.split(dy, sizeSplits, axis);
         return derTensors.map(function (t) { return function () { return t; }; });
     };
     var inputs = $tensors;
-    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axes); }, inputs, der);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axis); }, inputs, der);
 }
 function split_(x, numOrSizeSplits, axis) {
     if (axis === void 0) { axis = 0; }
@@ -20333,7 +21467,7 @@ exports.concat3d = operation_1.op({ concat3d_: concat3d_ });
 exports.concat4d = operation_1.op({ concat4d_: concat4d_ });
 exports.split = operation_1.op({ split_: split_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_util":143,"./operation":156,"./tensor_ops":171}],143:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_util":155,"./operation":171,"./tensor_ops":191}],155:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -20363,13 +21497,40 @@ function computeOutShape(shapes, axis) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194}],144:[function(require,module,exports){
+},{"../util":214}],156:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tensor_util_env_1 = require("../tensor_util_env");
+var util = require("../util");
+var array_ops_1 = require("./array_ops");
+var operation_1 = require("./operation");
+function confusionMatrix_(labels, predictions, numClasses) {
+    var $labels = tensor_util_env_1.convertToTensor(labels, 'label', 'confusionMatrix', 'int32');
+    var $predictions = tensor_util_env_1.convertToTensor(predictions, 'label', 'confusionMatrix', 'int32');
+    util.assert(numClasses == null || numClasses > 0 && Number.isInteger(numClasses), "If provided, numClasses must be a positive integer, " +
+        ("but got " + numClasses));
+    util.assert($labels.rank === 1, "Expected the rank of labels to be 1, but got " + $labels.rank);
+    util.assert($predictions.rank === 1, "Expected the rank of predictions to be 1, " +
+        ("but got " + $predictions.rank));
+    util.assert($labels.shape[0] === $predictions.shape[0], "Mismatch in the number of examples: " +
+        ($labels.shape[0] + " vs. " + $predictions.shape[0] + ". ") +
+        "Labels and predictions should have the same number of elements.");
+    util.assert(numClasses > 0 && Number.isInteger(numClasses), "numClasses is required to be a positive integer, but got " + numClasses);
+    var oneHotLabels = array_ops_1.oneHot($labels, numClasses);
+    var oneHotPredictions = array_ops_1.oneHot($predictions, numClasses);
+    return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+exports.confusionMatrix_ = confusionMatrix_;
+exports.confusionMatrix = operation_1.op({ confusionMatrix_: confusionMatrix_ });
+
+},{"../tensor_util_env":210,"../util":214,"./array_ops":146,"./operation":171}],157:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
+var matmul_1 = require("./matmul");
 var operation_1 = require("./operation");
 function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) {
     if (dataFormat === void 0) { dataFormat = 'NWC'; }
@@ -20391,7 +21552,7 @@ function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) 
     }
     util.assert(x3D.shape[2] === $filter.shape[1], "Error in conv1d: depth of input (" + x3D.shape[2] + ") must match " +
         ("input depth for filter " + $filter.shape[1] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
         ("Got stride " + stride + " and dilation '" + dilation + "'"));
     util.assert(dataFormat === 'NWC', "Error in conv1d: got dataFormat of " + dataFormat + " but only NWC is currently supported.");
     var filter4D = $filter.as4D(1, $filter.shape[0], $filter.shape[1], $filter.shape[2]);
@@ -20425,19 +21586,30 @@ function conv2d_(x, filter, strides, pad, dataFormat, dilations, dimRoundingMode
     }
     util.assert(x4D.shape[3] === $filter.shape[2], "Error in conv2d: depth of input (" + x4D.shape[3] + ") must match " +
         ("input depth for filter " + $filter.shape[2] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert(dataFormat === 'NHWC', "Error in conv2d: got dataFormat of " + dataFormat + " but only NHWC is currently supported.");
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
-    var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
-            ("yet supported in gradients. Got dilations '" + dilations + "'"));
-        return {
-            x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
-            $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+    var res;
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' || convInfo.padInfo.type === 'VALID')) {
+        var x2d = x4D.reshape([-1, convInfo.inChannels]);
+        var w2d = $filter.reshape([convInfo.inChannels, convInfo.outChannels]);
+        res = matmul_1.matMul(x2d, w2d).reshape(convInfo.outShape);
+    }
+    else {
+        var grad = function (dy) {
+            util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+                ("yet supported in gradients. Got dilations '" + dilations + "'"));
+            return {
+                x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
+                $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+            };
         };
-    };
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+        res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+    }
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20471,8 +21643,15 @@ function conv2dDerInput_(xShape, dy, filter, strides, pad, dimRoundingMode) {
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
     var dilations = 1;
+    var grad = function (ddx) {
+        var dataFormat = 'NHWC';
+        return {
+            dy4D: function () { return exports.conv2d(ddx, filter, strides, pad, dataFormat, dilations, dimRoundingMode); },
+            filter: function () { return exports.conv2dDerFilter(ddx, dy4D, filter.shape, strides, pad, dimRoundingMode); }
+        };
+    };
     var convInfo = conv_util.computeConv2DInfo(xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D });
+    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D, filter: filter }, grad);
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20531,7 +21710,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     if (dilations == null) {
         dilations = [1, 1];
     }
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in depthwiseConv2d: pad must be an integer when using, " +
@@ -20539,7 +21718,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     }
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode, true);
     var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+        util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
             ("1 are not yet supported. Got dilations '" + dilations + "'"));
         return {
             x: function () { return depthwiseConv2dDerInput(x4D.shape, dy, $filter, convInfo); },
@@ -20591,16 +21770,6 @@ function separableConv2d_(x, depthwiseFilter, pointwiseFilter, strides, pad, dil
     }
     return res;
 }
-function parseTupleParam(param) {
-    return typeof param === 'number' ? [param, param] : param;
-}
-function tupleValuesAreOne(param) {
-    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
-    return dimA === 1 && dimB === 1;
-}
-function eitherStridesOrDilationsAreOne(strides, dilations) {
-    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
-}
 function depthwiseConv2dDerInput(xShape, dy, filter, convInfo) {
     var dy4D = dy;
     var reshapedTo4D = false;
@@ -20627,15 +21796,16 @@ function depthwiseConv2dDerFilter(x, dy, filterShape, convInfo) {
 }
 exports.conv1d = operation_1.op({ conv1d_: conv1d_ });
 exports.conv2d = operation_1.op({ conv2d_: conv2d_ });
+exports.conv2dDerFilter = operation_1.op({ conv2dDerFilter_: conv2dDerFilter_ });
 exports.depthwiseConv2d = operation_1.op({ depthwiseConv2d_: depthwiseConv2d_ });
 exports.separableConv2d = operation_1.op({ separableConv2d_: separableConv2d_ });
 exports.conv2dTranspose = operation_1.op({ conv2dTranspose_: conv2dTranspose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],145:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./matmul":168,"./operation":171}],158:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
-function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, dataFormat) {
+function computePool2DInfo(inShape, filterSize, strides, dilations, pad, roundingMode, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var _a = parseTupleParam(filterSize), filterHeight = _a[0], filterWidth = _a[1];
     var filterShape;
@@ -20648,7 +21818,6 @@ function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, data
     else {
         throw new Error("Unknown dataFormat " + dataFormat);
     }
-    var dilations = 1;
     return computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundingMode, false, dataFormat);
 }
 exports.computePool2DInfo = computePool2DInfo;
@@ -20693,6 +21862,8 @@ function computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundi
         strideWidth: strideWidth,
         filterHeight: filterHeight,
         filterWidth: filterWidth,
+        effectiveFilterHeight: effectiveFilterHeight,
+        effectiveFilterWidth: effectiveFilterWidth,
         dilationHeight: dilationHeight,
         dilationWidth: dilationWidth,
         inShape: inShape,
@@ -20777,8 +21948,17 @@ function conditionalRound(value, roundingMode) {
             throw new Error("Unknown roundingMode " + roundingMode);
     }
 }
+function tupleValuesAreOne(param) {
+    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
+    return dimA === 1 && dimB === 1;
+}
+exports.tupleValuesAreOne = tupleValuesAreOne;
+function eitherStridesOrDilationsAreOne(strides, dilations) {
+    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+exports.eitherStridesOrDilationsAreOne = eitherStridesOrDilationsAreOne;
 
-},{"../util":194}],146:[function(require,module,exports){
+},{"../util":214}],159:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ERF_P = 0.3275911;
@@ -20788,7 +21968,64 @@ exports.ERF_A3 = 1.421413741;
 exports.ERF_A4 = -1.453152027;
 exports.ERF_A5 = 1.061405429;
 
-},{}],147:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function gatherND_(x, indices) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'gatherND', 'int32');
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'gatherND');
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.gatherND($x, $indices); }, { $x: $x, $indices: $indices });
+}
+exports.gatherND = operation_1.op({ gatherND_: gatherND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],161:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function prepareAndValidate(tensor, indices) {
+    if (tensor.rank < 1) {
+        throw new Error('tf.gatherND() expects the input to be rank 1 or higher,' +
+            (" but the rank was " + tensor.rank + "."));
+    }
+    if (indices.rank < 1) {
+        throw new Error('tf.gatherND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error('tf.gatherND() expects the indices to be int32 type,' +
+            (" but the dtype was " + indices.dtype + "."));
+    }
+    if (indices.shape[indices.rank - 1] > tensor.rank) {
+        throw new Error('index innermost dimension length must be <= tensor rank; saw: ' +
+            (indices.shape[indices.rank - 1] + " vs. " + tensor.rank));
+    }
+    if (tensor.size === 0) {
+        throw new Error('Requested more than 0 entries, but input is empty.' +
+            (" Input shape: " + tensor.shape + "."));
+    }
+    var indicesShape = indices.shape;
+    var sliceRank = indicesShape[indicesShape.length - 1];
+    var nResult = 1;
+    for (var i = 0; i < indicesShape.length - 1; ++i) {
+        nResult *= indicesShape[i];
+    }
+    var inputShape = tensor.shape;
+    var resultShape = indicesShape.slice();
+    resultShape.pop();
+    var sliceSize = 1;
+    for (var i = sliceRank; i < tensor.rank; ++i) {
+        sliceSize *= inputShape[i];
+        resultShape.push(inputShape[i]);
+    }
+    var strides = util_1.computeStrides(tensor.shape).map(function (stride) { return stride / sliceSize; }).concat([1]).slice(0, sliceRank);
+    return [resultShape, nResult, sliceSize, strides];
+}
+exports.prepareAndValidate = prepareAndValidate;
+
+},{"../util":214}],162:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -20983,7 +22220,7 @@ exports.nonMaxSuppression = operation_1.op({ nonMaxSuppression_: nonMaxSuppressi
 exports.nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
 exports.cropAndResize = cropAndResize_;
 
-},{"../environment":64,"../kernels/non_max_suppression_impl":84,"../tensor_util_env":190,"../util":194,"./operation":156}],148:[function(require,module,exports){
+},{"../environment":64,"../kernels/non_max_suppression_impl":85,"../tensor_util_env":210,"../util":214,"./operation":171}],163:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21129,7 +22366,7 @@ function qr2d(x, fullMatrices) {
 exports.gramSchmidt = operation_1.op({ gramSchmidt_: gramSchmidt_ });
 exports.qr = operation_1.op({ qr_: qr_ });
 
-},{"../environment":64,"../globals":66,"../util":194,"./array_ops":134,"./concat_split":142,"./norm":155,"./operation":156,"./reduction_ops":161,"./tensor_ops":171}],149:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../util":214,"./array_ops":146,"./concat_split":154,"./norm":170,"./operation":171,"./reduction_ops":176,"./tensor_ops":191}],164:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21246,7 +22483,7 @@ exports.logicalXor = operation_1.op({ logicalXor_: logicalXor_ });
 exports.where = operation_1.op({ where_: where_ });
 exports.whereAsync = whereAsync_;
 
-},{"../environment":64,"../kernels/where_impl":132,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],150:[function(require,module,exports){
+},{"../environment":64,"../kernels/where_impl":143,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],165:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var globals_1 = require("../globals");
@@ -21471,7 +22708,7 @@ exports.meanSquaredError = operation_1.op({ meanSquaredError_: meanSquaredError_
 exports.sigmoidCrossEntropy = operation_1.op({ sigmoidCrossEntropy_: sigmoidCrossEntropy_ });
 exports.softmaxCrossEntropy = operation_1.op({ softmaxCrossEntropy_: softmaxCrossEntropy_ });
 
-},{"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],151:[function(require,module,exports){
+},{"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],166:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21508,7 +22745,7 @@ function localResponseNormalization_(x, depthRadius, bias, alpha, beta) {
 }
 exports.localResponseNormalization = operation_1.op({ localResponseNormalization_: localResponseNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],152:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],167:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21557,7 +22794,7 @@ function basicLSTMCell_(forgetBias, lstmKernel, lstmBias, data, c, h) {
 exports.basicLSTMCell = operation_1.op({ basicLSTMCell_: basicLSTMCell_ });
 exports.multiRNNCell = operation_1.op({ multiRNNCell_: multiRNNCell_ });
 
-},{"../tensor_util_env":190,"./operation":156}],153:[function(require,module,exports){
+},{"../tensor_util_env":210,"./operation":171}],168:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21653,7 +22890,7 @@ exports.matMul = operation_1.op({ matMul_: matMul_ });
 exports.dot = operation_1.op({ dot_: dot_ });
 exports.outerProduct = operation_1.op({ outerProduct_: outerProduct_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],154:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],169:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_1 = require("../tensor_util");
@@ -21681,7 +22918,7 @@ function movingAverage_(v, x, decay, step, zeroDebias) {
 }
 exports.movingAverage = operation_1.op({ movingAverage_: movingAverage_ });
 
-},{"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],155:[function(require,module,exports){
+},{"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],170:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21744,7 +22981,7 @@ function normImpl(x, p, axis) {
 }
 exports.norm = operation_1.op({ norm_: norm_ });
 
-},{"../tensor_util_env":190,"./axis_util":136,"./operation":156,"./tensor_ops":171}],156:[function(require,module,exports){
+},{"../tensor_util_env":210,"./axis_util":148,"./operation":171,"./tensor_ops":191}],171:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21784,7 +23021,7 @@ function op(f) {
 }
 exports.op = op;
 
-},{"../environment":64}],157:[function(require,module,exports){
+},{"../environment":64}],172:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -21815,6 +23052,10 @@ __export(require("./lstm"));
 __export(require("./moving_average"));
 __export(require("./strided_slice"));
 __export(require("./topk"));
+__export(require("./scatter_nd"));
+__export(require("./spectral_ops"));
+__export(require("./sparse_to_dense"));
+__export(require("./gather_nd"));
 var operation_1 = require("./operation");
 exports.op = operation_1.op;
 var losses = require("./loss_ops");
@@ -21823,8 +23064,10 @@ var linalg = require("./linalg_ops");
 exports.linalg = linalg;
 var image = require("./image_ops");
 exports.image = image;
+var spectral = require("./spectral_ops");
+exports.spectral = spectral;
 
-},{"./array_ops":134,"./batchnorm":137,"./binary_ops":138,"./compare":140,"./complex_ops":141,"./concat_split":142,"./conv":144,"./image_ops":147,"./linalg_ops":148,"./logical_ops":149,"./loss_ops":150,"./lrn":151,"./lstm":152,"./matmul":153,"./moving_average":154,"./norm":155,"./operation":156,"./pool":158,"./reduction_ops":161,"./relu_ops":162,"./reverse":163,"./segment_ops":164,"./slice":167,"./softmax":169,"./strided_slice":170,"./tensor_ops":171,"./topk":172,"./transpose":173,"./unary_ops":174}],158:[function(require,module,exports){
+},{"./array_ops":146,"./batchnorm":149,"./binary_ops":150,"./compare":152,"./complex_ops":153,"./concat_split":154,"./conv":157,"./gather_nd":160,"./image_ops":162,"./linalg_ops":163,"./logical_ops":164,"./loss_ops":165,"./lrn":166,"./lstm":167,"./matmul":168,"./moving_average":169,"./norm":170,"./operation":171,"./pool":173,"./reduction_ops":176,"./relu_ops":177,"./reverse":178,"./scatter_nd":179,"./segment_ops":181,"./slice":184,"./softmax":186,"./sparse_to_dense":187,"./spectral_ops":189,"./strided_slice":190,"./tensor_ops":191,"./topk":192,"./transpose":193,"./unary_ops":194}],173:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21832,7 +23075,7 @@ var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
 var operation_1 = require("./operation");
-function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'maxPool');
     var x4D = $x;
     var reshapedTo4D = false;
@@ -21840,18 +23083,21 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
         reshapedTo4D = true;
         x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
     }
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
     util.assert(x4D.rank === 4, "Error in maxPool: input must be rank 4 but got rank " + x4D.rank + ".");
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in maxPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var grad = function (dy, saved) {
         var y4D = saved[0];
         return {
-            x: function () {
-                return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, pad);
-            }
+            x: function () { return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, dilations, pad); }
         };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.maxPool(x4D, convInfo)); }, { x: x4D }, grad);
@@ -21860,9 +23106,17 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return maxPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function avgPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'avgPool');
     util.assert($x.dtype === 'float32', 'The input dtype to avgPool must be float32');
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var x4D = $x;
     var reshapedTo4D = false;
     if ($x.rank === 3) {
@@ -21874,9 +23128,11 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
         util.assert(util.isInt(pad), "Error in avgPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad);
     var grad = function (dy) {
-        return { x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, pad); } };
+        return {
+            x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, dilations, pad); }
+        };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPool(x4D, convInfo); }, { x: x4D }, grad);
     res = res.cast($x.dtype);
@@ -21885,11 +23141,33 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundingMode) {
+function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return avgPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function pool_(input, windowShape, poolingType, padding, dilationRate, strides) {
+    if (dilationRate == null) {
+        dilationRate = 1;
+    }
+    if (strides == null) {
+        strides = 1;
+    }
+    if (poolingType === 'avg') {
+        return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+    else {
+        return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+}
+function maxPoolBackprop(dy, input, output, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'maxPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'maxPoolBackprop');
     var $output = tensor_util_env_1.convertToTensor(output, 'output', 'maxPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPoolBackProp: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert($dy.rank === 4, "Error in maxPoolBackprop: dy must be rank 4 but got rank " +
         ($dy.rank + "."));
     util.assert($input.rank === 4, "Error in maxPoolBackprop: input must be rank 4 but got rank " +
@@ -21898,14 +23176,19 @@ function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundin
         util.assert(util.isInt(pad), "Error in maxPoolBackprop: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.maxPoolBackprop($dy, $input, $output, convInfo); }, { $dy: $dy, $input: $input });
     return res;
 }
-function avgPoolBackprop(dy, input, filterSize, strides, pad) {
+function avgPoolBackprop(dy, input, filterSize, strides, dilations, pad) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'avgPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'avgPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPoolBackprop: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var input4D = $input;
     var dy4D = $dy;
     var reshapedTo4D = false;
@@ -21918,7 +23201,7 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
         (dy4D.rank + "."));
     util.assert(input4D.rank === 4, "Error in avgPoolBackprop: input must be rank 4 but got rank " +
         (input4D.rank + "."));
-    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, dilations, pad);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPoolBackprop(dy4D, input4D, convInfo); }, { dy4D: dy4D, input4D: input4D });
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
@@ -21927,8 +23210,9 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
 }
 exports.maxPool = operation_1.op({ maxPool_: maxPool_ });
 exports.avgPool = operation_1.op({ avgPool_: avgPool_ });
+exports.pool = operation_1.op({ pool_: pool_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],159:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./operation":171}],174:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var seedrandom = require("seedrandom");
@@ -21986,7 +23270,7 @@ var MPRandGauss = (function () {
 }());
 exports.MPRandGauss = MPRandGauss;
 
-},{"seedrandom":281}],160:[function(require,module,exports){
+},{"seedrandom":305}],175:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -21999,7 +23283,7 @@ function computeOptimalWindowSize(inSize) {
 }
 exports.computeOptimalWindowSize = computeOptimalWindowSize;
 
-},{"../util":194}],161:[function(require,module,exports){
+},{"../util":214}],176:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22060,6 +23344,28 @@ function sum_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function prod_(x, axis, keepDims) {
+    if (axis === void 0) { axis = null; }
+    if (keepDims === void 0) { keepDims = false; }
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'prod');
+    if ($x.dtype === 'bool') {
+        $x = $x.toInt();
+    }
+    var axes = axis_util.parseAxisParam(axis, $x.shape);
+    var permutation = axis_util.getAxesPermutation(axes, $x.rank);
+    var reductionAxes = axes;
+    var permutedX = $x;
+    if (permutation != null) {
+        permutedX = $x.transpose(permutation);
+        reductionAxes = axis_util.getInnerMostAxes(reductionAxes.length, $x.rank);
+    }
+    var value = environment_1.ENV.engine.runKernel(function (backend) { return backend.prod(permutedX, reductionAxes); }, { permutedX: permutedX });
+    if (keepDims) {
+        var newShape = axis_util.expandShapeToKeepDim(value.shape, axes);
+        value = value.reshape(newShape);
+    }
+    return value;
+}
 function mean_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
@@ -22086,10 +23392,26 @@ function mean_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes) {
+    var y = saved[0];
+    if (y.rank < xOrig.rank) {
+        y = y.reshape(axis_util.expandShapeToKeepDim(y.shape, origAxes));
+    }
+    if (dy.rank < xOrig.rank) {
+        dy = dy.reshape(axis_util.expandShapeToKeepDim(dy.shape, origAxes));
+    }
+    return {
+        $x: function () {
+            var dx = dy.mul(xOrig.equal(y).cast(dy.dtype));
+            return permutedAxes == null ? dx : dx.transpose(permutedAxes);
+        }
+    };
+}
 function min_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'min');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22097,10 +23419,13 @@ function min_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.min($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.min($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22108,6 +23433,7 @@ function max_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'max');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22115,10 +23441,13 @@ function max_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.max($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.max($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22218,8 +23547,9 @@ exports.mean = operation_1.op({ mean_: mean_ });
 exports.min = operation_1.op({ min_: min_ });
 exports.moments = operation_1.op({ moments_: moments_ });
 exports.sum = operation_1.op({ sum_: sum_ });
+exports.prod = operation_1.op({ prod_: prod_ });
 
-},{"../environment":64,"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156,"./tensor_ops":171}],162:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171,"./tensor_ops":191}],177:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22285,7 +23615,7 @@ exports.prelu = operation_1.op({ prelu_: prelu_ });
 exports.relu = operation_1.op({ relu_: relu_ });
 exports.selu = operation_1.op({ selu_: selu_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./binary_ops":138,"./logical_ops":149,"./operation":156,"./selu_util":166,"./tensor_ops":171}],163:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./binary_ops":150,"./logical_ops":164,"./operation":171,"./selu_util":183,"./tensor_ops":191}],178:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22331,7 +23661,99 @@ exports.reverse2d = operation_1.op({ reverse2d_: reverse2d_ });
 exports.reverse3d = operation_1.op({ reverse3d_: reverse3d_ });
 exports.reverse4d = operation_1.op({ reverse4d_: reverse4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],164:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],179:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+var scatter_nd_util = require("./scatter_nd_util");
+function scatterND_(indices, updates, shape) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'scatterND', 'int32');
+    var $updates = tensor_util_env_1.convertToTensor(updates, 'updates', 'scatterND');
+    scatter_nd_util.validateInput($updates, $indices, shape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.scatterND($indices, $updates, shape); }, { $indices: $indices, $updates: $updates });
+}
+exports.scatterND = operation_1.op({ scatterND_: scatterND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171,"./scatter_nd_util":180}],180:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function validateUpdateShape(shape, indices, updates) {
+    var sliceDim = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var batchDim = (indices.rank > 1) ? indices.rank - 1 : 1;
+    var shapeError = 'Must have updates.shape = indices.shape[:batchDim] + ' +
+        ("shape[sliceDim:], got updates.shape: " + updates.shape) +
+        (", indices.shape: " + indices.shape + ", shape: " + shape) +
+        (", sliceDim: " + sliceDim + ", and batchDim: " + batchDim + ".");
+    if (updates.rank < batchDim) {
+        throw new Error(shapeError + (" update.rank < " + batchDim + ". "));
+    }
+    if (shape.length < sliceDim + (updates.rank - batchDim)) {
+        throw new Error(shapeError +
+            (" Output shape length < " + (sliceDim + (updates.rank - batchDim))));
+    }
+    if (updates.rank !== batchDim + shape.length - sliceDim) {
+        throw new Error(shapeError + (" update.rank != " + (batchDim + shape.length - sliceDim)));
+    }
+    for (var d = 0; d < batchDim; ++d) {
+        if (updates.shape[d] !== indices.shape[d]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + d + "] (" + updates.shape[d] + ") != indices.shape[" + d + "] (" + indices.shape[d] + ")."));
+        }
+    }
+    for (var d = 0; d < updates.rank - batchDim; ++d) {
+        if (updates.shape[d + batchDim] !== shape[d + sliceDim]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + (d + batchDim) + "] (" + updates.shape[d + batchDim] + ") != shape[" + (d + batchDim) + "] (" + shape[d + batchDim] + ")"));
+        }
+    }
+}
+exports.validateUpdateShape = validateUpdateShape;
+function validateInput(updates, indices, shape) {
+    if (indices.rank < 1) {
+        throw new Error('tf.scatterND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (updates.rank < 1) {
+        throw new Error('tf.scatterND() expects the updates to be rank 1 or higher,' +
+            (" but the rank was " + updates.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error("The dtype of 'indices' should be int32, but got dtype: " + indices.dtype);
+    }
+    if (shape.length < 1) {
+        throw new Error("Output rank must be greater or equal to 1, but got shape: " + shape);
+    }
+    if (shape.length === 0) {
+        if (indices.size === 0) {
+            throw new Error("Indices specified for empty output. indices shape: " + indices.shape);
+        }
+        if (updates.size === 0) {
+            throw new Error("Updates specified for empty output. updates shape: " + updates.shape);
+        }
+    }
+    validateUpdateShape(shape, indices, updates);
+}
+exports.validateInput = validateInput;
+function calculateShapes(updates, indices, shape) {
+    var sliceRank = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var totalNd = shape.length;
+    var sliceSize = 1;
+    for (var i = sliceRank; i < totalNd; ++i) {
+        sliceSize *= shape[i];
+    }
+    var safeSliceDim = (sliceRank < 1) ? 1 : sliceRank;
+    var numUpdates = indices.size / safeSliceDim;
+    var outputStrides = util_1.computeStrides(shape).concat([1]);
+    var strides = outputStrides.slice(outputStrides.length - sliceRank, outputStrides.length);
+    var outputSize = util_1.sizeFromShape(shape);
+    return { sliceRank: sliceRank, numUpdates: numUpdates, sliceSize: sliceSize, strides: strides, outputSize: outputSize };
+}
+exports.calculateShapes = calculateShapes;
+
+},{"../util":214}],181:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22423,7 +23845,7 @@ function gatherDropNegatives(x, indices) {
 exports.gather = operation_1.op({ gather_: gather_ });
 exports.unsortedSegmentSum = operation_1.op({ unsortedSegmentSum_: unsortedSegmentSum_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./axis_util":136,"./binary_ops":138,"./compare":140,"./logical_ops":149,"./operation":156,"./tensor_ops":171}],165:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./axis_util":148,"./binary_ops":150,"./compare":152,"./logical_ops":164,"./operation":171,"./tensor_ops":191}],182:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22465,13 +23887,13 @@ function computeOutShape(aShape, axis, numSegments) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194,"./reduce_util":160}],166:[function(require,module,exports){
+},{"../util":214,"./reduce_util":175}],183:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SELU_SCALEALPHA = 1.7580993408473768599402175208123;
 exports.SELU_SCALE = 1.0507009873554804934193349852946;
 
-},{}],167:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22486,17 +23908,17 @@ function slice1d_(x, begin, size) {
 }
 function slice2d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice2d');
-    util.assert($x.rank === 2, "slice1d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 2, "slice2d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice3d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice3d');
-    util.assert($x.rank === 3, "slice1d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 3, "slice3d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice4d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice4d');
-    util.assert($x.rank === 4, "slice1d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 4, "slice4d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice_(x, begin, size) {
@@ -22553,7 +23975,7 @@ exports.slice2d = operation_1.op({ slice2d_: slice2d_ });
 exports.slice3d = operation_1.op({ slice3d_: slice3d_ });
 exports.slice4d = operation_1.op({ slice4d_: slice4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./slice_util":168}],168:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./slice_util":185}],185:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -22644,7 +24066,7 @@ function stopForAxis(endMask, stopIndices, strides, inputShape, axis) {
 }
 exports.stopForAxis = stopForAxis;
 
-},{"../util":194}],169:[function(require,module,exports){
+},{"../util":214}],186:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gradients_1 = require("../gradients");
@@ -22676,7 +24098,67 @@ function softmax_(logits, dim) {
 }
 exports.softmax = operation_1.op({ softmax_: softmax_ });
 
-},{"../gradients":67,"../tensor_util_env":190,"./operation":156}],170:[function(require,module,exports){
+},{"../gradients":67,"../tensor_util_env":210,"./operation":171}],187:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var sparse_to_dense = require("../ops/sparse_to_dense_util");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function sparseToDense_(sparseIndices, sparseValues, outputShape, defaultValue) {
+    var $sparseIndices = tensor_util_env_1.convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
+    var $sparseValues = tensor_util_env_1.convertToTensor(sparseValues, 'sparseValues', 'sparseToDense');
+    var $defaultValue = tensor_util_env_1.convertToTensor(defaultValue, 'defaultValue', 'sparseToDense');
+    sparse_to_dense.validateInput($sparseIndices, $sparseValues, outputShape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.sparseToDense($sparseIndices, $sparseValues, outputShape, $defaultValue); }, { $sparseIndices: $sparseIndices, $sparseValues: $sparseValues, $defaultValue: $defaultValue });
+}
+exports.sparseToDense = operation_1.op({ sparseToDense_: sparseToDense_ });
+
+},{"../environment":64,"../ops/sparse_to_dense_util":188,"../tensor_util_env":210,"./operation":171}],188:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateInput(sparseIndices, sparseValues, outputShape) {
+    if (sparseIndices.dtype !== 'int32') {
+        throw new Error('tf.sparseToDense() expects the indices to be int32 type,' +
+            (" but the dtype was " + sparseIndices.dtype + "."));
+    }
+    if (sparseIndices.rank > 2) {
+        throw new Error('sparseIndices should be a scalar, vector, or matrix,' +
+            (" but got shape " + sparseIndices.shape + "."));
+    }
+    var numElems = sparseIndices.rank > 0 ? sparseIndices.shape[0] : 1;
+    var numDims = sparseIndices.rank > 1 ? sparseIndices.shape[1] : 1;
+    if (outputShape.length !== numDims) {
+        throw new Error('outputShape has incorrect number of elements:,' +
+            (" " + outputShape.length + ", should be: " + numDims + "."));
+    }
+    var numValues = sparseValues.size;
+    if (!(sparseValues.rank === 0 ||
+        sparseValues.rank === 1 && numValues === numElems)) {
+        throw new Error('sparseValues has incorrect shape ' +
+            (sparseValues.shape + ", should be [] or [" + numElems + "]"));
+    }
+}
+exports.validateInput = validateInput;
+
+},{}],189:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var operation_1 = require("../ops/operation");
+var util_1 = require("../util");
+function fft_(input) {
+    util_1.assert(input.dtype === 'complex64', "The dtype for tf.spectral.fft() must be complex64 " +
+        ("but got " + input.dtype + "."));
+    var innerDimensionSize = input.shape[input.shape.length - 1];
+    var batch = input.size / innerDimensionSize;
+    var input2D = input.as2D(batch, innerDimensionSize);
+    var ret = environment_1.ENV.engine.runKernel(function (backend) { return backend.fft(input2D); }, { input: input });
+    return ret.reshape(input.shape);
+}
+exports.fft = operation_1.op({ fft_: fft_ });
+
+},{"../environment":64,"../ops/operation":171,"../util":214}],190:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22699,12 +24181,13 @@ function stridedSlice_(x, begin, end, strides, beginMask, endMask, ellipsisMask,
 }
 exports.stridedSlice = operation_1.op({ stridedSlice_: stridedSlice_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],171:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],191:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_1 = require("../tensor");
 var tensor_util_env_1 = require("../tensor_util_env");
+var tensor_util_env_2 = require("../tensor_util_env");
 var util_1 = require("../util");
 var complex_ops_1 = require("./complex_ops");
 var operation_1 = require("./operation");
@@ -22719,7 +24202,7 @@ function tensor(values, shape, dtype) {
         throw new Error('values passed to tensor(values) must be an ' +
             'array of numbers or booleans, or a TypedArray');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (shape != null && inferredShape.length !== 1) {
         util_1.assertShapesMatch(shape, inferredShape, "Error creating a new Tensor. " +
             ("Inferred shape (" + inferredShape + ") does not match the ") +
@@ -22746,7 +24229,7 @@ exports.scalar = scalar;
 function tensor1d(values, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     util_1.assertNonNull(values);
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 1) {
         throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
@@ -22759,7 +24242,7 @@ function tensor2d(values, shape, dtype) {
     if (shape != null && shape.length !== 2) {
         throw new Error('tensor2d() requires shape to have two numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
         throw new Error('tensor2d() requires values to be number[][] or flat/TypedArray');
     }
@@ -22777,7 +24260,7 @@ function tensor3d(values, shape, dtype) {
     if (shape != null && shape.length !== 3) {
         throw new Error('tensor3d() requires shape to have three numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
         throw new Error('tensor3d() requires values to be number[][][] or flat/TypedArray');
     }
@@ -22795,7 +24278,7 @@ function tensor4d(values, shape, dtype) {
     if (shape != null && shape.length !== 4) {
         throw new Error('tensor4d() requires shape to have four numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
         throw new Error('tensor4d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22813,7 +24296,7 @@ function tensor5d(values, shape, dtype) {
     if (shape != null && shape.length !== 5) {
         throw new Error('tensor5d() requires shape to have five numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 5 && inferredShape.length !== 1) {
         throw new Error('tensor5d() requires values to be ' +
             'number[][][][][] or flat/TypedArray');
@@ -22832,7 +24315,7 @@ function tensor6d(values, shape, dtype) {
     if (shape != null && shape.length !== 6) {
         throw new Error('tensor6d() requires shape to have six numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 6 && inferredShape.length !== 1) {
         throw new Error('tensor6d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22923,7 +24406,7 @@ exports.range = range;
 exports.onesLike = operation_1.op({ onesLike_: onesLike_ });
 exports.zerosLike = operation_1.op({ zerosLike_: zerosLike_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./complex_ops":141,"./operation":156}],172:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./complex_ops":153,"./operation":171}],192:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22946,7 +24429,7 @@ function topk_(x, k, sorted) {
 }
 exports.topk = operation_1.op({ topk_: topk_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],173:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],193:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22976,7 +24459,7 @@ function transpose_(x, perm) {
 }
 exports.transpose = operation_1.op({ transpose_: transpose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],174:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],194:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23266,7 +24749,7 @@ exports.step = operation_1.op({ step_: step_ });
 exports.tan = operation_1.op({ tan_: tan_ });
 exports.tanh = operation_1.op({ tanh_: tanh_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./tensor_ops":171}],175:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./tensor_ops":191}],195:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23373,7 +24856,7 @@ var AdadeltaOptimizer = (function (_super) {
 exports.AdadeltaOptimizer = AdadeltaOptimizer;
 serialization_1.registerClass(AdadeltaOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],176:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],196:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23455,7 +24938,7 @@ var AdagradOptimizer = (function (_super) {
 exports.AdagradOptimizer = AdagradOptimizer;
 serialization_1.registerClass(AdagradOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],177:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],197:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23574,7 +25057,7 @@ var AdamOptimizer = (function (_super) {
 exports.AdamOptimizer = AdamOptimizer;
 serialization_1.registerClass(AdamOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],178:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],198:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23695,7 +25178,7 @@ var AdamaxOptimizer = (function (_super) {
 exports.AdamaxOptimizer = AdamaxOptimizer;
 serialization_1.registerClass(AdamaxOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],179:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],199:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23785,7 +25268,7 @@ var MomentumOptimizer = (function (_super) {
 exports.MomentumOptimizer = MomentumOptimizer;
 serialization_1.registerClass(MomentumOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./sgd_optimizer":183}],180:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./sgd_optimizer":203}],200:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23826,7 +25309,7 @@ var Optimizer = (function (_super) {
 }(serialization_1.Serializable));
 exports.Optimizer = Optimizer;
 
-},{"../globals":66,"../serialization":185}],181:[function(require,module,exports){
+},{"../globals":66,"../serialization":205}],201:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./adadelta_optimizer");
@@ -23882,7 +25365,7 @@ var OptimizerConstructors = (function () {
 }());
 exports.OptimizerConstructors = OptimizerConstructors;
 
-},{"./adadelta_optimizer":175,"./adagrad_optimizer":176,"./adam_optimizer":177,"./adamax_optimizer":178,"./momentum_optimizer":179,"./rmsprop_optimizer":182,"./sgd_optimizer":183}],182:[function(require,module,exports){
+},{"./adadelta_optimizer":195,"./adagrad_optimizer":196,"./adam_optimizer":197,"./adamax_optimizer":198,"./momentum_optimizer":199,"./rmsprop_optimizer":202,"./sgd_optimizer":203}],202:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24026,7 +25509,7 @@ var RMSPropOptimizer = (function (_super) {
 exports.RMSPropOptimizer = RMSPropOptimizer;
 serialization_1.registerClass(RMSPropOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],183:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],203:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24086,7 +25569,7 @@ var SGDOptimizer = (function (_super) {
 exports.SGDOptimizer = SGDOptimizer;
 serialization_1.registerClass(SGDOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],184:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],204:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("./util");
@@ -24110,7 +25593,11 @@ var Profiler = (function () {
             var vals = r.dataSync();
             util.checkComputationForNaN(vals, r.dtype, name);
             timer.then(function (timing) {
-                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+                var extraInfo = '';
+                if (timing.getExtraProfileInfo != null) {
+                    extraInfo = timing.getExtraProfileInfo();
+                }
+                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
             });
         });
         return result;
@@ -24121,19 +25608,19 @@ exports.Profiler = Profiler;
 var Logger = (function () {
     function Logger() {
     }
-    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs) {
+    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs, extraInfo) {
         var time = util.rightPad(timeMs + "ms", 9);
         var paddedName = util.rightPad(name, 25);
         var rank = result.rank;
         var size = result.size;
         var shape = util.rightPad(result.shape.toString(), 14);
-        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size + "\t%c" + extraInfo, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange', 'color: green');
     };
     return Logger;
 }());
 exports.Logger = Logger;
 
-},{"./util":194}],185:[function(require,module,exports){
+},{"./util":214}],205:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -24178,7 +25665,7 @@ function registerClass(cls) {
 }
 exports.registerClass = registerClass;
 
-},{"./util":194}],186:[function(require,module,exports){
+},{"./util":214}],206:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -24291,7 +25778,7 @@ function backpropagateGradients(tensorAccumulatedGradientMap, filteredTape) {
 }
 exports.backpropagateGradients = backpropagateGradients;
 
-},{"./tensor":187,"./util":194}],187:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],207:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24677,6 +26164,12 @@ var Tensor = (function () {
         if (keepDims === void 0) { keepDims = false; }
         this.throwIfDisposed();
         return opHandler.sum(this, axis, keepDims);
+    };
+    Tensor.prototype.prod = function (axis, keepDims) {
+        if (axis === void 0) { axis = null; }
+        if (keepDims === void 0) { keepDims = false; }
+        this.throwIfDisposed();
+        return opHandler.prod(this, axis, keepDims);
     };
     Tensor.prototype.mean = function (axis, keepDims) {
         if (axis === void 0) { axis = null; }
@@ -25078,6 +26571,10 @@ var Tensor = (function () {
         if (beta === void 0) { beta = 0.5; }
         return opHandler.localResponseNormalization(this, radius, bias, alpha, beta);
     };
+    Tensor.prototype.pool = function (windowShape, poolingType, padding, dilationRate, strides) {
+        this.throwIfDisposed();
+        return opHandler.pool(this, windowShape, poolingType, padding, dilationRate, strides);
+    };
     Tensor.prototype.variable = function (trainable, name, dtype) {
         if (trainable === void 0) { trainable = true; }
         this.throwIfDisposed();
@@ -25110,6 +26607,10 @@ var Tensor = (function () {
     Tensor.prototype.depthToSpace = function (blockSize, dataFormat) {
         this.throwIfDisposed();
         return opHandler.depthToSpace(this, blockSize, dataFormat);
+    };
+    Tensor.prototype.fft = function () {
+        this.throwIfDisposed();
+        return opHandler.spectral.fft(this);
     };
     Tensor.nextId = 0;
     return Tensor;
@@ -25173,7 +26674,7 @@ Object.defineProperty(Variable, Symbol.hasInstance, {
 var variable = Variable.variable;
 exports.variable = variable;
 
-},{"./tensor_format":188,"./util":194}],188:[function(require,module,exports){
+},{"./tensor_format":208,"./util":214}],208:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -25304,7 +26805,7 @@ function createComplexTuples(vals) {
     return complexTuples;
 }
 
-},{"./util":194}],189:[function(require,module,exports){
+},{"./util":214}],209:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -25379,12 +26880,47 @@ function isIterable(obj) {
     return Array.isArray(obj) || typeof obj === 'object';
 }
 
-},{"./tensor":187,"./util":194}],190:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],210:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
 var tensor_1 = require("./tensor");
 var util_1 = require("./util");
+function inferShape(val) {
+    var firstElem = val;
+    if (util_1.isTypedArray(val)) {
+        return [val.length];
+    }
+    if (!Array.isArray(val)) {
+        return [];
+    }
+    var shape = [];
+    while (firstElem instanceof Array) {
+        shape.push(firstElem.length);
+        firstElem = firstElem[0];
+    }
+    if (val instanceof Array && environment_1.ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+        deepAssertShapeConsistency(val, shape, []);
+    }
+    return shape;
+}
+exports.inferShape = inferShape;
+function deepAssertShapeConsistency(val, shape, indices) {
+    indices = indices || [];
+    if (!(val instanceof Array)) {
+        util_1.assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
+            ("but should be an array of " + shape[0] + " elements"); });
+        return;
+    }
+    util_1.assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
+        ("but is an array of " + val.length + " elements"); });
+    util_1.assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
+        ("elements, but has " + val.length + " elements"); });
+    var subShape = shape.slice(1);
+    for (var i = 0; i < val.length; ++i) {
+        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
+    }
+}
 function convertToTensor(x, argName, functionName, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     dtype = dtype || 'float32';
@@ -25396,7 +26932,7 @@ function convertToTensor(x, argName, functionName, dtype) {
         throw new Error("Argument '" + argName + "' passed to '" + functionName + "' must be a " +
             ("Tensor or TensorLike, but got " + x.constructor.name));
     }
-    var inferredShape = util_1.inferShape(x);
+    var inferredShape = inferShape(x);
     if (!util_1.isTypedArray(x) && !Array.isArray(x)) {
         x = [x];
     }
@@ -25413,7 +26949,7 @@ function convertToTensorArray(arg, argName, functionName) {
 }
 exports.convertToTensorArray = convertToTensorArray;
 
-},{"./environment":64,"./tensor":187,"./util":194}],191:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],211:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -25433,6 +26969,9 @@ exports.BROWSER_ENVS = {
 };
 exports.CPU_ENVS = {
     'HAS_WEBGL': false
+};
+exports.BROWSER_CPU_ENVS = {
+    'BACKEND': 'test-cpu'
 };
 exports.ALL_ENVS = {};
 function expectArraysClose(actual, expected, epsilon) {
@@ -25534,7 +27073,7 @@ function expectArrayBuffersEqual(actual, expected) {
 }
 exports.expectArrayBuffersEqual = expectArrayBuffersEqual;
 
-},{"./environment":64,"./tensor":187,"./util":194}],192:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],212:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./optimizers/adadelta_optimizer");
@@ -25557,7 +27096,7 @@ exports.train = {
     adam: optimizer_constructors_1.OptimizerConstructors.adam
 };
 
-},{"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer_constructors":181,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183}],193:[function(require,module,exports){
+},{"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer_constructors":201,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203}],213:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DType;
@@ -25619,7 +27158,7 @@ function sumOutType(type) {
 }
 exports.sumOutType = sumOutType;
 
-},{}],194:[function(require,module,exports){
+},{}],214:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -25640,6 +27179,18 @@ function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 exports.clamp = clamp;
+function nearestLargerEven(val) {
+    return val % 2 === 0 ? val : val + 1;
+}
+exports.nearestLargerEven = nearestLargerEven;
+function sum(arr) {
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) {
+        sum += arr[i];
+    }
+    return sum;
+}
+exports.sum = sum;
 function randUniform(a, b) {
     var r = Math.random();
     return (b * r) + (1 - r) * a;
@@ -25682,41 +27233,6 @@ function flatten(arr, ret) {
     return ret;
 }
 exports.flatten = flatten;
-function inferShape(val) {
-    var firstElem = val;
-    if (isTypedArray(val)) {
-        return [val.length];
-    }
-    if (!Array.isArray(val)) {
-        return [];
-    }
-    var shape = [];
-    while (firstElem instanceof Array) {
-        shape.push(firstElem.length);
-        firstElem = firstElem[0];
-    }
-    if (val instanceof Array) {
-        deepAssertShapeConsistency(val, shape, []);
-    }
-    return shape;
-}
-exports.inferShape = inferShape;
-function deepAssertShapeConsistency(val, shape, indices) {
-    indices = indices || [];
-    if (!(val instanceof Array)) {
-        assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
-            ("but should be an array of " + shape[0] + " elements"); });
-        return;
-    }
-    assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
-        ("but is an array of " + val.length + " elements"); });
-    assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
-        ("elements, but has " + val.length + " elements"); });
-    var subShape = shape.slice(1);
-    for (var i = 0; i < val.length; ++i) {
-        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
-    }
-}
 function sizeFromShape(shape) {
     if (shape.length === 0) {
         return 1;
@@ -25733,6 +27249,12 @@ function isScalarShape(shape) {
 }
 exports.isScalarShape = isScalarShape;
 function arraysEqual(n1, n2) {
+    if (n1 === n2) {
+        return true;
+    }
+    if (n1 == null || n2 == null) {
+        return false;
+    }
     if (n1.length !== n2.length) {
         return false;
     }
@@ -26050,13 +27572,13 @@ function now() {
 exports.now = now;
 
 }).call(this,require('_process'))
-},{"_process":269}],195:[function(require,module,exports){
+},{"_process":293}],215:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.17';
+var version = '0.13.8';
 exports.version = version;
 
-},{}],196:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gpgpu_util = require("./kernels/webgl/gpgpu_util");
@@ -26068,7 +27590,7 @@ exports.MathBackendWebGL = backend_webgl_1.MathBackendWebGL;
 var gpgpu_context_1 = require("./kernels/webgl/gpgpu_context");
 exports.GPGPUContext = gpgpu_context_1.GPGPUContext;
 
-},{"./kernels/backend_webgl":82,"./kernels/webgl/gpgpu_context":104,"./kernels/webgl/gpgpu_util":106,"./kernels/webgl/webgl_util":131}],197:[function(require,module,exports){
+},{"./kernels/backend_webgl":83,"./kernels/webgl/gpgpu_context":110,"./kernels/webgl/gpgpu_util":112,"./kernels/webgl/webgl_util":142}],217:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26110,7 +27632,7 @@ var Elu = (function (_super) {
     return Elu;
 }(Activation));
 exports.Elu = Elu;
-tfjs_core_1.serialization.SerializationMap.register(Elu);
+tfjs_core_1.serialization.registerClass(Elu);
 var Selu = (function (_super) {
     __extends(Selu, _super);
     function Selu() {
@@ -26123,7 +27645,7 @@ var Selu = (function (_super) {
     return Selu;
 }(Activation));
 exports.Selu = Selu;
-tfjs_core_1.serialization.SerializationMap.register(Selu);
+tfjs_core_1.serialization.registerClass(Selu);
 var Relu = (function (_super) {
     __extends(Relu, _super);
     function Relu() {
@@ -26136,7 +27658,7 @@ var Relu = (function (_super) {
     return Relu;
 }(Activation));
 exports.Relu = Relu;
-tfjs_core_1.serialization.SerializationMap.register(Relu);
+tfjs_core_1.serialization.registerClass(Relu);
 var Relu6 = (function (_super) {
     __extends(Relu6, _super);
     function Relu6() {
@@ -26149,7 +27671,7 @@ var Relu6 = (function (_super) {
     return Relu6;
 }(Activation));
 exports.Relu6 = Relu6;
-tfjs_core_1.serialization.SerializationMap.register(Relu6);
+tfjs_core_1.serialization.registerClass(Relu6);
 var Linear = (function (_super) {
     __extends(Linear, _super);
     function Linear() {
@@ -26162,7 +27684,7 @@ var Linear = (function (_super) {
     return Linear;
 }(Activation));
 exports.Linear = Linear;
-tfjs_core_1.serialization.SerializationMap.register(Linear);
+tfjs_core_1.serialization.registerClass(Linear);
 var Sigmoid = (function (_super) {
     __extends(Sigmoid, _super);
     function Sigmoid() {
@@ -26175,7 +27697,7 @@ var Sigmoid = (function (_super) {
     return Sigmoid;
 }(Activation));
 exports.Sigmoid = Sigmoid;
-tfjs_core_1.serialization.SerializationMap.register(Sigmoid);
+tfjs_core_1.serialization.registerClass(Sigmoid);
 var HardSigmoid = (function (_super) {
     __extends(HardSigmoid, _super);
     function HardSigmoid() {
@@ -26188,7 +27710,7 @@ var HardSigmoid = (function (_super) {
     return HardSigmoid;
 }(Activation));
 exports.HardSigmoid = HardSigmoid;
-tfjs_core_1.serialization.SerializationMap.register(HardSigmoid);
+tfjs_core_1.serialization.registerClass(HardSigmoid);
 var Softplus = (function (_super) {
     __extends(Softplus, _super);
     function Softplus() {
@@ -26201,7 +27723,7 @@ var Softplus = (function (_super) {
     return Softplus;
 }(Activation));
 exports.Softplus = Softplus;
-tfjs_core_1.serialization.SerializationMap.register(Softplus);
+tfjs_core_1.serialization.registerClass(Softplus);
 var Softsign = (function (_super) {
     __extends(Softsign, _super);
     function Softsign() {
@@ -26214,7 +27736,7 @@ var Softsign = (function (_super) {
     return Softsign;
 }(Activation));
 exports.Softsign = Softsign;
-tfjs_core_1.serialization.SerializationMap.register(Softsign);
+tfjs_core_1.serialization.registerClass(Softsign);
 var Tanh = (function (_super) {
     __extends(Tanh, _super);
     function Tanh() {
@@ -26227,7 +27749,7 @@ var Tanh = (function (_super) {
     return Tanh;
 }(Activation));
 exports.Tanh = Tanh;
-tfjs_core_1.serialization.SerializationMap.register(Tanh);
+tfjs_core_1.serialization.registerClass(Tanh);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax() {
@@ -26241,7 +27763,7 @@ var Softmax = (function (_super) {
     return Softmax;
 }(Activation));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 function serializeActivation(activation) {
     return activation.getClassName();
 }
@@ -26269,7 +27791,7 @@ function getActivation(identifier) {
 }
 exports.getActivation = getActivation;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],198:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],218:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26287,7 +27809,7 @@ function imageDataFormat() {
 }
 exports.imageDataFormat = imageDataFormat;
 
-},{"@tensorflow/tfjs-core":68}],199:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26332,7 +27854,7 @@ function disposeScalarCache() {
 }
 exports.disposeScalarCache = disposeScalarCache;
 
-},{"@tensorflow/tfjs-core":68}],200:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -26541,27 +28063,42 @@ function randomNormal(shape, mean, stddev, dtype, seed) {
 }
 exports.randomNormal = randomNormal;
 function dot(x, y) {
-    if (y.rank !== 2) {
-        throw new errors_1.NotImplementedError("dot support for y other than rank 2 is not yet implemented: " +
-            ("y shape = " + y.shape));
+    if ((x.rank < 2) || (y.rank < 2)) {
+        throw new errors_1.NotImplementedError("dot requires both inputs to be rank >= 2" +
+            (" but got x shape = " + x.shape + " and y shape = " + y.shape));
+    }
+    if (y.rank >= 3) {
+        var xLastDim = x.shape.slice(-1)[0];
+        var ySecondLastDim = y.shape.slice(-2)[0];
+        if (xLastDim !== ySecondLastDim) {
+            throw new errors_1.NotImplementedError("If rank y >= 3, then the second last dim" +
+                (" of y must equal the last dim of x but got x shape = " + x.shape + " and ") +
+                (" y shape = " + y.shape));
+        }
+    }
+    if ((x.rank === 2) && (y.rank === 2)) {
+        return tfc.matMul(x, y);
     }
     else {
-        if (x.rank === 2) {
-            return tfc.matMul(x, y);
-        }
-        else if (x.rank === 3) {
-            var xShape0 = x.shape[0];
-            var xShape1 = x.shape[1];
-            var xShape2 = x.shape[2];
-            x = x.reshape([xShape0 * xShape1, xShape2]);
-            return tfc.matMul(x, y).reshape([
-                xShape0, xShape1, y.shape[1]
-            ]);
-        }
-        else {
-            throw new errors_1.NotImplementedError("dot support for x of rank " + x.rank + " is not yet implemented: " +
-                ("x shape = " + x.shape));
-        }
+        var xFirstDims = x.shape.slice();
+        var xLastDim = xFirstDims.pop();
+        x = x.reshape([-1, xLastDim]);
+        var yShape = y.shape.slice();
+        var yLastDim = yShape.pop();
+        var ySecondLastDim = yShape.pop();
+        var yOtherDims = yShape.concat([yLastDim]);
+        var perm = Array.from({ length: y.rank }, function (_, i) {
+            if (i === 0) {
+                return y.rank - 2;
+            }
+            else if (i <= y.rank - 2) {
+                return i - 1;
+            }
+            return i;
+        });
+        y = y.transpose(perm).reshape([ySecondLastDim, -1]);
+        var outputShape = xFirstDims.concat(yOtherDims);
+        return tfc.matMul(x, y).reshape(outputShape);
     }
 }
 exports.dot = dot;
@@ -26729,7 +28266,7 @@ function inTrainPhase(x, alt, training) {
 }
 exports.inTrainPhase = inTrainPhase;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/math_utils":240,"./common":198,"@tensorflow/tfjs-core":68}],201:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/math_utils":264,"./common":218,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26779,8 +28316,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("./backend/state");
+var errors_1 = require("./errors");
 var logs_1 = require("./logs");
 var generic_utils = require("./utils/generic_utils");
+var ModelLoggingVerbosity;
+(function (ModelLoggingVerbosity) {
+    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
+    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
+})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
 var BaseCallback = (function () {
     function BaseCallback() {
         this.validationData = null;
@@ -26934,19 +28477,22 @@ var CallbackList = (function () {
                         if (logs == null) {
                             logs = {};
                         }
-                        _i = 0, _a = this.callbacks;
-                        _b.label = 1;
+                        return [4, logs_1.resolveScalarsInLogs(logs)];
                     case 1:
-                        if (!(_i < _a.length)) return [3, 4];
+                        _b.sent();
+                        _i = 0, _a = this.callbacks;
+                        _b.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3, 5];
                         callback = _a[_i];
                         return [4, callback.onBatchEnd(batch, logs)];
-                    case 2:
-                        _b.sent();
-                        _b.label = 3;
                     case 3:
+                        _b.sent();
+                        _b.label = 4;
+                    case 4:
                         _i++;
-                        return [3, 1];
-                    case 4: return [2];
+                        return [3, 2];
+                    case 5: return [2];
                 }
             });
         });
@@ -27430,8 +28976,70 @@ function standardizeCallbacks(callbacks) {
     return callbackConfigs.map(function (callbackConfig) { return new CustomCallback(callbackConfig); });
 }
 exports.standardizeCallbacks = standardizeCallbacks;
+var CallbackConstructorRegistry = (function () {
+    function CallbackConstructorRegistry() {
+    }
+    CallbackConstructorRegistry.registerCallbackConstructor = function (verbosityLevel, callbackConstructor) {
+        tfjs_core_1.util.assert(verbosityLevel >= 0 && Number.isInteger(verbosityLevel), "Verbosity level is expected to be an integer >= 0, " +
+            ("but got " + verbosityLevel));
+        CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
+        if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {
+            CallbackConstructorRegistry.constructors[verbosityLevel] = [];
+        }
+        CallbackConstructorRegistry.constructors[verbosityLevel].push(callbackConstructor);
+    };
+    CallbackConstructorRegistry.checkForDuplicate = function (callbackConstructor) {
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var constructors = CallbackConstructorRegistry.constructors[+levelName];
+            constructors.forEach(function (ctor) {
+                if (ctor === callbackConstructor) {
+                    throw new errors_1.ValueError('Duplicate callback constructor.');
+                }
+            });
+        }
+    };
+    CallbackConstructorRegistry.clear = function () {
+        CallbackConstructorRegistry.constructors = {};
+    };
+    CallbackConstructorRegistry.createCallbacks = function (verbosityLevel) {
+        var constructors = [];
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var level = +levelName;
+            if (verbosityLevel >= level) {
+                constructors.push.apply(constructors, CallbackConstructorRegistry.constructors[level]);
+            }
+        }
+        return constructors.map(function (ctor) { return new ctor(); });
+    };
+    CallbackConstructorRegistry.constructors = {};
+    return CallbackConstructorRegistry;
+}());
+exports.CallbackConstructorRegistry = CallbackConstructorRegistry;
+function configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics) {
+    var history = new History();
+    var actualCallbacks = [
+        new BaseLogger(yieldEvery)
+    ].concat(CallbackConstructorRegistry.createCallbacks(verbose));
+    if (callbacks != null) {
+        actualCallbacks.push.apply(actualCallbacks, callbacks);
+    }
+    actualCallbacks.push(history);
+    var callbackList = new CallbackList(actualCallbacks);
+    callbackList.setParams({
+        epochs: epochs,
+        initialEpoch: initialEpoch,
+        samples: numTrainSamples,
+        steps: stepsPerEpoch,
+        batchSize: batchSize,
+        verbose: verbose,
+        doValidation: doValidation,
+        metrics: callbackMetrics,
+    });
+    return { callbackList: callbackList, history: history };
+}
+exports.configureCallbacks = configureCallbacks;
 
-},{"./backend/state":199,"./logs":231,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],202:[function(require,module,exports){
+},{"./backend/state":219,"./errors":233,"./logs":255,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27463,7 +29071,7 @@ var Callback = (function (_super) {
 }(base_callbacks_1.BaseCallback));
 exports.Callback = Callback;
 
-},{"./base_callbacks":201,"./engine/training":209}],203:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/training":230}],223:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils_1 = require("./utils/generic_utils");
@@ -27532,13 +29140,13 @@ function getUniqueTensorName(scopedName) {
     }
 }
 exports.getUniqueTensorName = getUniqueTensorName;
-var tensorNameRegex = new RegExp(/^[A-Za-z][A-Za-z0-9\._\/]*$/);
+var tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
 function isValidTensorName(name) {
     return name.match(tensorNameRegex) ? true : false;
 }
 exports.isValidTensorName = isValidTensorName;
 
-},{"./utils/generic_utils":238}],204:[function(require,module,exports){
+},{"./utils/generic_utils":262}],224:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27596,7 +29204,7 @@ var MaxNorm = (function (_super) {
     return MaxNorm;
 }(Constraint));
 exports.MaxNorm = MaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MaxNorm);
+tfjs_core_1.serialization.registerClass(MaxNorm);
 var UnitNorm = (function (_super) {
     __extends(UnitNorm, _super);
     function UnitNorm(config) {
@@ -27616,7 +29224,7 @@ var UnitNorm = (function (_super) {
     return UnitNorm;
 }(Constraint));
 exports.UnitNorm = UnitNorm;
-tfjs_core_1.serialization.SerializationMap.register(UnitNorm);
+tfjs_core_1.serialization.registerClass(UnitNorm);
 var NonNeg = (function (_super) {
     __extends(NonNeg, _super);
     function NonNeg() {
@@ -27629,7 +29237,7 @@ var NonNeg = (function (_super) {
     return NonNeg;
 }(Constraint));
 exports.NonNeg = NonNeg;
-tfjs_core_1.serialization.SerializationMap.register(NonNeg);
+tfjs_core_1.serialization.registerClass(NonNeg);
 var MinMaxNorm = (function (_super) {
     __extends(MinMaxNorm, _super);
     function MinMaxNorm(config) {
@@ -27666,7 +29274,7 @@ var MinMaxNorm = (function (_super) {
     return MinMaxNorm;
 }(Constraint));
 exports.MinMaxNorm = MinMaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MinMaxNorm);
+tfjs_core_1.serialization.registerClass(MinMaxNorm);
 exports.CONSTRAINT_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'maxNorm': 'MaxNorm',
     'minMaxNorm': 'MinMaxNorm',
@@ -27702,7 +29310,7 @@ function getConstraint(identifier) {
 }
 exports.getConstraint = getConstraint;
 
-},{"./backend/common":198,"./backend/state":199,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],205:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28365,7 +29973,7 @@ var Container = (function (_super) {
             keptNodes = layer instanceof Container ? 1 : 0;
             for (var originalNodeIndex = 0; originalNodeIndex < layer.inboundNodes.length; originalNodeIndex++) {
                 var nodeKey = Container.nodeKey(layer, originalNodeIndex);
-                if (nodeKey in this.containerNodes) {
+                if (this.containerNodes.has(nodeKey)) {
                     nodeConversionMap[nodeKey] = keptNodes;
                     keptNodes += 1;
                 }
@@ -28448,7 +30056,7 @@ var Container = (function (_super) {
                             var tensorIndex = node.tensorIndices[i];
                             var nodeKey_1 = Container.nodeKey(inboundLayer, nodeIndex);
                             var newNodeIndex = nodeConversionMap[nodeKey_1];
-                            if (newNodeIndex === null || newNodeIndex === undefined) {
+                            if (newNodeIndex == null) {
                                 newNodeIndex = 0;
                             }
                             nodeData.push([inboundLayer.name, newNodeIndex, tensorIndex, kwargs]);
@@ -28569,19 +30177,20 @@ var Container = (function (_super) {
                 var layerData = layersFromConfig_2[_a];
                 var layer = createdLayers[layerData.name];
                 if (layer.name in unprocessedNodes) {
-                    for (var _b = 0, _c = unprocessedNodes[layer.name]; _b < _c.length; _b++) {
-                        var nodeData = _c[_b];
+                    var currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
+                    delete unprocessedNodes[layer.name];
+                    for (var _b = 0, currentUnprocessedNodesForLayer_1 = currentUnprocessedNodesForLayer; _b < currentUnprocessedNodesForLayer_1.length; _b++) {
+                        var nodeData = currentUnprocessedNodesForLayer_1[_b];
                         processNode(layer, nodeData);
                     }
-                    delete unprocessedNodes[layer.name];
                 }
             }
         }
         var inputTensors = [];
         var outputTensors = [];
         var inputLayersFromConfig = config.inputLayers;
-        for (var _d = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _d < inputLayersFromConfig_1.length; _d++) {
-            var layerData = inputLayersFromConfig_1[_d];
+        for (var _c = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _c < inputLayersFromConfig_1.length; _c++) {
+            var layerData = inputLayersFromConfig_1[_c];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28591,8 +30200,8 @@ var Container = (function (_super) {
             inputTensors.push(layerOutputTensors[tensorIndex]);
         }
         var outputLayersFromConfig = config.outputLayers;
-        for (var _e = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _e < outputLayersFromConfig_1.length; _e++) {
-            var layerData = outputLayersFromConfig_1[_e];
+        for (var _d = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _d < outputLayersFromConfig_1.length; _d++) {
+            var layerData = outputLayersFromConfig_1[_d];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28635,7 +30244,23 @@ var Container = (function (_super) {
 }(topology_1.Layer));
 exports.Container = Container;
 
-},{"../backend/state":199,"../errors":210,"../layers/serialization":229,"../utils/generic_utils":238,"../utils/serialization_utils":241,"../utils/types_utils":242,"../variables":244,"../version":245,"./input_layer":207,"./topology":208,"@tensorflow/tfjs-core":68}],206:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"../layers/serialization":253,"../utils/generic_utils":262,"../utils/serialization_utils":265,"../utils/types_utils":266,"../variables":268,"../version":269,"./input_layer":228,"./topology":229,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyIterator = (function () {
+    function LazyIterator() {
+    }
+    return LazyIterator;
+}());
+exports.LazyIterator = LazyIterator;
+var Dataset = (function () {
+    function Dataset() {
+    }
+    return Dataset;
+}());
+exports.Dataset = Dataset;
+
+},{}],227:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -28769,7 +30394,7 @@ function getNodeOutputs(fetch) {
     return layerOutputs;
 }
 
-},{"../errors":210,"./input_layer":207,"@tensorflow/tfjs-core":68}],207:[function(require,module,exports){
+},{"../errors":233,"./input_layer":228,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28848,10 +30473,7 @@ var InputLayer = (function (_super) {
             ("InputLayer's apply() method. InputLayer name: " + this.name));
     };
     InputLayer.prototype.dispose = function () {
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: 0
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: 0 };
     };
     InputLayer.prototype.getConfig = function () {
         return {
@@ -28865,7 +30487,7 @@ var InputLayer = (function (_super) {
     return InputLayer;
 }(topology_1.Layer));
 exports.InputLayer = InputLayer;
-tfjs_core_1.serialization.SerializationMap.register(InputLayer);
+tfjs_core_1.serialization.registerClass(InputLayer);
 function Input(config) {
     if (config.batchShape == null && config.shape == null) {
         throw new Error('Please provide to Input either a `shape`' +
@@ -28896,7 +30518,7 @@ function Input(config) {
 }
 exports.Input = Input;
 
-},{"../backend/state":199,"../errors":210,"./topology":208,"@tensorflow/tfjs-core":68}],208:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"./topology":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29584,10 +31206,7 @@ var Layer = (function (_super) {
         if (--this._refCount === 0) {
             numDisposedVariables = this.disposeWeights();
         }
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: numDisposedVariables
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: numDisposedVariables };
     };
     return Layer;
 }(tfjs_core_1.serialization.Serializable));
@@ -29638,7 +31257,7 @@ function getSourceInputs(tensor, layer, nodeIndex) {
 }
 exports.getSourceInputs = getSourceInputs;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"../utils/variable_utils":243,"../variables":244,"@tensorflow/tfjs-core":68}],209:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"../utils/variable_utils":267,"../variables":268,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29690,10 +31309,8 @@ var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
-var base_callbacks_1 = require("../base_callbacks");
 var common_1 = require("../common");
 var errors_1 = require("../errors");
-var logs_1 = require("../logs");
 var losses = require("../losses");
 var Metrics = require("../metrics");
 var optimizers = require("../optimizers");
@@ -29702,6 +31319,8 @@ var layer_utils_1 = require("../utils/layer_utils");
 var math_utils_1 = require("../utils/math_utils");
 var container_1 = require("./container");
 var executor_1 = require("./executor");
+var training_dataset_1 = require("./training_dataset");
+var training_tensors_1 = require("./training_tensors");
 function isDataTensor(x) {
     return x instanceof tfjs_core_1.Tensor;
 }
@@ -29866,46 +31485,6 @@ function checkLossAndTargetCompatibility(targets, lossFns, outputShapes) {
         }
     }
 }
-function makeBatches(size, batchSize) {
-    var output = [];
-    var batchStart = 0;
-    var batchEnd = null;
-    while (batchStart < size) {
-        batchEnd = batchStart + batchSize;
-        if (batchEnd >= size) {
-            batchEnd = size;
-        }
-        output.push([batchStart, batchEnd]);
-        batchStart = batchEnd;
-    }
-    return output;
-}
-exports.makeBatches = makeBatches;
-function sliceArrays(arrays, start, stop) {
-    if (arrays == null) {
-        return [null];
-    }
-    else if (Array.isArray(arrays)) {
-        return arrays.map(function (array) { return K.sliceAlongFirstAxis(array, start, stop - start); });
-    }
-    else {
-        return K.sliceAlongFirstAxis(arrays, start, stop - start);
-    }
-}
-function sliceArraysByIndices(arrays, indices) {
-    return tfc.tidy(function () {
-        if (arrays == null) {
-            return null;
-        }
-        else if (Array.isArray(arrays)) {
-            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
-        }
-        else {
-            return K.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
-        }
-    });
-}
-exports.sliceArraysByIndices = sliceArraysByIndices;
 function checkInputData(data, names, shapes, checkBatchAxis, exceptionPrefix) {
     if (checkBatchAxis === void 0) { checkBatchAxis = true; }
     if (exceptionPrefix === void 0) { exceptionPrefix = ''; }
@@ -29978,14 +31557,6 @@ function collectMetrics(metrics, outputNames) {
         throw new TypeError('Type of metrics argument not understood. Expected an Array or ' +
             'Object, found: ' + metrics);
     }
-}
-var ModelLoggingVerbosity;
-(function (ModelLoggingVerbosity) {
-    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
-    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
-})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
-function checkBatchSize(batchSize) {
-    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
 }
 var Model = (function (_super) {
     __extends(Model, _super);
@@ -30176,13 +31747,21 @@ var Model = (function (_super) {
     Model.prototype.evaluate = function (x, y, config) {
         if (config === void 0) { config = {}; }
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         var standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
         var ins = standardizedOuts[0].concat(standardizedOuts[1]);
         this.makeTestFunction();
         var f = this.testFunction;
         var testOuts = this.testLoop(f, ins, batchSize, config.verbose, config.steps);
         return generic_utils_1.singletonOrArray(testOuts);
+    };
+    Model.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                this.makeTestFunction();
+                return [2, training_dataset_1.evaluateDataset(this, dataset, config)];
+            });
+        });
     };
     Model.prototype.checkNumSamples = function (ins, batchSize, steps, stepsName) {
         if (stepsName === void 0) { stepsName = 'steps'; }
@@ -30287,13 +31866,13 @@ var Model = (function (_super) {
             if (verbose) {
                 throw new errors_1.NotImplementedError('Verbose predictLoop() is not implemented yet.');
             }
-            var batches = makeBatches(numSamples, batchSize);
+            var batches = training_tensors_1.makeBatches(numSamples, batchSize);
             var outs = [];
             var _loop_3 = function (batchIndex) {
                 var batchOuts = tfc.tidy(function () {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
-                    var insBatch = sliceArrays(ins, batchStart, batchEnd);
+                    var insBatch = training_tensors_1.sliceArrays(ins, batchStart, batchEnd);
                     var feeds = [];
                     if (Array.isArray(insBatch)) {
                         for (var i = 0; i < insBatch.length; ++i) {
@@ -30328,7 +31907,7 @@ var Model = (function (_super) {
         if (config === void 0) { config = {}; }
         checkInputData(x, this.inputNames, this.feedInputShapes, false);
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         return this.predictLoop(x, batchSize);
     };
     Model.prototype.predictOnBatch = function (x) {
@@ -30365,204 +31944,26 @@ var Model = (function (_super) {
         }
         return [x, y, null];
     };
-    Model.prototype.fitLoop = function (f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var doValidation, numTrainSamples, indexArray, baseLogger, callbackList, _loop_4, this_1, epoch, state_2;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (batchSize == null) {
-                            batchSize = 32;
-                        }
-                        if (epochs == null) {
-                            epochs = 1;
-                        }
-                        if (shuffle == null) {
-                            shuffle = true;
-                        }
-                        if (initialEpoch == null) {
-                            initialEpoch = 0;
-                        }
-                        doValidation = false;
-                        if (valF != null && valIns != null) {
-                            doValidation = true;
-                        }
-                        if (validationSteps != null) {
-                            doValidation = true;
-                            if (stepsPerEpoch == null) {
-                                throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
-                                    'i.e., `stepsPerEpoch` must be set.');
-                            }
-                        }
-                        numTrainSamples = this.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
-                        if (numTrainSamples != null) {
-                            indexArray = math_utils_1.range(0, numTrainSamples);
-                        }
-                        this.history = new base_callbacks_1.History();
-                        baseLogger = new base_callbacks_1.BaseLogger(yieldEvery);
-                        if (callbacks == null) {
-                            callbacks = [baseLogger];
-                        }
-                        else {
-                            callbacks = [baseLogger].concat(callbacks);
-                        }
-                        callbacks = callbacks.concat([this.history]);
-                        if (verbose > 0) {
-                            throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
-                        }
-                        callbackList = new base_callbacks_1.CallbackList(callbacks);
-                        callbackList.setModel(this);
-                        callbackList.setParams({
-                            epochs: epochs,
-                            initialEpoch: initialEpoch,
-                            samples: numTrainSamples,
-                            steps: stepsPerEpoch,
-                            batchSize: batchSize,
-                            verbose: verbose,
-                            doValidation: doValidation,
-                            metrics: callbackMetrics,
-                        });
-                        return [4, callbackList.onTrainBegin()];
-                    case 1:
-                        _a.sent();
-                        this.stopTraining_ = false;
-                        _loop_4 = function (epoch) {
-                            var epochLogs, epochIndexArray1D_1, batches_1, _loop_5, batchIndex, state_3;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4, callbackList.onEpochBegin(epoch)];
-                                    case 1:
-                                        _a.sent();
-                                        epochLogs = {};
-                                        if (!(stepsPerEpoch != null)) return [3, 2];
-                                        throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
-                                    case 2:
-                                        if (shuffle === 'batch') {
-                                            throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
-                                        }
-                                        else if (shuffle) {
-                                            tfjs_core_1.util.shuffle(indexArray);
-                                        }
-                                        epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
-                                        batches_1 = makeBatches(numTrainSamples, batchSize);
-                                        _loop_5 = function (batchIndex) {
-                                            var batchLogs;
-                                            return __generator(this, function (_a) {
-                                                switch (_a.label) {
-                                                    case 0:
-                                                        batchLogs = {};
-                                                        return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
-                                                    case 1:
-                                                        _a.sent();
-                                                        tfc.tidy(function () {
-                                                            var batchStart = batches_1[batchIndex][0];
-                                                            var batchEnd = batches_1[batchIndex][1];
-                                                            var batchIds = K.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
-                                                            batchLogs['batch'] = batchIndex;
-                                                            batchLogs['size'] = batchEnd - batchStart;
-                                                            var insBatch = sliceArraysByIndices(ins, batchIds);
-                                                            var outs = f(insBatch);
-                                                            for (var i = 0; i < outLabels.length; ++i) {
-                                                                var label = outLabels[i];
-                                                                var out = outs[i];
-                                                                batchLogs[label] = out;
-                                                                tfc.keep(out);
-                                                            }
-                                                            if (batchIndex === batches_1.length - 1) {
-                                                                if (doValidation) {
-                                                                    var valOuts = _this.testLoop(valF, valIns, batchSize);
-                                                                    for (var i = 0; i < outLabels.length; ++i) {
-                                                                        var label = outLabels[i];
-                                                                        var out = valOuts[i];
-                                                                        tfc.keep(out);
-                                                                        epochLogs['val_' + label] = out;
-                                                                    }
-                                                                }
-                                                            }
-                                                        });
-                                                        return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
-                                                    case 2:
-                                                        _a.sent();
-                                                        logs_1.disposeTensorsInLogs(batchLogs);
-                                                        if (this_1.stopTraining_) {
-                                                            return [2, "break"];
-                                                        }
-                                                        return [2];
-                                                }
-                                            });
-                                        };
-                                        batchIndex = 0;
-                                        _a.label = 3;
-                                    case 3:
-                                        if (!(batchIndex < batches_1.length)) return [3, 6];
-                                        return [5, _loop_5(batchIndex)];
-                                    case 4:
-                                        state_3 = _a.sent();
-                                        if (state_3 === "break")
-                                            return [3, 6];
-                                        _a.label = 5;
-                                    case 5:
-                                        ++batchIndex;
-                                        return [3, 3];
-                                    case 6:
-                                        epochIndexArray1D_1.dispose();
-                                        _a.label = 7;
-                                    case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
-                                    case 8:
-                                        _a.sent();
-                                        if (this_1.stopTraining_) {
-                                            return [2, "break"];
-                                        }
-                                        return [2];
-                                }
-                            });
-                        };
-                        this_1 = this;
-                        epoch = initialEpoch;
-                        _a.label = 2;
-                    case 2:
-                        if (!(epoch < epochs)) return [3, 5];
-                        return [5, _loop_4(epoch)];
-                    case 3:
-                        state_2 = _a.sent();
-                        if (state_2 === "break")
-                            return [3, 5];
-                        _a.label = 4;
-                    case 4:
-                        ++epoch;
-                        return [3, 2];
-                    case 5: return [4, callbackList.onTrainEnd()];
-                    case 6:
-                        _a.sent();
-                        return [4, this.history.syncData()];
-                    case 7:
-                        _a.sent();
-                        return [2, this.history];
-                }
-            });
-        });
-    };
     Model.prototype.testLoop = function (f, ins, batchSize, verbose, steps) {
         var _this = this;
         if (verbose === void 0) { verbose = 0; }
         return tfc.tidy(function () {
             var numSamples = _this.checkNumSamples(ins, batchSize, steps, 'steps');
             var outs = [];
-            if (verbose === 1) {
+            if (verbose > 0) {
                 throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
             }
             if (steps != null) {
                 throw new errors_1.NotImplementedError('steps mode in testLoop() is not implemented yet');
             }
             else {
-                var batches = makeBatches(numSamples, batchSize);
+                var batches = training_tensors_1.makeBatches(numSamples, batchSize);
                 var indexArray = tfjs_core_1.tensor1d(math_utils_1.range(0, numSamples));
                 for (var batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
                     var batchIds = K.sliceAlongFirstAxis(indexArray, batchStart, batchEnd - batchStart);
-                    var insBatch = sliceArraysByIndices(ins, batchIds);
+                    var insBatch = training_tensors_1.sliceArraysByIndices(ins, batchIds);
                     var batchOuts = f(insBatch);
                     if (batchIndex === 0) {
                         for (var i = 0; i < batchOuts.length; ++i) {
@@ -30595,6 +31996,54 @@ var Model = (function (_super) {
             dedupedOutLabels.push(newLabel);
         }
         return dedupedOutLabels;
+    };
+    Model.prototype.makeTrainFunction = function () {
+        var _this = this;
+        return function (data) {
+            var losses = [];
+            var lossValues = [];
+            var inputs = data.slice(0, _this.inputs.length);
+            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
+            var metricsValues = [];
+            var totalLossFunction = function () {
+                var feeds = [];
+                for (var i = 0; i < _this.inputs.length; ++i) {
+                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
+                }
+                var feedDict = new executor_1.FeedDict(feeds);
+                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
+                var totalLoss;
+                for (var i = 0; i < _this.lossFunctions.length; ++i) {
+                    var lossFunction = _this.lossFunctions[i];
+                    var loss = lossFunction(targets[i], outputs[i]);
+                    losses.push(loss);
+                    var meanLoss = tfc.mean(loss);
+                    lossValues.push(meanLoss);
+                    if (i === 0) {
+                        totalLoss = loss;
+                    }
+                    else {
+                        totalLoss = tfc.add(totalLoss, loss);
+                    }
+                }
+                for (var i = 0; i < _this.metricsTensors.length; ++i) {
+                    var metric = _this.metricsTensors[i][0];
+                    var outputIndex = _this.metricsTensors[i][1];
+                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
+                    tfc.keep(meanMetric);
+                    metricsValues.push(meanMetric);
+                }
+                totalLoss = tfc.mean(totalLoss);
+                _this.calculateLosses().forEach(function (regularizerLoss) {
+                    totalLoss = tfc.add(totalLoss, regularizerLoss);
+                });
+                return totalLoss;
+            };
+            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
+            var returnCost = true;
+            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
+            return [totalLossValue].concat(metricsValues);
+        };
     };
     Model.prototype.makeTestFunction = function () {
         var _this = this;
@@ -30634,139 +32083,15 @@ var Model = (function (_super) {
     Model.prototype.fit = function (x, y, config) {
         if (config === void 0) { config = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (this.isTraining) {
-                            throw new Error('Cannot start training because another fit() call is ongoing.');
-                        }
-                        this.isTraining = true;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, , 3, 4]);
-                        batchSize = config.batchSize == null ? 32 : config.batchSize;
-                        checkBatchSize(batchSize);
-                        standardizedOuts = this.standardizeUserData(x, y, false, batchSize);
-                        inputs = standardizedOuts[0];
-                        targets = standardizedOuts[1];
-                        doValidation = false;
-                        valX = void 0;
-                        valY = void 0;
-                        valIns = void 0;
-                        needValidationDisposal = false;
-                        if (config.validationData != null && config.validationData.length > 0) {
-                            doValidation = true;
-                            if (config.validationData.length === 2) {
-                                valX = config.validationData[0];
-                                valY = config.validationData[1];
-                            }
-                            else if (config.validationData.length === 3) {
-                                throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
-                            }
-                            else {
-                                throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
-                                    "or 3 (valX, valY, valSampleWeight) items; " +
-                                    (config.validationData + " is invalid."));
-                            }
-                            valStandardized = this.standardizeUserData(valX, valY, true, batchSize);
-                            valX = valStandardized[0];
-                            valY = valStandardized[1];
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSplit != null && config.validationSplit > 0 &&
-                            config.validationSplit < 1) {
-                            doValidation = true;
-                            splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
-                            originalBatchSize = inputs[0].shape[0];
-                            valX = sliceArrays(inputs, splitAt, originalBatchSize);
-                            inputs = sliceArrays(inputs, 0, splitAt);
-                            valY = sliceArrays(targets, splitAt, originalBatchSize);
-                            targets = sliceArrays(targets, 0, splitAt);
-                            needValidationDisposal = true;
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSteps != null) {
-                            doValidation = true;
-                        }
-                        ins = inputs.concat(targets);
-                        this.checkTrainableWeightsConsistency();
-                        trainFunction = function (data) {
-                            var losses = [];
-                            var lossValues = [];
-                            var inputs = data.slice(0, _this.inputs.length);
-                            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
-                            var metricsValues = [];
-                            var totalLossFunction = function () {
-                                var feeds = [];
-                                for (var i = 0; i < _this.inputs.length; ++i) {
-                                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
-                                }
-                                var feedDict = new executor_1.FeedDict(feeds);
-                                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
-                                var totalLoss;
-                                for (var i = 0; i < _this.lossFunctions.length; ++i) {
-                                    var lossFunction = _this.lossFunctions[i];
-                                    var loss = lossFunction(targets[i], outputs[i]);
-                                    losses.push(loss);
-                                    var meanLoss = tfc.mean(loss);
-                                    lossValues.push(meanLoss);
-                                    if (i === 0) {
-                                        totalLoss = loss;
-                                    }
-                                    else {
-                                        totalLoss = tfc.add(totalLoss, loss);
-                                    }
-                                }
-                                for (var i = 0; i < _this.metricsTensors.length; ++i) {
-                                    var metric = _this.metricsTensors[i][0];
-                                    var outputIndex = _this.metricsTensors[i][1];
-                                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
-                                    tfc.keep(meanMetric);
-                                    metricsValues.push(meanMetric);
-                                }
-                                totalLoss = tfc.mean(totalLoss);
-                                _this.calculateLosses().forEach(function (regularizerLoss) {
-                                    totalLoss = tfc.add(totalLoss, regularizerLoss);
-                                });
-                                return totalLoss;
-                            };
-                            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
-                            var returnCost = true;
-                            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
-                            return [totalLossValue].concat(metricsValues);
-                        };
-                        outLabels = this.getDedupedMetricsNames();
-                        valFunction = void 0;
-                        callbackMetrics = void 0;
-                        if (doValidation) {
-                            this.makeTestFunction();
-                            valFunction = this.testFunction;
-                            callbackMetrics =
-                                outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
-                        }
-                        else {
-                            valFunction = null;
-                            valIns = [];
-                            callbackMetrics = outLabels.slice();
-                        }
-                        callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
-                        return [4, this.fitLoop(trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
-                    case 2:
-                        out = _a.sent();
-                        if (needValidationDisposal) {
-                            valIns.forEach(function (tensor) { return tensor.dispose(); });
-                            inputs.forEach(function (tensor) { return tensor.dispose(); });
-                            targets.forEach(function (tensor) { return tensor.dispose(); });
-                        }
-                        this.isTraining = false;
-                        return [2, out];
-                    case 3:
-                        this.isTraining = false;
-                        return [7];
-                    case 4: return [2];
-                }
+                return [2, training_tensors_1.fitTensors(this, x, y, config)];
+            });
+        });
+    };
+    Model.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, training_dataset_1.fitDataset(this, dataset, config)];
             });
         });
     };
@@ -30830,9 +32155,699 @@ var Model = (function (_super) {
     return Model;
 }(container_1.Container));
 exports.Model = Model;
-tfjs_core_1.serialization.SerializationMap.register(Model);
+tfjs_core_1.serialization.registerClass(Model);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../base_callbacks":201,"../common":203,"../errors":210,"../logs":231,"../losses":232,"../metrics":233,"../optimizers":235,"../utils/generic_utils":238,"../utils/layer_utils":239,"../utils/math_utils":240,"./container":205,"./executor":206,"@tensorflow/tfjs-core":68}],210:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../errors":233,"../losses":256,"../metrics":257,"../optimizers":259,"../utils/generic_utils":262,"../utils/layer_utils":263,"../utils/math_utils":264,"./container":225,"./executor":227,"./training_dataset":231,"./training_tensors":232,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var state_1 = require("../backend/state");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var generic_utils_1 = require("../utils/generic_utils");
+var dataset_stub_1 = require("./dataset_stub");
+var DEFAULT_VALIDATION_BATCH_SIZE = 32;
+function standardizeDataIteratorOutput(model, iteratorOut) {
+    if (model.outputs.length > 1) {
+        throw new errors_1.NotImplementedError("Support for training a model with multiple output tensors with " +
+            "a dataset object is not implemented yet.");
+    }
+    tfc.util.assert(Array.isArray(iteratorOut) && iteratorOut.length === 2, 'Dataset iterator for fitDataset() is expected to generate ' +
+        'an Array of length 2: `[xs, ys]`, but instead generates ' +
+        iteratorOut);
+    iteratorOut = iteratorOut;
+    var ys = iteratorOut[1];
+    var xs = iteratorOut[0];
+    if (xs instanceof tfc.Tensor) {
+        tfc.util.assert(model.inputs.length === 1, "Model has multiple " + model.inputs.length + " inputs, hence it " +
+            "expects the input dataset to generate a dictionary of tensors " +
+            (" (with keys " + JSON.stringify(model.inputNames) + ", ") +
+            "but received a single tensor.");
+        tfc.util.assert(xs.shape[0] === ys.shape[0], "Mismatch in batch size between x and y tensors (" + xs.shape[0] + " vs. " +
+            (ys.shape[0] + ")"));
+        return [xs, ys];
+    }
+    else {
+        var batchSize = void 0;
+        xs = xs;
+        var flattendXs = [];
+        for (var _i = 0, _a = model.inputNames; _i < _a.length; _i++) {
+            var inputName = _a[_i];
+            if (xs[inputName] == null) {
+                throw new errors_1.ValueError("The feature data generated by the dataset lacks the required " +
+                    ("input key '" + inputName + "'."));
+            }
+            flattendXs.push(xs[inputName]);
+            if (batchSize == null) {
+                batchSize = xs[inputName].shape[0];
+            }
+            else {
+                tfc.util.assert(xs[inputName].shape[0] === batchSize, "Mismatch in batch size between x and y tensors " +
+                    ("(" + xs[inputName].shape[0] + " vs. " + ys.shape[0] + ")"));
+            }
+        }
+        return flattendXs.concat(ys);
+    }
+}
+function standardizeTensorValidationData(data) {
+    if (data.length === 3) {
+        throw new errors_1.NotImplementedError('Validation with sample weights is not implemented yet.');
+    }
+    return { xs: data[0], ys: data[1] };
+}
+function fitDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, validationDataIterator, valXs, valYs, validationData, trainFunction, outLabels, callbackMetrics, callbacks, _a, callbackList, history_1, epoch, epochLogs, dataIterator, stepsDone, batchIndex, iteratorOut, xsAndYs, batchLogs, outs, i, label, out, valOuts, _b, i;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    tfc.util.assert(model.optimizer != null, 'You must compile a model before training/testing. Use ' +
+                        'Model.compile(modelCompileConfig).');
+                    tfc.util.assert(config != null, "For fitDataset(), the 2nd argument (config) is required, " +
+                        "but it is not provided in this call.");
+                    tfc.util.assert(config.epochs != null && config.epochs > 0 &&
+                        Number.isInteger(config.epochs), "For fitDataset(), config.epochs is expected to be a positive " +
+                        ("integer, but got " + config.epochs));
+                    tfc.util.assert(config.batchesPerEpoch != null && config.batchesPerEpoch > 0 &&
+                        Number.isInteger(config.batchesPerEpoch), "For fitDataset(), config.batchesPerEpoch is expected to be a " +
+                        ("positive integer, but got " + config.batchesPerEpoch));
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _c.label = 1;
+                case 1:
+                    _c.trys.push([1, , 21, 22]);
+                    doValidation = config.validationData != null;
+                    validationDataIterator = void 0;
+                    valXs = void 0;
+                    valYs = void 0;
+                    if (!doValidation) return [3, 4];
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 3];
+                    tfc.util.assert(config.validationBatches > 0 &&
+                        Number.isInteger(config.validationBatches), "For fitDataset() with dataset-based validation, " +
+                        "config.validationBatches is expected to be a " +
+                        ("positive integer, but got " + config.validationBatches));
+                    return [4, config.validationData.iterator()];
+                case 2:
+                    validationDataIterator = _c.sent();
+                    return [3, 4];
+                case 3:
+                    validationData = standardizeTensorValidationData(config.validationData);
+                    valXs = validationData.xs;
+                    valYs = validationData.ys;
+                    _c.label = 4;
+                case 4:
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    _a = base_callbacks_1.configureCallbacks(callbacks, config.yieldEvery, config.verbose, config.epochs, null, null, config.batchesPerEpoch, null, doValidation, callbackMetrics), callbackList = _a.callbackList, history_1 = _a.history;
+                    model.history = history_1;
+                    return [4, callbackList.onTrainBegin()];
+                case 5:
+                    _c.sent();
+                    epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
+                    epochLogs = {};
+                    return [4, dataset.iterator()];
+                case 6:
+                    dataIterator = _c.sent();
+                    _c.label = 7;
+                case 7:
+                    if (!(epoch < config.epochs)) return [3, 18];
+                    return [4, callbackList.onEpochBegin(epoch)];
+                case 8:
+                    _c.sent();
+                    stepsDone = 0;
+                    batchIndex = 0;
+                    _c.label = 9;
+                case 9:
+                    if (!(stepsDone < config.batchesPerEpoch)) return [3, 16];
+                    return [4, dataIterator.next()];
+                case 10:
+                    iteratorOut = _c.sent();
+                    if (iteratorOut.done) {
+                        console.warn('Your dataset iterator ran out of data; ' +
+                            'interrupting training. Make sure that your ' +
+                            'dataset can generate at least `batchesPerEpoch * epochs` ' +
+                            'batches (in this case, ' +
+                            (config.batchesPerEpoch * config.epochs + " batches). ") +
+                            'You may need to use the repeat() function when building ' +
+                            'your dataset.');
+                        return [3, 16];
+                    }
+                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                    batchLogs = {};
+                    batchLogs['batch'] = batchIndex;
+                    batchLogs['size'] = xsAndYs[0].shape[0];
+                    callbackList.onBatchBegin(batchIndex, batchLogs);
+                    outs = trainFunction(xsAndYs);
+                    tfc.dispose(xsAndYs);
+                    for (i = 0; i < outLabels.length; ++i) {
+                        label = outLabels[i];
+                        out = outs[i];
+                        batchLogs[label] = out;
+                        tfc.keep(out);
+                    }
+                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                case 11:
+                    _c.sent();
+                    logs_1.disposeTensorsInLogs(batchLogs);
+                    batchIndex++;
+                    stepsDone++;
+                    if (!(stepsDone >= config.batchesPerEpoch && doValidation)) return [3, 15];
+                    valOuts = void 0;
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 13];
+                    _b = generic_utils_1.toList;
+                    return [4, model.evaluateDataset(validationDataIterator, { batches: config.validationBatches })];
+                case 12:
+                    valOuts = _b.apply(void 0, [_c.sent()]);
+                    return [3, 14];
+                case 13:
+                    valOuts = generic_utils_1.toList(model.evaluate(valXs, valYs, {
+                        batchSize: config.validationBatchSize == null ?
+                            DEFAULT_VALIDATION_BATCH_SIZE :
+                            config.validationBatchSize,
+                        verbose: 0
+                    }));
+                    _c.label = 14;
+                case 14:
+                    for (i = 0; i < model.metricsNames.length; ++i) {
+                        epochLogs["val_" + model.metricsNames[i]] = valOuts[i];
+                    }
+                    _c.label = 15;
+                case 15:
+                    if (model.stopTraining_) {
+                        return [3, 16];
+                    }
+                    return [3, 9];
+                case 16: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                case 17:
+                    _c.sent();
+                    epoch++;
+                    if (model.stopTraining_) {
+                        return [3, 18];
+                    }
+                    return [3, 7];
+                case 18: return [4, callbackList.onTrainEnd()];
+                case 19:
+                    _c.sent();
+                    return [4, model.history.syncData()];
+                case 20:
+                    _c.sent();
+                    return [2, model.history];
+                case 21:
+                    model.isTraining = false;
+                    return [7];
+                case 22: return [2];
+            }
+        });
+    });
+}
+exports.fitDataset = fitDataset;
+function evaluateDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var f, outs, dataIterator, _a, numExamples, _loop_1, batch, state_2, _loop_2, i;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    f = model.testFunction;
+                    outs = [];
+                    if (config.verbose > 0) {
+                        throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
+                    }
+                    tfc.util.assert(config.batches > 0 && Number.isInteger(config.batches), 'Test loop expects `batches` to be a positive integer, but ' +
+                        ("received " + JSON.stringify(config.batches)));
+                    if (!(dataset instanceof dataset_stub_1.LazyIterator)) return [3, 1];
+                    _a = dataset;
+                    return [3, 3];
+                case 1: return [4, dataset.iterator()];
+                case 2:
+                    _a = _b.sent();
+                    _b.label = 3;
+                case 3:
+                    dataIterator = _a;
+                    numExamples = 0;
+                    _loop_1 = function (batch) {
+                        var iteratorOut, xsAndYs, batchOuts, i, batchSize, _loop_3, i;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, dataIterator.next()];
+                                case 1:
+                                    iteratorOut = _a.sent();
+                                    if (iteratorOut.done) {
+                                        console.warn('Your dataset iterator ran out of data during evaluateDataset(). ' +
+                                            'Interrupting evalution. Make sure that your ' +
+                                            'dataset can generate at least `batches` ' +
+                                            ("batches (in this case, " + config.batches + " batches). ") +
+                                            'You may need to use the repeat() function when building ' +
+                                            'your dataset.');
+                                        return [2, "break"];
+                                    }
+                                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                                    batchOuts = tfc.tidy(function () { return f(xsAndYs); });
+                                    tfc.dispose(xsAndYs);
+                                    if (batch === 0) {
+                                        for (i = 0; i < batchOuts.length; ++i) {
+                                            outs.push(state_1.getScalar(0));
+                                        }
+                                    }
+                                    batchSize = xsAndYs[0].shape[0];
+                                    _loop_3 = function (i) {
+                                        var batchOut = batchOuts[i];
+                                        var oldScalar = outs[i];
+                                        outs[i] = tfc.tidy(function () { return tfc.add(outs[i], tfc.mul(state_1.getScalar(batchSize), batchOut)); });
+                                        if (batch > 0) {
+                                            tfc.dispose(oldScalar);
+                                        }
+                                    };
+                                    for (i = 0; i < batchOuts.length; ++i) {
+                                        _loop_3(i);
+                                    }
+                                    tfc.dispose(batchOuts);
+                                    numExamples += batchSize;
+                                    return [2];
+                            }
+                        });
+                    };
+                    batch = 0;
+                    _b.label = 4;
+                case 4:
+                    if (!(batch < config.batches)) return [3, 7];
+                    return [5, _loop_1(batch)];
+                case 5:
+                    state_2 = _b.sent();
+                    if (state_2 === "break")
+                        return [3, 7];
+                    _b.label = 6;
+                case 6:
+                    ++batch;
+                    return [3, 4];
+                case 7:
+                    _loop_2 = function (i) {
+                        var oldScalar = outs[i];
+                        outs[i] =
+                            tfc.tidy(function () { return tfc.div(outs[i], state_1.getScalar(numExamples)); });
+                        tfc.dispose(oldScalar);
+                    };
+                    for (i = 0; i < outs.length; ++i) {
+                        _loop_2(i);
+                    }
+                    return [2, generic_utils_1.singletonOrArray(outs)];
+            }
+        });
+    });
+}
+exports.evaluateDataset = evaluateDataset;
+
+},{"../backend/state":219,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/generic_utils":262,"./dataset_stub":226,"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfjs_backend_1 = require("../backend/tfjs_backend");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var math_utils_1 = require("../utils/math_utils");
+function checkBatchSize(batchSize) {
+    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
+}
+exports.checkBatchSize = checkBatchSize;
+function sliceArrays(arrays, start, stop) {
+    if (arrays == null) {
+        return [null];
+    }
+    else if (Array.isArray(arrays)) {
+        return arrays.map(function (array) { return tfjs_backend_1.sliceAlongFirstAxis(array, start, stop - start); });
+    }
+    else {
+        return tfjs_backend_1.sliceAlongFirstAxis(arrays, start, stop - start);
+    }
+}
+exports.sliceArrays = sliceArrays;
+function sliceArraysByIndices(arrays, indices) {
+    return tfc.tidy(function () {
+        if (arrays == null) {
+            return null;
+        }
+        else if (Array.isArray(arrays)) {
+            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
+        }
+        else {
+            return tfjs_backend_1.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
+        }
+    });
+}
+exports.sliceArraysByIndices = sliceArraysByIndices;
+function makeBatches(size, batchSize) {
+    var output = [];
+    var batchStart = 0;
+    var batchEnd = null;
+    while (batchStart < size) {
+        batchEnd = batchStart + batchSize;
+        if (batchEnd >= size) {
+            batchEnd = size;
+        }
+        output.push([batchStart, batchEnd]);
+        batchStart = batchEnd;
+    }
+    return output;
+}
+exports.makeBatches = makeBatches;
+function fitLoop(model, f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, numTrainSamples, indexArray, _a, callbackList, history, _loop_1, epoch, state_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (batchSize == null) {
+                        batchSize = 32;
+                    }
+                    if (epochs == null) {
+                        epochs = 1;
+                    }
+                    if (shuffle == null) {
+                        shuffle = true;
+                    }
+                    if (initialEpoch == null) {
+                        initialEpoch = 0;
+                    }
+                    doValidation = false;
+                    if (valF != null && valIns != null) {
+                        doValidation = true;
+                    }
+                    if (validationSteps != null) {
+                        doValidation = true;
+                        if (stepsPerEpoch == null) {
+                            throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
+                                'i.e., `stepsPerEpoch` must be set.');
+                        }
+                    }
+                    numTrainSamples = model.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
+                    if (numTrainSamples != null) {
+                        indexArray = math_utils_1.range(0, numTrainSamples);
+                    }
+                    if (verbose == null) {
+                        verbose = 1;
+                    }
+                    _a = base_callbacks_1.configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics), callbackList = _a.callbackList, history = _a.history;
+                    callbackList.setModel(model);
+                    model.history = history;
+                    return [4, callbackList.onTrainBegin()];
+                case 1:
+                    _b.sent();
+                    model.stopTraining_ = false;
+                    _loop_1 = function (epoch) {
+                        var epochLogs, epochIndexArray1D_1, batches_1, _loop_2, batchIndex, state_2;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, callbackList.onEpochBegin(epoch)];
+                                case 1:
+                                    _a.sent();
+                                    epochLogs = {};
+                                    if (!(stepsPerEpoch != null)) return [3, 2];
+                                    throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
+                                case 2:
+                                    if (shuffle === 'batch') {
+                                        throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
+                                    }
+                                    else if (shuffle) {
+                                        tfjs_core_1.util.shuffle(indexArray);
+                                    }
+                                    epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
+                                    batches_1 = makeBatches(numTrainSamples, batchSize);
+                                    _loop_2 = function (batchIndex) {
+                                        var batchLogs;
+                                        return __generator(this, function (_a) {
+                                            switch (_a.label) {
+                                                case 0:
+                                                    batchLogs = {};
+                                                    return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
+                                                case 1:
+                                                    _a.sent();
+                                                    tfc.tidy(function () {
+                                                        var batchStart = batches_1[batchIndex][0];
+                                                        var batchEnd = batches_1[batchIndex][1];
+                                                        var batchIds = tfjs_backend_1.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
+                                                        batchLogs['batch'] = batchIndex;
+                                                        batchLogs['size'] = batchEnd - batchStart;
+                                                        var insBatch = sliceArraysByIndices(ins, batchIds);
+                                                        var outs = f(insBatch);
+                                                        for (var i = 0; i < outLabels.length; ++i) {
+                                                            var label = outLabels[i];
+                                                            var out = outs[i];
+                                                            batchLogs[label] = out;
+                                                            tfc.keep(out);
+                                                        }
+                                                        if (batchIndex === batches_1.length - 1) {
+                                                            if (doValidation) {
+                                                                var valOuts = model.testLoop(valF, valIns, batchSize);
+                                                                for (var i = 0; i < outLabels.length; ++i) {
+                                                                    var label = outLabels[i];
+                                                                    var out = valOuts[i];
+                                                                    tfc.keep(out);
+                                                                    epochLogs['val_' + label] = out;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                                                case 2:
+                                                    _a.sent();
+                                                    logs_1.disposeTensorsInLogs(batchLogs);
+                                                    if (model.stopTraining_) {
+                                                        return [2, "break"];
+                                                    }
+                                                    return [2];
+                                            }
+                                        });
+                                    };
+                                    batchIndex = 0;
+                                    _a.label = 3;
+                                case 3:
+                                    if (!(batchIndex < batches_1.length)) return [3, 6];
+                                    return [5, _loop_2(batchIndex)];
+                                case 4:
+                                    state_2 = _a.sent();
+                                    if (state_2 === "break")
+                                        return [3, 6];
+                                    _a.label = 5;
+                                case 5:
+                                    ++batchIndex;
+                                    return [3, 3];
+                                case 6:
+                                    epochIndexArray1D_1.dispose();
+                                    _a.label = 7;
+                                case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                                case 8:
+                                    _a.sent();
+                                    if (model.stopTraining_) {
+                                        return [2, "break"];
+                                    }
+                                    return [2];
+                            }
+                        });
+                    };
+                    epoch = initialEpoch;
+                    _b.label = 2;
+                case 2:
+                    if (!(epoch < epochs)) return [3, 5];
+                    return [5, _loop_1(epoch)];
+                case 3:
+                    state_1 = _b.sent();
+                    if (state_1 === "break")
+                        return [3, 5];
+                    _b.label = 4;
+                case 4:
+                    ++epoch;
+                    return [3, 2];
+                case 5: return [4, callbackList.onTrainEnd()];
+                case 6:
+                    _b.sent();
+                    return [4, model.history.syncData()];
+                case 7:
+                    _b.sent();
+                    return [2, model.history];
+            }
+        });
+    });
+}
+function fitTensors(model, x, y, config) {
+    if (config === void 0) { config = {}; }
+    return __awaiter(this, void 0, void 0, function () {
+        var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, , 3, 4]);
+                    batchSize = config.batchSize == null ? 32 : config.batchSize;
+                    checkBatchSize(batchSize);
+                    standardizedOuts = model.standardizeUserData(x, y, false, batchSize);
+                    inputs = standardizedOuts[0];
+                    targets = standardizedOuts[1];
+                    doValidation = false;
+                    valX = void 0;
+                    valY = void 0;
+                    valIns = void 0;
+                    needValidationDisposal = false;
+                    if (config.validationData != null && config.validationData.length > 0) {
+                        doValidation = true;
+                        if (config.validationData.length === 2) {
+                            valX = config.validationData[0];
+                            valY = config.validationData[1];
+                        }
+                        else if (config.validationData.length === 3) {
+                            throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
+                        }
+                        else {
+                            throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
+                                "or 3 (valX, valY, valSampleWeight) items; " +
+                                (config.validationData + " is invalid."));
+                        }
+                        valStandardized = model.standardizeUserData(valX, valY, true, batchSize);
+                        valX = valStandardized[0];
+                        valY = valStandardized[1];
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSplit != null && config.validationSplit > 0 &&
+                        config.validationSplit < 1) {
+                        doValidation = true;
+                        splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
+                        originalBatchSize = inputs[0].shape[0];
+                        valX = sliceArrays(inputs, splitAt, originalBatchSize);
+                        inputs = sliceArrays(inputs, 0, splitAt);
+                        valY = sliceArrays(targets, splitAt, originalBatchSize);
+                        targets = sliceArrays(targets, 0, splitAt);
+                        needValidationDisposal = true;
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSteps != null) {
+                        doValidation = true;
+                    }
+                    ins = inputs.concat(targets);
+                    model.checkTrainableWeightsConsistency();
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    valFunction = void 0;
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        model.makeTestFunction();
+                        valFunction = model.testFunction;
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        valFunction = null;
+                        valIns = [];
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    return [4, fitLoop(model, trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
+                case 2:
+                    out = _a.sent();
+                    if (needValidationDisposal) {
+                        valIns.forEach(function (tensor) { return tensor.dispose(); });
+                        inputs.forEach(function (tensor) { return tensor.dispose(); });
+                        targets.forEach(function (tensor) { return tensor.dispose(); });
+                    }
+                    model.isTraining = false;
+                    return [2, out];
+                case 3:
+                    model.isTraining = false;
+                    return [7];
+                case 4: return [2];
+            }
+        });
+    });
+}
+exports.fitTensors = fitTensors;
+
+},{"../backend/tfjs_backend":220,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/math_utils":264,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -30906,12 +32921,13 @@ var IndexError = (function (_super) {
 }(Error));
 exports.IndexError = IndexError;
 
-},{}],211:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
 var training_1 = require("./engine/training");
 var models_1 = require("./models");
+var base_callbacks_1 = require("./base_callbacks");
 function model(config) {
     return new training_1.Model(config);
 }
@@ -30929,8 +32945,12 @@ function input(config) {
     return input_layer_1.Input(config);
 }
 exports.input = input;
+function registerCallbackConstructor(verbosityLevel, callbackConstructor) {
+    base_callbacks_1.CallbackConstructorRegistry.registerCallbackConstructor(verbosityLevel, callbackConstructor);
+}
+exports.registerCallbackConstructor = registerCallbackConstructor;
 
-},{"./engine/input_layer":207,"./engine/training":209,"./models":234}],212:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/input_layer":228,"./engine/training":230,"./models":258}],235:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints_1 = require("./constraints");
@@ -30951,7 +32971,7 @@ function minMaxNorm(config) {
 }
 exports.minMaxNorm = minMaxNorm;
 
-},{"./constraints":204}],213:[function(require,module,exports){
+},{"./constraints":224}],236:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var initializers_1 = require("./initializers");
@@ -31008,7 +33028,7 @@ function orthogonal(config) {
 }
 exports.orthogonal = orthogonal;
 
-},{"./initializers":218}],214:[function(require,module,exports){
+},{"./initializers":242}],237:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
@@ -31137,6 +33157,10 @@ function multiply(config) {
     return new merge_1.Multiply(config);
 }
 exports.multiply = multiply;
+function dot(config) {
+    return new merge_1.Dot(config);
+}
+exports.dot = dot;
 function batchNormalization(config) {
     return new normalization_1.BatchNormalization(config);
 }
@@ -31238,7 +33262,7 @@ exports.globalMaxPool2d = globalMaxPooling2d;
 exports.maxPool1d = maxPooling1d;
 exports.maxPool2d = maxPooling2d;
 
-},{"./engine/input_layer":207,"./engine/topology":208,"./exports":211,"./layers/advanced_activations":219,"./layers/convolutional":220,"./layers/convolutional_depthwise":221,"./layers/core":222,"./layers/embeddings":223,"./layers/merge":224,"./layers/normalization":225,"./layers/padding":226,"./layers/pooling":227,"./layers/recurrent":228,"./layers/wrappers":230}],215:[function(require,module,exports){
+},{"./engine/input_layer":228,"./engine/topology":229,"./exports":234,"./layers/advanced_activations":243,"./layers/convolutional":244,"./layers/convolutional_depthwise":245,"./layers/core":246,"./layers/embeddings":247,"./layers/merge":248,"./layers/normalization":249,"./layers/padding":250,"./layers/pooling":251,"./layers/recurrent":252,"./layers/wrappers":254}],238:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var losses = require("./losses");
@@ -31259,6 +33283,14 @@ function categoricalCrossentropy(yTrue, yPred) {
     return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 exports.categoricalCrossentropy = categoricalCrossentropy;
+function precision(yTrue, yPred) {
+    return metrics.precision(yTrue, yPred);
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return metrics.recall(yTrue, yPred);
+}
+exports.recall = recall;
 function cosineProximity(yTrue, yPred) {
     return losses.cosineProximity(yTrue, yPred);
 }
@@ -31292,7 +33324,13 @@ function mse(yTrue, yPred) {
 }
 exports.mse = mse;
 
-},{"./losses":232,"./metrics":233}],216:[function(require,module,exports){
+},{"./losses":256,"./metrics":257}],239:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var models_1 = require("./models");
+exports.modelFromJSON = models_1.modelFromJSON;
+
+},{"./models":258}],240:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var regularizers = require("./regularizers");
@@ -31310,7 +33348,7 @@ function l2(config) {
 }
 exports.l2 = l2;
 
-},{"./regularizers":236}],217:[function(require,module,exports){
+},{"./regularizers":260}],241:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints = require("./exports_constraints");
@@ -31319,6 +33357,8 @@ var initializers = require("./exports_initializers");
 exports.initializers = initializers;
 var layers = require("./exports_layers");
 exports.layers = layers;
+var models = require("./exports_models");
+exports.models = models;
 var metrics = require("./exports_metrics");
 exports.metrics = metrics;
 var regularizers = require("./exports_regularizers");
@@ -31330,6 +33370,7 @@ exports.History = base_callbacks_1.History;
 var callbacks_1 = require("./callbacks");
 exports.Callback = callbacks_1.Callback;
 var topology_1 = require("./engine/topology");
+exports.InputSpec = topology_1.InputSpec;
 exports.SymbolicTensor = topology_1.SymbolicTensor;
 var training_1 = require("./engine/training");
 exports.Model = training_1.Model;
@@ -31337,6 +33378,7 @@ var exports_1 = require("./exports");
 exports.input = exports_1.input;
 exports.loadModel = exports_1.loadModel;
 exports.model = exports_1.model;
+exports.registerCallbackConstructor = exports_1.registerCallbackConstructor;
 exports.sequential = exports_1.sequential;
 var recurrent_1 = require("./layers/recurrent");
 exports.RNN = recurrent_1.RNN;
@@ -31347,7 +33389,7 @@ exports.LayerVariable = variables_1.LayerVariable;
 var version_1 = require("./version");
 exports.version_layers = version_1.version;
 
-},{"./base_callbacks":201,"./callbacks":202,"./engine/topology":208,"./engine/training":209,"./exports":211,"./exports_constraints":212,"./exports_initializers":213,"./exports_layers":214,"./exports_metrics":215,"./exports_regularizers":216,"./layers/recurrent":228,"./models":234,"./variables":244,"./version":245}],218:[function(require,module,exports){
+},{"./base_callbacks":221,"./callbacks":222,"./engine/topology":229,"./engine/training":230,"./exports":234,"./exports_constraints":235,"./exports_initializers":236,"./exports_layers":237,"./exports_metrics":238,"./exports_models":239,"./exports_regularizers":240,"./layers/recurrent":252,"./models":258,"./variables":268,"./version":269}],242:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31403,7 +33445,7 @@ var Zeros = (function (_super) {
     return Zeros;
 }(Initializer));
 exports.Zeros = Zeros;
-tfjs_core_1.serialization.SerializationMap.register(Zeros);
+tfjs_core_1.serialization.registerClass(Zeros);
 var Ones = (function (_super) {
     __extends(Ones, _super);
     function Ones() {
@@ -31416,7 +33458,7 @@ var Ones = (function (_super) {
     return Ones;
 }(Initializer));
 exports.Ones = Ones;
-tfjs_core_1.serialization.SerializationMap.register(Ones);
+tfjs_core_1.serialization.registerClass(Ones);
 var Constant = (function (_super) {
     __extends(Constant, _super);
     function Constant(config) {
@@ -31443,7 +33485,7 @@ var Constant = (function (_super) {
     return Constant;
 }(Initializer));
 exports.Constant = Constant;
-tfjs_core_1.serialization.SerializationMap.register(Constant);
+tfjs_core_1.serialization.registerClass(Constant);
 var RandomUniform = (function (_super) {
     __extends(RandomUniform, _super);
     function RandomUniform(config) {
@@ -31465,7 +33507,7 @@ var RandomUniform = (function (_super) {
     return RandomUniform;
 }(Initializer));
 exports.RandomUniform = RandomUniform;
-tfjs_core_1.serialization.SerializationMap.register(RandomUniform);
+tfjs_core_1.serialization.registerClass(RandomUniform);
 var RandomNormal = (function (_super) {
     __extends(RandomNormal, _super);
     function RandomNormal(config) {
@@ -31478,8 +33520,9 @@ var RandomNormal = (function (_super) {
         return _this;
     }
     RandomNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
         }
         return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31490,7 +33533,7 @@ var RandomNormal = (function (_super) {
     return RandomNormal;
 }(Initializer));
 exports.RandomNormal = RandomNormal;
-tfjs_core_1.serialization.SerializationMap.register(RandomNormal);
+tfjs_core_1.serialization.registerClass(RandomNormal);
 var TruncatedNormal = (function (_super) {
     __extends(TruncatedNormal, _super);
     function TruncatedNormal(config) {
@@ -31503,8 +33546,9 @@ var TruncatedNormal = (function (_super) {
         return _this;
     }
     TruncatedNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("truncatedNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("truncatedNormal does not support dType " + dtype + ".");
         }
         return tfjs_core_1.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31515,7 +33559,7 @@ var TruncatedNormal = (function (_super) {
     return TruncatedNormal;
 }(Initializer));
 exports.TruncatedNormal = TruncatedNormal;
-tfjs_core_1.serialization.SerializationMap.register(TruncatedNormal);
+tfjs_core_1.serialization.registerClass(TruncatedNormal);
 var Identity = (function (_super) {
     __extends(Identity, _super);
     function Identity(config) {
@@ -31542,7 +33586,7 @@ var Identity = (function (_super) {
     return Identity;
 }(Initializer));
 exports.Identity = Identity;
-tfjs_core_1.serialization.SerializationMap.register(Identity);
+tfjs_core_1.serialization.registerClass(Identity);
 function computeFans(shape, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var fanIn;
@@ -31602,8 +33646,9 @@ var VarianceScaling = (function (_super) {
         }
         if (this.distribution === 'normal') {
             var stddev = Math.sqrt(scale);
-            if (dtype === 'bool') {
-                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType bool.");
+            dtype = dtype || 'float32';
+            if (dtype !== 'float32' && dtype !== 'int32') {
+                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType " + dtype + ".");
             }
             return tfjs_core_1.truncatedNormal(shape, 0, stddev, dtype, this.seed);
         }
@@ -31624,7 +33669,7 @@ var VarianceScaling = (function (_super) {
     return VarianceScaling;
 }(Initializer));
 exports.VarianceScaling = VarianceScaling;
-tfjs_core_1.serialization.SerializationMap.register(VarianceScaling);
+tfjs_core_1.serialization.registerClass(VarianceScaling);
 var GlorotUniform = (function (_super) {
     __extends(GlorotUniform, _super);
     function GlorotUniform(config) {
@@ -31638,9 +33683,11 @@ var GlorotUniform = (function (_super) {
     GlorotUniform.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotUniform.className = 'GlorotUniform';
     return GlorotUniform;
 }(VarianceScaling));
 exports.GlorotUniform = GlorotUniform;
+tfjs_core_1.serialization.registerClass(GlorotUniform);
 var GlorotNormal = (function (_super) {
     __extends(GlorotNormal, _super);
     function GlorotNormal(config) {
@@ -31654,9 +33701,11 @@ var GlorotNormal = (function (_super) {
     GlorotNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotNormal.className = 'GlorotNormal';
     return GlorotNormal;
 }(VarianceScaling));
 exports.GlorotNormal = GlorotNormal;
+tfjs_core_1.serialization.registerClass(GlorotNormal);
 var HeNormal = (function (_super) {
     __extends(HeNormal, _super);
     function HeNormal(config) {
@@ -31670,9 +33719,11 @@ var HeNormal = (function (_super) {
     HeNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    HeNormal.className = 'HeNormal';
     return HeNormal;
 }(VarianceScaling));
 exports.HeNormal = HeNormal;
+tfjs_core_1.serialization.registerClass(HeNormal);
 var LeCunNormal = (function (_super) {
     __extends(LeCunNormal, _super);
     function LeCunNormal(config) {
@@ -31686,9 +33737,11 @@ var LeCunNormal = (function (_super) {
     LeCunNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    LeCunNormal.className = 'LeCunNormal';
     return LeCunNormal;
 }(VarianceScaling));
 exports.LeCunNormal = LeCunNormal;
+tfjs_core_1.serialization.registerClass(LeCunNormal);
 var Orthogonal = (function (_super) {
     __extends(Orthogonal, _super);
     function Orthogonal(config) {
@@ -31731,7 +33784,7 @@ var Orthogonal = (function (_super) {
     return Orthogonal;
 }(Initializer));
 exports.Orthogonal = Orthogonal;
-tfjs_core_1.serialization.SerializationMap.register(Orthogonal);
+tfjs_core_1.serialization.registerClass(Orthogonal);
 exports.INITIALIZER_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'constant': 'Constant',
     'glorotNormal': 'GlorotNormal',
@@ -31786,7 +33839,7 @@ function getInitializer(identifier) {
 }
 exports.getInitializer = getInitializer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./common":203,"./errors":210,"./utils/generic_utils":238,"./utils/math_utils":240,"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./common":223,"./errors":233,"./utils/generic_utils":262,"./utils/math_utils":264,"@tensorflow/tfjs-core":68}],243:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31837,7 +33890,7 @@ var ReLU = (function (_super) {
     return ReLU;
 }(topology_1.Layer));
 exports.ReLU = ReLU;
-tfjs_core_1.serialization.SerializationMap.register(ReLU);
+tfjs_core_1.serialization.registerClass(ReLU);
 var LeakyReLU = (function (_super) {
     __extends(LeakyReLU, _super);
     function LeakyReLU(config) {
@@ -31866,7 +33919,7 @@ var LeakyReLU = (function (_super) {
     return LeakyReLU;
 }(topology_1.Layer));
 exports.LeakyReLU = LeakyReLU;
-tfjs_core_1.serialization.SerializationMap.register(LeakyReLU);
+tfjs_core_1.serialization.registerClass(LeakyReLU);
 var ELU = (function (_super) {
     __extends(ELU, _super);
     function ELU(config) {
@@ -31899,7 +33952,7 @@ var ELU = (function (_super) {
     return ELU;
 }(topology_1.Layer));
 exports.ELU = ELU;
-tfjs_core_1.serialization.SerializationMap.register(ELU);
+tfjs_core_1.serialization.registerClass(ELU);
 var ThresholdedReLU = (function (_super) {
     __extends(ThresholdedReLU, _super);
     function ThresholdedReLU(config) {
@@ -31929,7 +33982,7 @@ var ThresholdedReLU = (function (_super) {
     return ThresholdedReLU;
 }(topology_1.Layer));
 exports.ThresholdedReLU = ThresholdedReLU;
-tfjs_core_1.serialization.SerializationMap.register(ThresholdedReLU);
+tfjs_core_1.serialization.registerClass(ThresholdedReLU);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax(config) {
@@ -31959,9 +34012,9 @@ var Softmax = (function (_super) {
     return Softmax;
 }(topology_1.Layer));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],244:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32276,7 +34329,7 @@ var Conv2D = (function (_super) {
     return Conv2D;
 }(Conv));
 exports.Conv2D = Conv2D;
-tfjs_core_1.serialization.SerializationMap.register(Conv2D);
+tfjs_core_1.serialization.registerClass(Conv2D);
 var Conv2DTranspose = (function (_super) {
     __extends(Conv2DTranspose, _super);
     function Conv2DTranspose(config) {
@@ -32392,7 +34445,7 @@ var Conv2DTranspose = (function (_super) {
     return Conv2DTranspose;
 }(Conv2D));
 exports.Conv2DTranspose = Conv2DTranspose;
-tfjs_core_1.serialization.SerializationMap.register(Conv2DTranspose);
+tfjs_core_1.serialization.registerClass(Conv2DTranspose);
 var SeparableConv = (function (_super) {
     __extends(SeparableConv, _super);
     function SeparableConv(rank, config) {
@@ -32519,7 +34572,7 @@ var SeparableConv2D = (function (_super) {
     return SeparableConv2D;
 }(SeparableConv));
 exports.SeparableConv2D = SeparableConv2D;
-tfjs_core_1.serialization.SerializationMap.register(SeparableConv2D);
+tfjs_core_1.serialization.registerClass(SeparableConv2D);
 var Conv1D = (function (_super) {
     __extends(Conv1D, _super);
     function Conv1D(config) {
@@ -32544,7 +34597,7 @@ var Conv1D = (function (_super) {
     return Conv1D;
 }(Conv));
 exports.Conv1D = Conv1D;
-tfjs_core_1.serialization.SerializationMap.register(Conv1D);
+tfjs_core_1.serialization.registerClass(Conv1D);
 var Cropping2D = (function (_super) {
     __extends(Cropping2D, _super);
     function Cropping2D(config) {
@@ -32568,15 +34621,17 @@ var Cropping2D = (function (_super) {
     Cropping2D.prototype.computeOutputShape = function (inputShape) {
         if (this.dataFormat === 'channelsFirst')
             return [
-                inputShape[0], inputShape[1],
+                inputShape[0],
+                inputShape[1],
                 inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+                inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
             ];
         else
             return [
                 inputShape[0],
                 inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+                inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+                inputShape[3]
             ];
     };
     Cropping2D.prototype.call = function (inputs, kwargs) {
@@ -32603,7 +34658,7 @@ var Cropping2D = (function (_super) {
     return Cropping2D;
 }(topology_1.Layer));
 exports.Cropping2D = Cropping2D;
-tfjs_core_1.serialization.SerializationMap.register(Cropping2D);
+tfjs_core_1.serialization.registerClass(Cropping2D);
 var UpSampling2D = (function (_super) {
     __extends(UpSampling2D, _super);
     function UpSampling2D(config) {
@@ -32656,9 +34711,9 @@ var UpSampling2D = (function (_super) {
     return UpSampling2D;
 }(topology_1.Layer));
 exports.UpSampling2D = UpSampling2D;
-tfjs_core_1.serialization.SerializationMap.register(UpSampling2D);
+tfjs_core_1.serialization.registerClass(UpSampling2D);
 
-},{"../activations":197,"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
+},{"../activations":217,"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32789,9 +34844,9 @@ var DepthwiseConv2D = (function (_super) {
     return DepthwiseConv2D;
 }(convolutional_1.BaseConv));
 exports.DepthwiseConv2D = DepthwiseConv2D;
-tfjs_core_1.serialization.SerializationMap.register(DepthwiseConv2D);
+tfjs_core_1.serialization.registerClass(DepthwiseConv2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],246:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32874,7 +34929,7 @@ var Dropout = (function (_super) {
     return Dropout;
 }(topology_1.Layer));
 exports.Dropout = Dropout;
-tfjs_core_1.serialization.SerializationMap.register(Dropout);
+tfjs_core_1.serialization.registerClass(Dropout);
 var Dense = (function (_super) {
     __extends(Dense, _super);
     function Dense(config) {
@@ -32964,7 +35019,7 @@ var Dense = (function (_super) {
     return Dense;
 }(topology_1.Layer));
 exports.Dense = Dense;
-tfjs_core_1.serialization.SerializationMap.register(Dense);
+tfjs_core_1.serialization.registerClass(Dense);
 var Flatten = (function (_super) {
     __extends(Flatten, _super);
     function Flatten(config) {
@@ -32996,7 +35051,7 @@ var Flatten = (function (_super) {
     return Flatten;
 }(topology_1.Layer));
 exports.Flatten = Flatten;
-tfjs_core_1.serialization.SerializationMap.register(Flatten);
+tfjs_core_1.serialization.registerClass(Flatten);
 var Activation = (function (_super) {
     __extends(Activation, _super);
     function Activation(config) {
@@ -33023,7 +35078,7 @@ var Activation = (function (_super) {
     return Activation;
 }(topology_1.Layer));
 exports.Activation = Activation;
-tfjs_core_1.serialization.SerializationMap.register(Activation);
+tfjs_core_1.serialization.registerClass(Activation);
 var RepeatVector = (function (_super) {
     __extends(RepeatVector, _super);
     function RepeatVector(config) {
@@ -33054,7 +35109,7 @@ var RepeatVector = (function (_super) {
     return RepeatVector;
 }(topology_1.Layer));
 exports.RepeatVector = RepeatVector;
-tfjs_core_1.serialization.SerializationMap.register(RepeatVector);
+tfjs_core_1.serialization.registerClass(RepeatVector);
 var Reshape = (function (_super) {
     __extends(Reshape, _super);
     function Reshape(config) {
@@ -33138,7 +35193,7 @@ var Reshape = (function (_super) {
     return Reshape;
 }(topology_1.Layer));
 exports.Reshape = Reshape;
-tfjs_core_1.serialization.SerializationMap.register(Reshape);
+tfjs_core_1.serialization.registerClass(Reshape);
 var Permute = (function (_super) {
     __extends(Permute, _super);
     function Permute(config) {
@@ -33184,9 +35239,9 @@ var Permute = (function (_super) {
     return Permute;
 }(topology_1.Layer));
 exports.Permute = Permute;
-tfjs_core_1.serialization.SerializationMap.register(Permute);
+tfjs_core_1.serialization.registerClass(Permute);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],223:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],247:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33303,9 +35358,9 @@ var Embedding = (function (_super) {
     return Embedding;
 }(topology_1.Layer));
 exports.Embedding = Embedding;
-tfjs_core_1.serialization.SerializationMap.register(Embedding);
+tfjs_core_1.serialization.registerClass(Embedding);
 
-},{"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],224:[function(require,module,exports){
+},{"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],248:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33324,6 +35379,7 @@ var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
 var topology_1 = require("../engine/topology");
 var errors_1 = require("../errors");
+var losses_1 = require("../losses");
 var generic_utils = require("../utils/generic_utils");
 var mathUtils = require("../utils/math_utils");
 var types_utils_1 = require("../utils/types_utils");
@@ -33501,6 +35557,9 @@ var Merge = (function (_super) {
         }
         return outputShape;
     };
+    Merge.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Merge yet');
+    };
     return Merge;
 }(topology_1.Layer));
 exports.Merge = Merge;
@@ -33522,7 +35581,7 @@ var Add = (function (_super) {
     return Add;
 }(Merge));
 exports.Add = Add;
-tfjs_core_1.serialization.SerializationMap.register(Add);
+tfjs_core_1.serialization.registerClass(Add);
 function add(config) {
     if (Array.isArray(config)) {
         var layer = new Add({});
@@ -33551,7 +35610,7 @@ var Multiply = (function (_super) {
     return Multiply;
 }(Merge));
 exports.Multiply = Multiply;
-tfjs_core_1.serialization.SerializationMap.register(Multiply);
+tfjs_core_1.serialization.registerClass(Multiply);
 function multiply(config) {
     if (Array.isArray(config)) {
         var layer = new Multiply({});
@@ -33580,7 +35639,7 @@ var Average = (function (_super) {
     return Average;
 }(Merge));
 exports.Average = Average;
-tfjs_core_1.serialization.SerializationMap.register(Average);
+tfjs_core_1.serialization.registerClass(Average);
 function average(config) {
     if (Array.isArray(config)) {
         var layer = new Average({});
@@ -33609,7 +35668,7 @@ var Maximum = (function (_super) {
     return Maximum;
 }(Merge));
 exports.Maximum = Maximum;
-tfjs_core_1.serialization.SerializationMap.register(Maximum);
+tfjs_core_1.serialization.registerClass(Maximum);
 function maximum(config) {
     if (Array.isArray(config)) {
         var layer = new Maximum({});
@@ -33638,7 +35697,7 @@ var Minimum = (function (_super) {
     return Minimum;
 }(Merge));
 exports.Minimum = Minimum;
-tfjs_core_1.serialization.SerializationMap.register(Minimum);
+tfjs_core_1.serialization.registerClass(Minimum);
 function minimum(config) {
     if (Array.isArray(config)) {
         var layer = new Minimum({});
@@ -33725,6 +35784,9 @@ var Concatenate = (function (_super) {
         }
         return outputShape;
     };
+    Concatenate.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Concatenate yet');
+    };
     Concatenate.prototype.getConfig = function () {
         var config = {
             'axis': this.axis,
@@ -33737,7 +35799,7 @@ var Concatenate = (function (_super) {
     return Concatenate;
 }(Merge));
 exports.Concatenate = Concatenate;
-tfjs_core_1.serialization.SerializationMap.register(Concatenate);
+tfjs_core_1.serialization.registerClass(Concatenate);
 function concatenate(config) {
     if (Array.isArray(config)) {
         var layer = new Concatenate({});
@@ -33748,8 +35810,184 @@ function concatenate(config) {
     }
 }
 exports.concatenate = concatenate;
+function interpretAxis(axis, dim) {
+    while (axis < 0) {
+        axis += dim;
+    }
+    return axis;
+}
+function batchDot(x, y, axes) {
+    if (x.shape.length > 3 || y.shape.length > 3) {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for tensors of 4D or higher rank yet');
+    }
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of x to be >= 2, " +
+        ("but got " + x.shape.length));
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of y to be >= 2, " +
+        ("but got " + y.shape.length));
+    if (typeof axes === 'number') {
+        axes = [axes, axes];
+    }
+    if (x.dtype === 'complex64' || y.dtype === 'complex64') {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for complex64-type Tensors yet.');
+    }
+    var xNDim = x.shape.length;
+    var yNDim = y.shape.length;
+    if (axes == null) {
+        axes = [xNDim - 1, yNDim - 2];
+    }
+    var axesArray = axes;
+    return tfc.tidy(function () {
+        var diff;
+        if (xNDim > yNDim) {
+            diff = xNDim - yNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            y = y.reshape(y.shape.concat(diffShape));
+        }
+        else if (yNDim > xNDim) {
+            diff = yNDim - xNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            x = x.reshape(x.shape.concat(diffShape));
+        }
+        else {
+            diff = 0;
+        }
+        var out;
+        if (x.shape.length === 2 && y.shape.length === 2) {
+            if (axesArray[0] === axesArray[1]) {
+                out = x.mulStrict(y).sum(axesArray[0]);
+            }
+            else {
+                out = x.transpose([1, 0]).mulStrict(y).sum(axesArray[1]);
+            }
+        }
+        else {
+            var adjX = axesArray[0] === x.shape.length - 1 ? null : true;
+            var adjY = axesArray[1] === y.shape.length - 1 ? true : null;
+            out = x.matMul(y, adjX, adjY);
+        }
+        if (diff > 0) {
+            var idx = void 0;
+            if (xNDim > yNDim) {
+                idx = xNDim + yNDim - 3;
+            }
+            else {
+                idx = xNDim - 1;
+            }
+            var squeezeAxes = [];
+            for (var i = idx; i < idx + diff; ++i) {
+                squeezeAxes.push(i);
+            }
+            out = out.squeeze(squeezeAxes);
+        }
+        if (out.shape.length === 1) {
+            out = out.expandDims(1);
+        }
+        return out;
+    });
+}
+var Dot = (function (_super) {
+    __extends(Dot, _super);
+    function Dot(config) {
+        var _this = _super.call(this, config) || this;
+        _this.axes = config.axes;
+        _this.normalize = config.normalize == null ? false : config.normalize;
+        _this.supportsMasking = true;
+        _this.reshapeRequired = false;
+        return _this;
+    }
+    Dot.prototype.build = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0];
+        var shape2 = inputShape[1];
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        if (shape1[axes[0]] !== shape2[axes[1]]) {
+            throw new errors_1.ValueError("Dimension incompatibility: " +
+                (shape1[axes[0]] + " !== " + shape2[axes[1]]));
+        }
+    };
+    Dot.prototype.mergeFunction = function (inputs) {
+        if (inputs.length !== 2) {
+            throw new errors_1.ValueError('A `Dot` layer must be called on exactly 2 inputs, ' +
+                ("but received " + inputs.length + " input(s)."));
+        }
+        var x1 = inputs[0];
+        var x2 = inputs[1];
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, x1.shape.length),
+                interpretAxis(this.axes, x2.shape.length)
+            ];
+        }
+        else {
+            axes = this.axes.map(function (axis, i) { return interpretAxis(axis, inputs[i].shape.length); });
+        }
+        if (this.normalize) {
+            x1 = losses_1.l2Normalize(x1, axes[0]);
+            x2 = losses_1.l2Normalize(x2, axes[1]);
+        }
+        return batchDot(x1, x2, axes);
+    };
+    Dot.prototype.interpretAxes = function (shape1, shape2) {
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, shape1.length),
+                interpretAxis(this.axes, shape2.length)
+            ];
+        }
+        else {
+            axes = this.axes;
+        }
+        return axes;
+    };
+    Dot.prototype.computeOutputShape = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0].slice();
+        var shape2 = inputShape[1].slice();
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        shape1.splice(axes[0], 1);
+        shape2.splice(axes[1], 1);
+        shape2.splice(0, 1);
+        var outputShape = shape1.concat(shape2);
+        if (outputShape.length === 1) {
+            outputShape.push(1);
+        }
+        return outputShape;
+    };
+    Dot.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Dot yet');
+    };
+    Dot.prototype.getConfig = function () {
+        var config = {
+            'axes': this.axes,
+            'normalize': this.normalize
+        };
+        var baseConfig = _super.prototype.getConfig.call(this);
+        Object.assign(config, baseConfig);
+        return config;
+    };
+    Dot.className = 'Dot';
+    return Dot;
+}(Merge));
+exports.Dot = Dot;
+tfjs_core_1.serialization.registerClass(Dot);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../losses":256,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],249:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33786,7 +36024,7 @@ function batchNormalization(x, mean, variance, beta, gamma, epsilon) {
         out = tfc.batchNormalization4d(x, mean, variance, epsilon, gamma, beta);
     }
     else {
-        throw new errors_1.NotImplementedError("batchNormalization is not implememnted for array of rank " + x.rank + " " +
+        throw new errors_1.NotImplementedError("batchNormalization is not implemented for array of rank " + x.rank + " " +
             "yet");
     }
     return out;
@@ -33839,7 +36077,11 @@ exports.normalizeBatchInTraining = normalizeBatchInTraining;
 var BatchNormalization = (function (_super) {
     __extends(BatchNormalization, _super);
     function BatchNormalization(config) {
-        var _this = _super.call(this, config) || this;
+        var _this = this;
+        if (config == null) {
+            config = {};
+        }
+        _this = _super.call(this, config) || this;
         _this.supportsMasking = true;
         _this.axis = config.axis == null ? -1 : config.axis;
         _this.momentum = config.momentum == null ? 0.99 : config.momentum;
@@ -33950,9 +36192,9 @@ var BatchNormalization = (function (_super) {
     return BatchNormalization;
 }(topology_1.Layer));
 exports.BatchNormalization = BatchNormalization;
-tfjs_core_1.serialization.SerializationMap.register(BatchNormalization);
+tfjs_core_1.serialization.registerClass(BatchNormalization);
 
-},{"../backend/state":199,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+},{"../backend/state":219,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],250:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34122,9 +36364,9 @@ var ZeroPadding2D = (function (_super) {
     return ZeroPadding2D;
 }(topology_1.Layer));
 exports.ZeroPadding2D = ZeroPadding2D;
-tfjs_core_1.serialization.SerializationMap.register(ZeroPadding2D);
+tfjs_core_1.serialization.registerClass(ZeroPadding2D);
 
-},{"../backend/common":198,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],227:[function(require,module,exports){
+},{"../backend/common":218,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],251:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34266,7 +36508,7 @@ var MaxPooling1D = (function (_super) {
     return MaxPooling1D;
 }(Pooling1D));
 exports.MaxPooling1D = MaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling1D);
+tfjs_core_1.serialization.registerClass(MaxPooling1D);
 var AveragePooling1D = (function (_super) {
     __extends(AveragePooling1D, _super);
     function AveragePooling1D(config) {
@@ -34281,7 +36523,7 @@ var AveragePooling1D = (function (_super) {
     return AveragePooling1D;
 }(Pooling1D));
 exports.AveragePooling1D = AveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling1D);
+tfjs_core_1.serialization.registerClass(AveragePooling1D);
 var Pooling2D = (function (_super) {
     __extends(Pooling2D, _super);
     function Pooling2D(config) {
@@ -34365,7 +36607,7 @@ var MaxPooling2D = (function (_super) {
     return MaxPooling2D;
 }(Pooling2D));
 exports.MaxPooling2D = MaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling2D);
+tfjs_core_1.serialization.registerClass(MaxPooling2D);
 var AveragePooling2D = (function (_super) {
     __extends(AveragePooling2D, _super);
     function AveragePooling2D(config) {
@@ -34380,7 +36622,7 @@ var AveragePooling2D = (function (_super) {
     return AveragePooling2D;
 }(Pooling2D));
 exports.AveragePooling2D = AveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling2D);
+tfjs_core_1.serialization.registerClass(AveragePooling2D);
 var GlobalPooling1D = (function (_super) {
     __extends(GlobalPooling1D, _super);
     function GlobalPooling1D(config) {
@@ -34412,7 +36654,7 @@ var GlobalAveragePooling1D = (function (_super) {
     return GlobalAveragePooling1D;
 }(GlobalPooling1D));
 exports.GlobalAveragePooling1D = GlobalAveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling1D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling1D);
 var GlobalMaxPooling1D = (function (_super) {
     __extends(GlobalMaxPooling1D, _super);
     function GlobalMaxPooling1D(config) {
@@ -34428,7 +36670,7 @@ var GlobalMaxPooling1D = (function (_super) {
     return GlobalMaxPooling1D;
 }(GlobalPooling1D));
 exports.GlobalMaxPooling1D = GlobalMaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling1D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling1D);
 var GlobalPooling2D = (function (_super) {
     __extends(GlobalPooling2D, _super);
     function GlobalPooling2D(config) {
@@ -34481,7 +36723,7 @@ var GlobalAveragePooling2D = (function (_super) {
     return GlobalAveragePooling2D;
 }(GlobalPooling2D));
 exports.GlobalAveragePooling2D = GlobalAveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling2D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling2D);
 var GlobalMaxPooling2D = (function (_super) {
     __extends(GlobalMaxPooling2D, _super);
     function GlobalMaxPooling2D() {
@@ -34503,9 +36745,9 @@ var GlobalMaxPooling2D = (function (_super) {
     return GlobalMaxPooling2D;
 }(GlobalPooling2D));
 exports.GlobalMaxPooling2D = GlobalMaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling2D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],252:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34561,9 +36803,10 @@ function standardizeArgs(inputs, initialState, constants, numConstants) {
     return { inputs: inputs, initialState: initialState, constants: constants };
 }
 exports.standardizeArgs = standardizeArgs;
-function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, inputLength) {
+function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, needPerStepOutputs) {
     if (goBackwards === void 0) { goBackwards = false; }
     if (unroll === void 0) { unroll = false; }
+    if (needPerStepOutputs === void 0) { needPerStepOutputs = false; }
     var ndim = inputs.shape.length;
     if (ndim < 3) {
         throw new errors_1.ValueError("Input should be at least 3D, but is " + ndim + "D.");
@@ -34589,24 +36832,27 @@ function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, 
     var lastOutput;
     var states = initialStates;
     var timeSteps = inputs.shape[0];
-    for (var t = 0; t < timeSteps; ++t) {
+    var _loop_1 = function (t) {
         var currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
         currentInput = currentInput.reshape(currentInput.shape.slice(1));
-        var stepOutputs = stepFunction(currentInput, states);
+        var stepOutputs = tfc.tidy(function () { return stepFunction(currentInput, states); });
         lastOutput = stepOutputs[0];
-        if (t === 0) {
-            outputs = lastOutput.reshape([1].concat(lastOutput.shape));
-        }
-        else {
-            outputs = K.concatAlongFirstAxis(outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        if (needPerStepOutputs) {
+            if (t === 0) {
+                outputs = lastOutput.expandDims(1);
+            }
+            else {
+                var newOutputs = tfc.concat([outputs, lastOutput.expandDims(1)], 1);
+                outputs.dispose();
+                outputs = newOutputs;
+            }
         }
         states = stepOutputs[1];
+    };
+    for (var t = 0; t < timeSteps; ++t) {
+        _loop_1(t);
     }
-    return [
-        lastOutput,
-        tfc.transpose(outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
-        states
-    ];
+    return [lastOutput, outputs, states];
 }
 exports.rnn = rnn;
 var RNN = (function (_super) {
@@ -34855,8 +37101,6 @@ var RNN = (function (_super) {
                 throw new errors_1.ValueError("RNN Layer has " + numStates + " state(s) but was passed " +
                     (initialState.length + " initial state(s)."));
             }
-            var inputShape = inputs.shape;
-            var timesteps = inputShape[1];
             if (_this.unroll) {
                 console.warn('Ignoring unroll = true for RNN layer, due to imperative backend.');
             }
@@ -34865,7 +37109,7 @@ var RNN = (function (_super) {
                 var outputs = _this.cell.call([inputs].concat(states), cellCallKwargs);
                 return [outputs[0], outputs.slice(1)];
             };
-            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, timesteps);
+            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, _this.returnSequences);
             var lastOutput = rnnOutputs[0];
             var outputs = rnnOutputs[1];
             var states = rnnOutputs[2];
@@ -34941,7 +37185,7 @@ var RNN = (function (_super) {
     return RNN;
 }(topology_2.Layer));
 exports.RNN = RNN;
-tfjs_core_1.serialization.SerializationMap.register(RNN);
+tfjs_core_1.serialization.registerClass(RNN);
 var RNNCell = (function (_super) {
     __extends(RNNCell, _super);
     function RNNCell() {
@@ -35060,7 +37304,7 @@ var SimpleRNNCell = (function (_super) {
     return SimpleRNNCell;
 }(RNNCell));
 exports.SimpleRNNCell = SimpleRNNCell;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNNCell);
+tfjs_core_1.serialization.registerClass(SimpleRNNCell);
 var SimpleRNN = (function (_super) {
     __extends(SimpleRNN, _super);
     function SimpleRNN(config) {
@@ -35211,7 +37455,7 @@ var SimpleRNN = (function (_super) {
     return SimpleRNN;
 }(RNN));
 exports.SimpleRNN = SimpleRNN;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNN);
+tfjs_core_1.serialization.registerClass(SimpleRNN);
 var GRUCell = (function (_super) {
     __extends(GRUCell, _super);
     function GRUCell(config) {
@@ -35386,7 +37630,7 @@ var GRUCell = (function (_super) {
     return GRUCell;
 }(RNNCell));
 exports.GRUCell = GRUCell;
-tfjs_core_1.serialization.SerializationMap.register(GRUCell);
+tfjs_core_1.serialization.registerClass(GRUCell);
 var GRU = (function (_super) {
     __extends(GRU, _super);
     function GRU(config) {
@@ -35563,7 +37807,7 @@ var GRU = (function (_super) {
     return GRU;
 }(RNN));
 exports.GRU = GRU;
-tfjs_core_1.serialization.SerializationMap.register(GRU);
+tfjs_core_1.serialization.registerClass(GRU);
 var LSTMCell = (function (_super) {
     __extends(LSTMCell, _super);
     function LSTMCell(config) {
@@ -35773,7 +38017,7 @@ var LSTMCell = (function (_super) {
     return LSTMCell;
 }(RNNCell));
 exports.LSTMCell = LSTMCell;
-tfjs_core_1.serialization.SerializationMap.register(LSTMCell);
+tfjs_core_1.serialization.registerClass(LSTMCell);
 var LSTM = (function (_super) {
     __extends(LSTM, _super);
     function LSTM(config) {
@@ -35958,7 +38202,7 @@ var LSTM = (function (_super) {
     return LSTM;
 }(RNN));
 exports.LSTM = LSTM;
-tfjs_core_1.serialization.SerializationMap.register(LSTM);
+tfjs_core_1.serialization.registerClass(LSTM);
 var StackedRNNCells = (function (_super) {
     __extends(StackedRNNCells, _super);
     function StackedRNNCells(config) {
@@ -36122,7 +38366,7 @@ var StackedRNNCells = (function (_super) {
     return StackedRNNCells;
 }(RNNCell));
 exports.StackedRNNCells = StackedRNNCells;
-tfjs_core_1.serialization.SerializationMap.register(StackedRNNCells);
+tfjs_core_1.serialization.registerClass(StackedRNNCells);
 function generateDropoutMask(ones, rate, training, count) {
     if (training === void 0) { training = null; }
     if (count === void 0) { count = 1; }
@@ -36142,7 +38386,7 @@ function generateDropoutMask(ones, rate, training, count) {
     }
 }
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"../variables":244,"./serialization":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"../variables":268,"./serialization":253,"@tensorflow/tfjs-core":68}],253:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -36153,7 +38397,7 @@ function deserialize(config, customObjects) {
 }
 exports.deserialize = deserialize;
 
-},{"../utils/generic_utils":238,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
+},{"../utils/generic_utils":262,"@tensorflow/tfjs-core":68}],254:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36294,10 +38538,10 @@ var TimeDistributed = (function (_super) {
         return tfjs_core_1.tidy(function () {
             inputs = types_utils_1.getExactlyOneTensor(inputs);
             var step = function (inputs, states) {
-                var output = _this.layer.call(inputs, kwargs);
+                var output = types_utils_1.getExactlyOneTensor(_this.layer.call(inputs, kwargs));
                 return [output, []];
             };
-            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, true);
             var y = rnnOutputs[1];
             return y;
         });
@@ -36306,7 +38550,7 @@ var TimeDistributed = (function (_super) {
     return TimeDistributed;
 }(Wrapper));
 exports.TimeDistributed = TimeDistributed;
-tfjs_core_1.serialization.SerializationMap.register(TimeDistributed);
+tfjs_core_1.serialization.registerClass(TimeDistributed);
 exports.VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
 function checkBidirectionalMergeMode(value) {
     generic_utils.checkStringTypeUnionValue(exports.VALID_BIDIRECTIONAL_MERGE_MODES, 'BidirectionalMergeMode', value);
@@ -36477,7 +38721,7 @@ var Bidirectional = (function (_super) {
                 var forwardState = initialState.slice(0, initialState.length / 2);
                 var backwardState = initialState.slice(initialState.length / 2);
                 y = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: forwardState }));
-                yRev = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
+                yRev = _this.backwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
             }
             var states;
             if (_this.returnState) {
@@ -36568,9 +38812,9 @@ var Bidirectional = (function (_super) {
     return Bidirectional;
 }(Wrapper));
 exports.Bidirectional = Bidirectional;
-tfjs_core_1.serialization.SerializationMap.register(Bidirectional);
+tfjs_core_1.serialization.registerClass(Bidirectional);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"./recurrent":228,"./serialization":229,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"./recurrent":252,"./serialization":253,"@tensorflow/tfjs-core":68}],255:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36656,14 +38900,14 @@ function disposeTensorsInLogs(logs) {
 }
 exports.disposeTensorsInLogs = disposeTensorsInLogs;
 
-},{"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],256:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var common_1 = require("./backend/common");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 function l2Normalize(x, axis) {
     return tfjs_core_1.tidy(function () {
@@ -36840,7 +39084,13 @@ function get(identifierOrFn) {
         if (identifierOrFn in lossesMap) {
             return lossesMap[identifierOrFn];
         }
-        throw new errors_1.ValueError("Unknown loss " + identifierOrFn);
+        var errMsg = "Unknown loss " + identifierOrFn;
+        if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+            errMsg = "Unknown loss " + identifierOrFn + ". " +
+                'Use "categoricalCrossentropy" as the string name for ' +
+                'tf.losses.softmaxCrossEntropy';
+        }
+        throw new errors_1.ValueError(errMsg);
     }
     else {
         return identifierOrFn;
@@ -36848,13 +39098,13 @@ function get(identifierOrFn) {
 }
 exports.get = get;
 
-},{"./backend/common":198,"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"@tensorflow/tfjs-core":68}],257:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 var losses_1 = require("./losses");
 var losses_2 = require("./losses");
@@ -36870,6 +39120,54 @@ function categoricalAccuracy(yTrue, yPred) {
     return tfjs_core_1.tidy(function () { return K.cast(tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'); });
 }
 exports.categoricalAccuracy = categoricalAccuracy;
+function truePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function falseNegatives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(zero))
+            .sum()
+            .cast('float32');
+    });
+}
+function falsePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function precision(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fp = falsePositives(yTrue, yPred);
+        var denominator = tp.add(fp);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fn = falseNegatives(yTrue, yPred);
+        var denominator = tp.add(fn);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.recall = recall;
 function binaryCrossentropy(yTrue, yPred) {
     return losses_2.binaryCrossentropy(yTrue, yPred);
 }
@@ -36899,6 +39197,7 @@ function get(identifier) {
     var metricsMap = {
         binaryAccuracy: binaryAccuracy,
         categoricalAccuracy: categoricalAccuracy,
+        precision: precision,
         categoricalCrossentropy: exports.categoricalCrossentropy,
         sparseCategoricalCrossentropy: exports.sparseCategoricalCrossentropy,
         mse: exports.mse,
@@ -36921,7 +39220,7 @@ function get(identifier) {
 }
 exports.get = get;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"./losses":232,"@tensorflow/tfjs-core":68}],234:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"./losses":256,"@tensorflow/tfjs-core":68}],258:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36985,6 +39284,10 @@ function modelFromJSON(modelAndWeightsConfig, customObjects) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
+                    if (!('modelTopology' in modelAndWeightsConfig)) {
+                        modelAndWeightsConfig = { modelTopology: modelAndWeightsConfig };
+                    }
+                    modelAndWeightsConfig = modelAndWeightsConfig;
                     modelTopology = modelAndWeightsConfig.modelTopology;
                     if (modelTopology['model_config'] != null) {
                         modelTopology = modelTopology['model_config'];
@@ -37083,6 +39386,14 @@ var Sequential = (function (_super) {
         }
         return _this;
     }
+    Sequential.prototype.checkShape = function (layer) {
+        var shape = layer.inboundNodes[0].outputTensors[0].shape;
+        if (shape.some(function (x) { return x < 0; })) {
+            throw new errors_1.ValueError('Negative dimension size caused by adding layer ' +
+                (layer.name + " with input shape [") +
+                (layer.inboundNodes[0].inputTensors[0].shape + "]"));
+        }
+    };
     Sequential.prototype.add = function (layer) {
         var isLayerModelInstance = layer instanceof Sequential || layer instanceof training_1.Model;
         var modelLayer;
@@ -37131,6 +39442,7 @@ var Sequential = (function (_super) {
                         'For multi-output layers, ' +
                         'use the functional API.');
                 }
+                this.checkShape(layer);
                 this.outputs = [layer.inboundNodes[0].outputTensors[0]];
                 this.inputs = topology_1.getSourceInputs(this.outputs[0]);
             }
@@ -37156,6 +39468,7 @@ var Sequential = (function (_super) {
                     'For multi-output layers, ' +
                     'use the functional API.');
             }
+            this.checkShape(layer);
             this.outputs = [outputTensor];
             this.inboundNodes[0].outputTensors = this.outputs;
             this.inboundNodes[0].outputShapes = [this.outputs[0].shape];
@@ -37252,6 +39565,16 @@ var Sequential = (function (_super) {
         }
         return this.model.evaluate(x, y, config);
     };
+    Sequential.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before being used.');
+                }
+                return [2, this.model.evaluateDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.prototype.predict = function (x, config) {
         if (config === void 0) { config = {}; }
         if (this.model == null) {
@@ -37286,19 +39609,40 @@ var Sequential = (function (_super) {
             });
         });
     };
+    Sequential.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before ' +
+                        'being used.');
+                }
+                return [2, this.model.fitDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.fromConfig = function (cls, config) {
-        var model = new cls({});
+        var configArray;
+        var extraModelConfig = {};
+        if (config instanceof Array) {
+            if (!(config[0].className != null) ||
+                config[0]['className'] === 'Merge') {
+                throw new errors_1.ValueError('Legacy serialization format not supported yet.');
+            }
+            configArray = config;
+        }
+        else {
+            tfjs_core_1.util.assert(config['layers'] != null, "When the config data for a Sequential model is not an Array, " +
+                "it must be an Object that contains the 'layers' field.");
+            configArray = config['layers'];
+            delete config['layers'];
+            extraModelConfig = config;
+        }
+        var model = new cls(extraModelConfig);
         if (!(model instanceof Sequential)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called on non-Sequential input: " + model);
+            throw new errors_1.NotImplementedError("Sequential.fromConfig called on non-Sequential input: " + model);
         }
-        if (!(config instanceof Array)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called without an array of configs");
-        }
-        if (!(config[0].className != null) || config[0]['className'] === 'Merge') {
-            throw new errors_1.ValueError('Legacy serialization format not supported yet.');
-        }
-        for (var _i = 0, _a = config; _i < _a.length; _i++) {
-            var conf = _a[_i];
+        for (var _i = 0, configArray_1 = configArray; _i < configArray_1.length; _i++) {
+            var conf = configArray_1[_i];
             var layer = serialization_1.deserialize(conf);
             model.add(layer);
         }
@@ -37326,9 +39670,9 @@ var Sequential = (function (_super) {
     return Sequential;
 }(training_1.Model));
 exports.Sequential = Sequential;
-tfjs_core_1.serialization.SerializationMap.register(Sequential);
+tfjs_core_1.serialization.registerClass(Sequential);
 
-},{"./backend/state":199,"./engine/input_layer":207,"./engine/topology":208,"./engine/training":209,"./errors":210,"./layers/serialization":229,"./utils/generic_utils":238,"./utils/serialization_utils":241,"./utils/types_utils":242,"@tensorflow/tfjs-core":68}],235:[function(require,module,exports){
+},{"./backend/state":219,"./engine/input_layer":228,"./engine/topology":229,"./engine/training":230,"./errors":233,"./layers/serialization":253,"./utils/generic_utils":262,"./utils/serialization_utils":265,"./utils/types_utils":266,"@tensorflow/tfjs-core":68}],259:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -37356,7 +39700,7 @@ function getOptimizer(identifier) {
 }
 exports.getOptimizer = getOptimizer;
 
-},{"./backend/common":198,"./errors":210,"@tensorflow/tfjs-core":68}],236:[function(require,module,exports){
+},{"./backend/common":218,"./errors":233,"@tensorflow/tfjs-core":68}],260:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37418,7 +39762,7 @@ var L1L2 = (function (_super) {
     return L1L2;
 }(Regularizer));
 exports.L1L2 = L1L2;
-tfjs_core_1.serialization.SerializationMap.register(L1L2);
+tfjs_core_1.serialization.registerClass(L1L2);
 function l1(config) {
     return new L1L2({ l1: config != null ? config.l1 : null, l2: 0 });
 }
@@ -37459,7 +39803,7 @@ function getRegularizer(identifier) {
 }
 exports.getRegularizer = getRegularizer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],237:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],261:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37519,7 +39863,7 @@ function deconvLength(dimSize, strideSize, kernelSize, padding) {
 }
 exports.deconvLength = deconvLength;
 
-},{"../errors":210,"./generic_utils":238,"./math_utils":240}],238:[function(require,module,exports){
+},{"../errors":233,"./generic_utils":262,"./math_utils":264}],262:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -37788,7 +40132,7 @@ function checkArrayTypeAndLength(x, expectedType, minLength, maxLength) {
 }
 exports.checkArrayTypeAndLength = checkArrayTypeAndLength;
 
-},{"../errors":210}],239:[function(require,module,exports){
+},{"../errors":233}],263:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var variable_utils_1 = require("./variable_utils");
@@ -37948,7 +40292,7 @@ function printLayerSummaryWithConnections(layer, positions, relevantNodes, print
     }
 }
 
-},{"./variable_utils":243}],240:[function(require,module,exports){
+},{"./variable_utils":267}],264:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38020,7 +40364,7 @@ function range(begin, end) {
 }
 exports.range = range;
 
-},{"../errors":210,"@tensorflow/tfjs-core":68}],241:[function(require,module,exports){
+},{"../errors":233,"@tensorflow/tfjs-core":68}],265:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils = require("../utils/generic_utils");
@@ -38114,7 +40458,7 @@ function convertTsToPythonic(tsConfig, key) {
 }
 exports.convertTsToPythonic = convertTsToPythonic;
 
-},{"../utils/generic_utils":238}],242:[function(require,module,exports){
+},{"../utils/generic_utils":262}],266:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -38162,7 +40506,7 @@ function getExactlyOneShape(shapes) {
 }
 exports.getExactlyOneShape = getExactlyOneShape;
 
-},{"../errors":210}],243:[function(require,module,exports){
+},{"../errors":233}],267:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function countParamsInWeights(weights) {
@@ -38180,7 +40524,7 @@ function countParamsInWeights(weights) {
 }
 exports.countParamsInWeights = countParamsInWeights;
 
-},{}],244:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38273,8 +40617,9 @@ function truncatedNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'truncatedNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38283,8 +40628,9 @@ function randomNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'randomNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38319,13 +40665,13 @@ function gradients(lossFn, variables) {
 }
 exports.gradients = gradients;
 
-},{"./backend/state":199,"./common":203,"./errors":210,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
+},{"./backend/state":219,"./common":223,"./errors":233,"@tensorflow/tfjs-core":68}],269:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.7.5';
+var version = '0.8.3';
 exports.version = version;
 
-},{}],246:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -38345,13 +40691,13 @@ exports.version = {
     'tfjs': version_1.version
 };
 
-},{"./version":247,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":217}],247:[function(require,module,exports){
+},{"./version":271,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":241}],271:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.7';
+var version = '0.13.3';
 exports.version = version;
 
-},{}],248:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -38469,7 +40815,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],249:[function(require,module,exports){
+},{}],273:[function(require,module,exports){
 /**
  * Bit twiddling hacks for JavaScript.
  *
@@ -38675,9 +41021,9 @@ exports.nextCombination = function(v) {
 }
 
 
-},{}],250:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 
-},{}],251:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -40415,7 +42761,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":248,"ieee754":259}],252:[function(require,module,exports){
+},{"base64-js":272,"ieee754":283}],276:[function(require,module,exports){
 "use strict"
 
 var createThunk = require("./lib/thunk.js")
@@ -40526,7 +42872,7 @@ function compileCwise(user_args) {
 
 module.exports = compileCwise
 
-},{"./lib/thunk.js":254}],253:[function(require,module,exports){
+},{"./lib/thunk.js":278}],277:[function(require,module,exports){
 "use strict"
 
 var uniq = require("uniq")
@@ -40886,7 +43232,7 @@ function generateCWiseOp(proc, typesig) {
 }
 module.exports = generateCWiseOp
 
-},{"uniq":300}],254:[function(require,module,exports){
+},{"uniq":324}],278:[function(require,module,exports){
 "use strict"
 
 // The function below is called when constructing a cwise function object, and does the following:
@@ -40974,9 +43320,9 @@ function createThunk(proc) {
 
 module.exports = createThunk
 
-},{"./compile.js":253}],255:[function(require,module,exports){
+},{"./compile.js":277}],279:[function(require,module,exports){
 module.exports = require("cwise-compiler")
-},{"cwise-compiler":252}],256:[function(require,module,exports){
+},{"cwise-compiler":276}],280:[function(require,module,exports){
 "use strict"
 
 function dupe_array(count, value, i) {
@@ -41026,7 +43372,7 @@ function dupe(count, value) {
 }
 
 module.exports = dupe
-},{}],257:[function(require,module,exports){
+},{}],281:[function(require,module,exports){
 'use strict';
 
 function FFT(size) {
@@ -41535,7 +43881,7 @@ FFT.prototype._singleRealTransform4 = function _singleRealTransform4(outOff,
   out[outOff + 7] = FDi;
 };
 
-},{}],258:[function(require,module,exports){
+},{}],282:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 1.3.2
@@ -41725,7 +44071,7 @@ if (typeof module !== "undefined" && module.exports) {
   });
 }
 
-},{}],259:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -41811,7 +44157,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],260:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 "use strict"
 
 function iota(n) {
@@ -41823,7 +44169,7 @@ function iota(n) {
 }
 
 module.exports = iota
-},{}],261:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -41846,10 +44192,10 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],262:[function(require,module,exports){
+},{}],286:[function(require,module,exports){
 !function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.MidiConvert=e():t.MidiConvert=e()}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="",e(e.s=7)}([function(t,e,n){"use strict";n.d(e,"a",function(){return r}),n.d(e,"b",function(){return i}),n.d(e,"c",function(){return a});var r=["acoustic grand piano","bright acoustic piano","electric grand piano","honky-tonk piano","electric piano 1","electric piano 2","harpsichord","clavi","celesta","glockenspiel","music box","vibraphone","marimba","xylophone","tubular bells","dulcimer","drawbar organ","percussive organ","rock organ","church organ","reed organ","accordion","harmonica","tango accordion","acoustic guitar (nylon)","acoustic guitar (steel)","electric guitar (jazz)","electric guitar (clean)","electric guitar (muted)","overdriven guitar","distortion guitar","guitar harmonics","acoustic bass","electric bass (finger)","electric bass (pick)","fretless bass","slap bass 1","slap bass 2","synth bass 1","synth bass 2","violin","viola","cello","contrabass","tremolo strings","pizzicato strings","orchestral harp","timpani","string ensemble 1","string ensemble 2","synthstrings 1","synthstrings 2","choir aahs","voice oohs","synth voice","orchestra hit","trumpet","trombone","tuba","muted trumpet","french horn","brass section","synthbrass 1","synthbrass 2","soprano sax","alto sax","tenor sax","baritone sax","oboe","english horn","bassoon","clarinet","piccolo","flute","recorder","pan flute","blown bottle","shakuhachi","whistle","ocarina","lead 1 (square)","lead 2 (sawtooth)","lead 3 (calliope)","lead 4 (chiff)","lead 5 (charang)","lead 6 (voice)","lead 7 (fifths)","lead 8 (bass + lead)","pad 1 (new age)","pad 2 (warm)","pad 3 (polysynth)","pad 4 (choir)","pad 5 (bowed)","pad 6 (metallic)","pad 7 (halo)","pad 8 (sweep)","fx 1 (rain)","fx 2 (soundtrack)","fx 3 (crystal)","fx 4 (atmosphere)","fx 5 (brightness)","fx 6 (goblins)","fx 7 (echoes)","fx 8 (sci-fi)","sitar","banjo","shamisen","koto","kalimba","bag pipe","fiddle","shanai","tinkle bell","agogo","steel drums","woodblock","taiko drum","melodic tom","synth drum","reverse cymbal","guitar fret noise","breath noise","seashore","bird tweet","telephone ring","helicopter","applause","gunshot"],i=["piano","chromatic percussion","organ","guitar","bass","strings","ensemble","brass","reed","pipe","synth lead","synth pad","synth effects","ethnic","percussive","sound effects"],a={0:"standard kit",8:"room kit",16:"power kit",24:"electronic kit",25:"tr-808 kit",32:"jazz kit",40:"brush kit",48:"orchestra kit",56:"sound fx kit"}},function(t,e,n){"use strict";function r(t){return t.replace(/\u0000/g,"")}function i(t,e){return 60/e.bpm*(t/e.PPQ)}function a(t){return"number"==typeof t}function o(t){return"string"==typeof t}function s(t){return["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"][t%12]+(Math.floor(t/12)-1)}e.b=r,e.a=i,e.c=a,n.d(e,"d",function(){return u}),e.e=s,n.d(e,"f",function(){return c});var u=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i;return function(e){return o(e)&&t.test(e)}}(),c=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,e={cbb:-2,cb:-1,c:0,"c#":1,cx:2,dbb:0,db:1,d:2,"d#":3,dx:4,ebb:2,eb:3,e:4,"e#":5,ex:6,fbb:3,fb:4,f:5,"f#":6,fx:7,gbb:5,gb:6,g:7,"g#":8,gx:9,abb:7,ab:8,a:9,"a#":10,ax:11,bbb:9,bb:10,b:11,"b#":12,bx:13};return function(n){var r=t.exec(n),i=r[1],a=r[2];return e[i.toLowerCase()]+12*(parseInt(a)+1)}}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(11),a=(n.n(i),n(10)),o=(n.n(a),n(1)),s=n(9),u=n(5),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(){r(this,t),this.header={bpm:120,timeSignature:[4,4],PPQ:480},this.tracks=[]}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t;return n.header=e.header,e.tracks.forEach(function(t){var e=s.a.fromJSON(t);n.tracks.push(e)}),n}}]),c(t,[{key:"load",value:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:null,r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"GET";return new Promise(function(i,a){var o=new XMLHttpRequest;o.open(r,t),o.responseType="arraybuffer",o.addEventListener("load",function(){4===o.readyState&&200===o.status?i(e.decode(o.response)):a(o.status)}),o.addEventListener("error",a),o.send(n)}).catch(function(t){console.log(t)})}},{key:"decode",value:function(t){var e=this;if(t instanceof ArrayBuffer){var r=new Uint8Array(t);t=String.fromCharCode.apply(null,r)}var a=i(t);return this.header=n.i(u.a)(a),this.tracks=[],a.tracks.forEach(function(t,n){var r=new s.a;r.id=n,e.tracks.push(r);var i=0;t.forEach(function(t){i+=o.a(t.deltaTime,e.header),"meta"===t.type&&"trackName"===t.subtype?r.name=o.b(t.text):"noteOn"===t.subtype?(r.noteOn(t.noteNumber,i,t.velocity/127),-1===r.channelNumber&&(r.channelNumber=t.channel)):"noteOff"===t.subtype?r.noteOff(t.noteNumber,i):"controller"===t.subtype&&t.controllerType?r.cc(t.controllerType,i,t.value/127):"meta"===t.type&&"instrumentName"===t.subtype?r.instrument=t.text:"channel"===t.type&&"programChange"===t.subtype&&(r.patch(t.programNumber),r.channelNumber=t.channel)}),e.header.name||r.length||!r.name||(e.header.name=r.name)}),this}},{key:"encode",value:function(){var t=this,e=new a.File({ticks:this.header.PPQ}),n=this.tracks.filter(function(t){return!t.length})[0];if(this.header.name&&(!n||n.name!==this.header.name)){e.addTrack().addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:this.header.name}))}return this.tracks.forEach(function(n){var r=e.addTrack();r.setTempo(t.bpm),n.name&&r.addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:n.name})),n.encode(r,t.header)}),e.toBytes()}},{key:"toArray",value:function(){for(var t=this.encode(),e=new Array(t.length),n=0;n<t.length;n++)e[n]=t.charCodeAt(n);return e}},{key:"toJSON",value:function(){var t={header:this.header,startTime:this.startTime,duration:this.duration,tracks:(this.tracks||[]).map(function(t){return t.toJSON()})};return t.header.name||(t.header.name=""),t}},{key:"track",value:function(t){var e=new s.a(t);return this.tracks.push(e),e}},{key:"get",value:function(t){return o.c(t)?this.tracks[t]:this.tracks.find(function(e){return e.name===t})}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=new t;return r.header=this.header,r.tracks=this.tracks.map(function(t){return t.slice(e,n)}),r}},{key:"startTime",get:function(){var t=this.tracks.map(function(t){return t.startTime});return t.length?Math.min.apply(Math,t)||0:0}},{key:"bpm",get:function(){return this.header.bpm},set:function(t){var e=this.header.bpm;this.header.bpm=t;var n=e/t;this.tracks.forEach(function(t){return t.scale(n)})}},{key:"timeSignature",get:function(){return this.header.timeSignature},set:function(t){this.header.timeSignature=t}},{key:"duration",get:function(){var t=this.tracks.map(function(t){return t.duration});return t.length?Math.max.apply(Math,t)||0:0}}]),t}()},function(t,e,n){"use strict";function r(t,e){var n=0,r=t.length,i=r;if(r>0&&t[r-1].time<=e)return r-1;for(;n<i;){var a=Math.floor(n+(i-n)/2),o=t[a],s=t[a+1];if(o.time===e){for(var u=a;u<t.length;u++){t[u].time===e&&(a=u)}return a}if(o.time<e&&s.time>e)return a;o.time>e?i=a:o.time<e&&(n=a+1)}return-1}function i(t,e){if(t.length){var n=r(t,e.time);t.splice(n+1,0,e)}else t.push(e)}n.d(e,"a",function(){return i})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),a={1:"modulationWheel",2:"breath",4:"footController",5:"portamentoTime",7:"volume",8:"balance",10:"pan",64:"sustain",65:"portamentoTime",66:"sostenuto",67:"softPedal",68:"legatoFootswitch",84:"portamentoContro"},o=function(){function t(e,n,i){r(this,t),this.number=e,this.time=n,this.value=i}return i(t,[{key:"name",get:function(){if(a.hasOwnProperty(this.number))return a[this.number]}}]),t}()},function(t,e,n){"use strict";function r(t){for(var e={PPQ:t.header.ticksPerBeat},n=0;n<t.tracks.length;n++)for(var r=t.tracks[n],i=0;i<r.length;i++){var a=r[i];"meta"===a.type&&("timeSignature"===a.subtype?e.timeSignature=[a.numerator,a.denominator]:"setTempo"===a.subtype&&(e.bpm||(e.bpm=6e7/a.microsecondsPerBeat)))}return e.bpm=e.bpm||120,e}n.d(e,"a",function(){return r})},function(t,e,n){"use strict";function r(t,e){for(var n=0;n<t.length;n++){var r=t[n],i=e[n];if(r.length>i)return!0}return!1}function i(t,e,n){for(var r=0,i=1/0,a=0;a<t.length;a++){var o=t[a],s=e[a];o[s]&&o[s].time<i&&(r=a,i=o[s].time)}n[r](t[r][e[r]]),e[r]+=1}function a(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];for(var a=e.filter(function(t,e){return e%2==0}),o=new Uint32Array(a.length),s=e.filter(function(t,e){return e%2==1});r(a,o);)i(a,o,s)}n.d(e,"a",function(){return a})},function(t,e,n){"use strict";function r(t){return(new s.a).decode(t)}function i(t,e){var n=(new s.a).load(t);return e&&n.then(e),n}function a(){return new s.a}function o(t){return s.a.fromJSON(t)}Object.defineProperty(e,"__esModule",{value:!0}),e.parse=r,e.load=i,e.create=a,e.fromJSON=o;var s=n(2),u=n(0);n.d(e,"instrumentByPatchID",function(){return u.a}),n.d(e,"instrumentFamilyByID",function(){return u.b}),n.d(e,"drumKitByPatchID",function(){return u.c})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=n(1),a=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),o=function(){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1;if(r(this,t),i.c(e))this.midi=e;else{if(!i.d(e))throw new Error("the midi value must either be in Pitch Notation (e.g. C#4) or a midi value");this.name=e}this.time=n,this.duration=a,this.velocity=o}return a(t,null,[{key:"fromJSON",value:function(e){return new t(e.midi,e.time,e.duration,e.velocity)}}]),a(t,[{key:"match",value:function(t){return i.c(t)?this.midi===t:i.d(t)?this.name.toLowerCase()===t.toLowerCase():void 0}},{key:"toJSON",value:function(){return{name:this.name,midi:this.midi,time:this.time,velocity:this.velocity,duration:this.duration}}},{key:"name",get:function(){return i.e(this.midi)},set:function(t){this.midi=i.f(t)}},{key:"noteOn",get:function(){return this.time},set:function(t){this.time=t}},{key:"noteOff",get:function(){return this.time+this.duration},set:function(t){this.duration=t-this.time}}]),t}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(3),a=n(4),o=n(6),s=n(8),u=n(0),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:-1,i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:-1;r(this,t),this.name=e,this.channelNumber=i,this.notes=[],this.controlChanges={},this.instrumentNumber=n}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t(e.name,e.instrumentNumber,e.channelNumber);return n.id=e.id,e.notes&&e.notes.forEach(function(t){var e=s.a.fromJSON(t);n.notes.push(e)}),e.controlChanges&&(n.controlChanges=e.controlChanges),n}}]),c(t,[{key:"note",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,a=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1,o=new s.a(t,e,r,a);return n.i(i.a)(this.notes,o),this}},{key:"noteOn",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:1,a=new s.a(t,e,0,r);return n.i(i.a)(this.notes,a),this}},{key:"noteOff",value:function(t,e){for(var n=0;n<this.notes.length;n++){var r=this.notes[n];if(r.match(t)&&0===r.duration){r.noteOff=e;break}}return this}},{key:"cc",value:function(t,e,r){this.controlChanges.hasOwnProperty(t)||(this.controlChanges[t]=[]);var o=new a.a(t,e,r);return n.i(i.a)(this.controlChanges[t],o),this}},{key:"patch",value:function(t){return this.instrumentNumber=t,this}},{key:"channel",value:function(t){return this.channelNumber=t,this}},{key:"scale",value:function(t){return this.notes.forEach(function(e){e.time*=t,e.duration*=t}),this}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=Math.max(this.notes.findIndex(function(t){return t.time>=e}),0),i=this.notes.findIndex(function(t){return t.noteOff>=n})+1,a=new t(this.name);return a.notes=this.notes.slice(r,i),a.notes.forEach(function(t){return t.time=t.time-e}),a}},{key:"encode",value:function(t,e){function r(t){var e=Math.floor(i*t),n=Math.max(e-a,0);return a=e,n}var i=e.PPQ/(60/e.bpm),a=0,s=Math.max(0,this.channelNumber);-1!==this.instrumentNumber&&t.instrument(s,this.instrumentNumber),n.i(o.a)(this.noteOns.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOn(s,e.name,r(e.time),Math.floor(127*e.velocity))},this.noteOffs.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOff(s,e.name,r(e.time))})}},{key:"toJSON",value:function(){var t={startTime:this.startTime,duration:this.duration,length:this.length,notes:[],controlChanges:{}};return void 0!==this.id&&(t.id=this.id),t.name=this.name,-1!==this.instrumentNumber&&(t.instrumentNumber=this.instrumentNumber,t.instrument=this.instrument,t.instrumentFamily=this.instrumentFamily),-1!==this.channelNumber&&(t.channelNumber=this.channelNumber,t.isPercussion=this.isPercussion),this.notes.length&&(t.notes=this.notes.map(function(t){return t.toJSON()})),Object.keys(this.controlChanges).length&&(t.controlChanges=this.controlChanges),t}},{key:"noteOns",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOn,midi:e.midi,name:e.name,velocity:e.velocity})}),t}},{key:"noteOffs",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOff,midi:e.midi,name:e.name})}),t}},{key:"length",get:function(){return this.notes.length}},{key:"startTime",get:function(){if(this.notes.length){return this.notes[0].noteOn}return 0}},{key:"duration",get:function(){if(this.notes.length){return this.notes[this.notes.length-1].noteOff}return 0}},{key:"instrument",get:function(){return this.isPercussion?u.c[this.instrumentNumber]:u.a[this.instrumentNumber]},set:function(t){var e=u.a.indexOf(t);-1!==e&&(this.instrumentNumber=e)}},{key:"isPercussion",get:function(){return[9,10].includes(this.channelNumber)}},{key:"instrumentFamily",get:function(){return this.isPercussion?"drums":u.b[Math.floor(this.instrumentNumber/8)]}}]),t}()},function(t,e,n){(function(t){var n={};!function(t){var e=t.DEFAULT_VOLUME=90,n=(t.DEFAULT_DURATION=128,t.DEFAULT_CHANNEL=0,{midi_letter_pitches:{a:21,b:23,c:12,d:14,e:16,f:17,g:19},midiPitchFromNote:function(t){var e=/([a-g])(#+|b+)?([0-9]+)$/i.exec(t),r=e[1].toLowerCase(),i=e[2]||"";return 12*parseInt(e[3],10)+n.midi_letter_pitches[r]+("#"==i.substr(0,1)?1:-1)*i.length},ensureMidiPitch:function(t){return"number"!=typeof t&&/[^0-9]/.test(t)?n.midiPitchFromNote(t):parseInt(t,10)},midi_pitches_letter:{12:"c",13:"c#",14:"d",15:"d#",16:"e",17:"f",18:"f#",19:"g",20:"g#",21:"a",22:"a#",23:"b"},midi_flattened_notes:{"a#":"bb","c#":"db","d#":"eb","f#":"gb","g#":"ab"},noteFromMidiPitch:function(t,e){var r,i=0,a=t,e=e||!1;return t>23&&(i=Math.floor(t/12)-1,a=t-12*i),r=n.midi_pitches_letter[a],e&&r.indexOf("#")>0&&(r=n.midi_flattened_notes[r]),r+i},mpqnFromBpm:function(t){var e=Math.floor(6e7/t),n=[];do{n.unshift(255&e),e>>=8}while(e);for(;n.length<3;)n.push(0);return n},bpmFromMpqn:function(t){var e=t;if(void 0!==t[0]){e=0;for(var n=0,r=t.length-1;r>=0;++n,--r)e|=t[n]<<r}return Math.floor(6e7/t)},codes2Str:function(t){return String.fromCharCode.apply(null,t)},str2Bytes:function(t,e){if(e)for(;t.length/2<e;)t="0"+t;for(var n=[],r=t.length-1;r>=0;r-=2){var i=0===r?t[r]:t[r-1]+t[r];n.unshift(parseInt(i,16))}return n},translateTickTime:function(t){for(var e=127&t;t>>=7;)e<<=8,e|=127&t|128;for(var n=[];;){if(n.push(255&e),!(128&e))break;e>>=8}return n}}),r=function(t){if(!this)return new r(t);!t||null===t.type&&void 0===t.type||null===t.channel&&void 0===t.channel||null===t.param1&&void 0===t.param1||(this.setTime(t.time),this.setType(t.type),this.setChannel(t.channel),this.setParam1(t.param1),this.setParam2(t.param2))};r.NOTE_OFF=128,r.NOTE_ON=144,r.AFTER_TOUCH=160,r.CONTROLLER=176,r.PROGRAM_CHANGE=192,r.CHANNEL_AFTERTOUCH=208,r.PITCH_BEND=224,r.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},r.prototype.setType=function(t){if(t<r.NOTE_OFF||t>r.PITCH_BEND)throw new Error("Trying to set an unknown event: "+t);this.type=t},r.prototype.setChannel=function(t){if(t<0||t>15)throw new Error("Channel is out of bounds.");this.channel=t},r.prototype.setParam1=function(t){this.param1=t},r.prototype.setParam2=function(t){this.param2=t},r.prototype.toBytes=function(){var t=[],e=this.type|15&this.channel;return t.push.apply(t,this.time),t.push(e),t.push(this.param1),void 0!==this.param2&&null!==this.param2&&t.push(this.param2),t};var i=function(t){if(!this)return new i(t);this.setTime(t.time),this.setType(t.type),this.setData(t.data)};i.SEQUENCE=0,i.TEXT=1,i.COPYRIGHT=2,i.TRACK_NAME=3,i.INSTRUMENT=4,i.LYRIC=5,i.MARKER=6,i.CUE_POINT=7,i.CHANNEL_PREFIX=32,i.END_OF_TRACK=47,i.TEMPO=81,i.SMPTE=84,i.TIME_SIG=88,i.KEY_SIG=89,i.SEQ_EVENT=127,i.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},i.prototype.setType=function(t){this.type=t},i.prototype.setData=function(t){this.data=t},i.prototype.toBytes=function(){if(!this.type)throw new Error("Type for meta-event not specified.");var t=[];if(t.push.apply(t,this.time),t.push(255,this.type),Array.isArray(this.data))t.push(this.data.length),t.push.apply(t,this.data);else if("number"==typeof this.data)t.push(1,this.data);else if(null!==this.data&&void 0!==this.data){t.push(this.data.length);var e=this.data.split("").map(function(t){return t.charCodeAt(0)});t.push.apply(t,e)}else t.push(0);return t};var a=function(t){if(!this)return new a(t);var e=t||{};this.events=e.events||[]};a.START_BYTES=[77,84,114,107],a.END_BYTES=[0,255,47,0],a.prototype.addEvent=function(t){return this.events.push(t),this},a.prototype.addNoteOn=a.prototype.noteOn=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_ON,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNoteOff=a.prototype.noteOff=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_OFF,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNote=a.prototype.note=function(t,e,n,r,i){return this.noteOn(t,e,r,i),n&&this.noteOff(t,e,n,i),this},a.prototype.addChord=a.prototype.chord=function(t,e,n,r){if(!Array.isArray(e)&&!e.length)throw new Error("Chord must be an array of pitches");return e.forEach(function(e){this.noteOn(t,e,0,r)},this),e.forEach(function(e,r){0===r?this.noteOff(t,e,n):this.noteOff(t,e)},this),this},a.prototype.setInstrument=a.prototype.instrument=function(t,e,n){return this.events.push(new r({type:r.PROGRAM_CHANGE,channel:t,param1:e,time:n||0})),this},a.prototype.setTempo=a.prototype.tempo=function(t,e){return this.events.push(new i({type:i.TEMPO,data:n.mpqnFromBpm(t),time:e||0})),this},a.prototype.toBytes=function(){var t=0,e=[],r=a.START_BYTES,i=a.END_BYTES,o=function(n){var r=n.toBytes();t+=r.length,e.push.apply(e,r)};this.events.forEach(o),t+=i.length;var s=n.str2Bytes(t.toString(16),4);return r.concat(s,e,i)};var o=function(t){if(!this)return new o(t);var e=t||{};if(e.ticks){if("number"!=typeof e.ticks)throw new Error("Ticks per beat must be a number!");if(e.ticks<=0||e.ticks>=32768||e.ticks%1!=0)throw new Error("Ticks per beat must be an integer between 1 and 32767!")}this.ticks=e.ticks||128,this.tracks=e.tracks||[]};o.HDR_CHUNKID="MThd",o.HDR_CHUNK_SIZE="\0\0\0",o.HDR_TYPE0="\0\0",o.HDR_TYPE1="\0",o.prototype.addTrack=function(t){return t?(this.tracks.push(t),this):(t=new a,this.tracks.push(t),t)},o.prototype.toBytes=function(){var t=this.tracks.length.toString(16),e=o.HDR_CHUNKID+o.HDR_CHUNK_SIZE;return parseInt(t,16)>1?e+=o.HDR_TYPE1:e+=o.HDR_TYPE0,e+=n.codes2Str(n.str2Bytes(t,2)),e+=String.fromCharCode(this.ticks/256,this.ticks%256),this.tracks.forEach(function(t){e+=n.codes2Str(t.toBytes())}),e},t.Util=n,t.File=o,t.Track=a,t.Event=r,t.MetaEvent=i}(n),void 0!==t&&null!==t?t.exports=n:void 0!==e&&null!==e?e=n:this.Midi=n}).call(e,n(12)(t))},function(t,e){function n(t){function e(t){var e=t.read(4),n=t.readInt32();return{id:e,length:n,data:t.read(n)}}var n;stream=r(t);var i=e(stream);if("MThd"!=i.id||6!=i.length)throw"Bad .mid file - header not found";var a=r(i.data),o=a.readInt16(),s=a.readInt16(),u=a.readInt16();if(32768&u)throw"Expressing time division in SMTPE frames is not supported yet";ticksPerBeat=u;for(var c={formatType:o,trackCount:s,ticksPerBeat:ticksPerBeat},h=[],f=0;f<c.trackCount;f++){h[f]=[];var d=e(stream);if("MTrk"!=d.id)throw"Unexpected chunk - expected MTrk, got "+d.id;for(var l=r(d.data);!l.eof();){var p=function(t){var e={};e.deltaTime=t.readVarInt();var r=t.readInt8();if(240==(240&r)){if(255==r){e.type="meta";var i=t.readInt8(),a=t.readVarInt();switch(i){case 0:if(e.subtype="sequenceNumber",2!=a)throw"Expected length for sequenceNumber event is 2, got "+a;return e.number=t.readInt16(),e;case 1:return e.subtype="text",e.text=t.read(a),e;case 2:return e.subtype="copyrightNotice",e.text=t.read(a),e;case 3:return e.subtype="trackName",e.text=t.read(a),e;case 4:return e.subtype="instrumentName",e.text=t.read(a),e;case 5:return e.subtype="lyrics",e.text=t.read(a),e;case 6:return e.subtype="marker",e.text=t.read(a),e;case 7:return e.subtype="cuePoint",e.text=t.read(a),e;case 32:if(e.subtype="midiChannelPrefix",1!=a)throw"Expected length for midiChannelPrefix event is 1, got "+a;return e.channel=t.readInt8(),e;case 47:if(e.subtype="endOfTrack",0!=a)throw"Expected length for endOfTrack event is 0, got "+a;return e;case 81:if(e.subtype="setTempo",3!=a)throw"Expected length for setTempo event is 3, got "+a;return e.microsecondsPerBeat=(t.readInt8()<<16)+(t.readInt8()<<8)+t.readInt8(),e;case 84:if(e.subtype="smpteOffset",5!=a)throw"Expected length for smpteOffset event is 5, got "+a;var o=t.readInt8();return e.frameRate={0:24,32:25,64:29,96:30}[96&o],e.hour=31&o,e.min=t.readInt8(),e.sec=t.readInt8(),e.frame=t.readInt8(),e.subframe=t.readInt8(),e;case 88:if(e.subtype="timeSignature",4!=a)throw"Expected length for timeSignature event is 4, got "+a;return e.numerator=t.readInt8(),e.denominator=Math.pow(2,t.readInt8()),e.metronome=t.readInt8(),e.thirtyseconds=t.readInt8(),e;case 89:if(e.subtype="keySignature",2!=a)throw"Expected length for keySignature event is 2, got "+a;return e.key=t.readInt8(!0),e.scale=t.readInt8(),e;case 127:return e.subtype="sequencerSpecific",e.data=t.read(a),e;default:return e.subtype="unknown",e.data=t.read(a),e}return e.data=t.read(a),e}if(240==r){e.type="sysEx";var a=t.readVarInt();return e.data=t.read(a),e}if(247==r){e.type="dividedSysEx";var a=t.readVarInt();return e.data=t.read(a),e}throw"Unrecognised MIDI event type byte: "+r}var s;0==(128&r)?(s=r,r=n):(s=t.readInt8(),n=r);var u=r>>4;switch(e.channel=15&r,e.type="channel",u){case 8:return e.subtype="noteOff",e.noteNumber=s,e.velocity=t.readInt8(),e;case 9:return e.noteNumber=s,e.velocity=t.readInt8(),0==e.velocity?e.subtype="noteOff":e.subtype="noteOn",e;case 10:return e.subtype="noteAftertouch",e.noteNumber=s,e.amount=t.readInt8(),e;case 11:return e.subtype="controller",e.controllerType=s,e.value=t.readInt8(),e;case 12:return e.subtype="programChange",e.programNumber=s,e;case 13:return e.subtype="channelAftertouch",e.amount=s,e;case 14:return e.subtype="pitchBend",e.value=s+(t.readInt8()<<7),e;default:throw"Unrecognised MIDI event type: "+u}}(l);h[f].push(p)}}return{header:c,tracks:h}}function r(t){function e(e){var n=t.substr(s,e);return s+=e,n}function n(){var e=(t.charCodeAt(s)<<24)+(t.charCodeAt(s+1)<<16)+(t.charCodeAt(s+2)<<8)+t.charCodeAt(s+3);return s+=4,e}function r(){var e=(t.charCodeAt(s)<<8)+t.charCodeAt(s+1);return s+=2,e}function i(e){var n=t.charCodeAt(s);return e&&n>127&&(n-=256),s+=1,n}function a(){return s>=t.length}function o(){for(var t=0;;){var e=i();if(!(128&e))return t+e;t+=127&e,t<<=7}}var s=0;return{eof:a,read:e,readInt32:n,readInt16:r,readInt8:i,readVarInt:o}}t.exports=function(t){return n(t)}},function(t,e){t.exports=function(t){return t.webpackPolyfill||(t.deprecate=function(){},t.paths=[],t.children||(t.children=[]),Object.defineProperty(t,"loaded",{enumerable:!0,get:function(){return t.l}}),Object.defineProperty(t,"id",{enumerable:!0,get:function(){return t.i}}),t.webpackPolyfill=1),t}}])});
 
-},{}],263:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 'use strict'
 
 var ops = require('ndarray-ops')
@@ -41932,7 +44278,7 @@ function ndfft(dir, x, y) {
 }
 
 module.exports = ndfft
-},{"./lib/fft-matrix.js":264,"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],264:[function(require,module,exports){
+},{"./lib/fft-matrix.js":288,"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],288:[function(require,module,exports){
 var bits = require('bit-twiddle')
 
 function fft(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
@@ -42151,7 +44497,7 @@ function fftBluestein(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
   }
 }
 
-},{"bit-twiddle":249}],265:[function(require,module,exports){
+},{"bit-twiddle":273}],289:[function(require,module,exports){
 "use strict"
 
 var compile = require("cwise-compiler")
@@ -42614,7 +44960,7 @@ exports.equals = compile({
 
 
 
-},{"cwise-compiler":252}],266:[function(require,module,exports){
+},{"cwise-compiler":276}],290:[function(require,module,exports){
 "use strict"
 
 var fft = require("ndarray-fft")
@@ -42718,7 +45064,7 @@ function resample(out, inp, clamp_lo, clamp_hi) {
 }
 
 module.exports = resample
-},{"cwise/lib/wrapper":255,"ndarray-fft":263,"ndarray-ops":265,"ndarray-scratch":267}],267:[function(require,module,exports){
+},{"cwise/lib/wrapper":279,"ndarray-fft":287,"ndarray-ops":289,"ndarray-scratch":291}],291:[function(require,module,exports){
 "use strict"
 
 var ndarray = require("ndarray")
@@ -42826,7 +45172,7 @@ function eye(shape, dtype) {
 }
 exports.eye = eye
 
-},{"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],268:[function(require,module,exports){
+},{"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],292:[function(require,module,exports){
 var iota = require("iota-array")
 var isBuffer = require("is-buffer")
 
@@ -43171,7 +45517,7 @@ function wrappedNDArrayCtor(data, shape, stride, offset) {
 
 module.exports = wrappedNDArrayCtor
 
-},{"iota-array":260,"is-buffer":261}],269:[function(require,module,exports){
+},{"iota-array":284,"is-buffer":285}],293:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -43357,9 +45703,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],270:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 arguments[4][50][0].apply(exports,arguments)
-},{"./src/index-minimal":271,"dup":50}],271:[function(require,module,exports){
+},{"./src/index-minimal":295,"dup":50}],295:[function(require,module,exports){
 "use strict";
 var protobuf = exports;
 
@@ -43397,7 +45743,7 @@ function configure() {
 protobuf.Writer._configure(protobuf.BufferWriter);
 configure();
 
-},{"./reader":272,"./reader_buffer":273,"./roots":274,"./rpc":275,"./util/minimal":278,"./writer":279,"./writer_buffer":280}],272:[function(require,module,exports){
+},{"./reader":296,"./reader_buffer":297,"./roots":298,"./rpc":299,"./util/minimal":302,"./writer":303,"./writer_buffer":304}],296:[function(require,module,exports){
 "use strict";
 module.exports = Reader;
 
@@ -43806,17 +46152,17 @@ Reader._configure = function(BufferReader_) {
     });
 };
 
-},{"./util/minimal":278}],273:[function(require,module,exports){
+},{"./util/minimal":302}],297:[function(require,module,exports){
 arguments[4][53][0].apply(exports,arguments)
-},{"./reader":272,"./util/minimal":278,"dup":53}],274:[function(require,module,exports){
+},{"./reader":296,"./util/minimal":302,"dup":53}],298:[function(require,module,exports){
 arguments[4][54][0].apply(exports,arguments)
-},{"dup":54}],275:[function(require,module,exports){
+},{"dup":54}],299:[function(require,module,exports){
 arguments[4][55][0].apply(exports,arguments)
-},{"./rpc/service":276,"dup":55}],276:[function(require,module,exports){
+},{"./rpc/service":300,"dup":55}],300:[function(require,module,exports){
 arguments[4][56][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":56}],277:[function(require,module,exports){
+},{"../util/minimal":302,"dup":56}],301:[function(require,module,exports){
 arguments[4][57][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":57}],278:[function(require,module,exports){
+},{"../util/minimal":302,"dup":57}],302:[function(require,module,exports){
 (function (global){
 "use strict";
 var util = exports;
@@ -44225,11 +46571,11 @@ util._configure = function() {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./longbits":277,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],279:[function(require,module,exports){
+},{"./longbits":301,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],303:[function(require,module,exports){
 arguments[4][59][0].apply(exports,arguments)
-},{"./util/minimal":278,"dup":59}],280:[function(require,module,exports){
+},{"./util/minimal":302,"dup":59}],304:[function(require,module,exports){
 arguments[4][60][0].apply(exports,arguments)
-},{"./util/minimal":278,"./writer":279,"dup":60}],281:[function(require,module,exports){
+},{"./util/minimal":302,"./writer":303,"dup":60}],305:[function(require,module,exports){
 // A library of seedable RNGs implemented in Javascript.
 //
 // Usage:
@@ -44291,7 +46637,7 @@ sr.tychei = tychei;
 
 module.exports = sr;
 
-},{"./lib/alea":282,"./lib/tychei":283,"./lib/xor128":284,"./lib/xor4096":285,"./lib/xorshift7":286,"./lib/xorwow":287,"./seedrandom":288}],282:[function(require,module,exports){
+},{"./lib/alea":306,"./lib/tychei":307,"./lib/xor128":308,"./lib/xor4096":309,"./lib/xorshift7":310,"./lib/xorwow":311,"./seedrandom":312}],306:[function(require,module,exports){
 // A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
 // http://baagoe.com/en/RandomMusings/javascript/
 // https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
@@ -44407,7 +46753,7 @@ if (module && module.exports) {
 
 
 
-},{}],283:[function(require,module,exports){
+},{}],307:[function(require,module,exports){
 // A Javascript implementaion of the "Tyche-i" prng algorithm by
 // Samuel Neves and Filipe Araujo.
 // See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
@@ -44512,7 +46858,7 @@ if (module && module.exports) {
 
 
 
-},{}],284:[function(require,module,exports){
+},{}],308:[function(require,module,exports){
 // A Javascript implementaion of the "xor128" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44595,7 +46941,7 @@ if (module && module.exports) {
 
 
 
-},{}],285:[function(require,module,exports){
+},{}],309:[function(require,module,exports){
 // A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
 //
 // This fast non-cryptographic random number generator is designed for
@@ -44743,7 +47089,7 @@ if (module && module.exports) {
   (typeof define) == 'function' && define   // present with an AMD loader
 );
 
-},{}],286:[function(require,module,exports){
+},{}],310:[function(require,module,exports){
 // A Javascript implementaion of the "xorshift7" algorithm by
 // François Panneton and Pierre L'ecuyer:
 // "On the Xorgshift Random Number Generators"
@@ -44842,7 +47188,7 @@ if (module && module.exports) {
 );
 
 
-},{}],287:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 // A Javascript implementaion of the "xorwow" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44930,7 +47276,7 @@ if (module && module.exports) {
 
 
 
-},{}],288:[function(require,module,exports){
+},{}],312:[function(require,module,exports){
 /*
 Copyright 2014 David Bau.
 
@@ -45179,7 +47525,7 @@ if ((typeof module) == 'object' && module.exports) {
   Math    // math: package containing random, pow, and seedrandom
 );
 
-},{"crypto":250}],289:[function(require,module,exports){
+},{"crypto":274}],313:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45335,7 +47681,7 @@ exports.unique = unique;
 exports.shuffle = shuffle;
 exports.permutations = permutations;
 
-},{"tonal-note":294}],290:[function(require,module,exports){
+},{"tonal-note":318}],314:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45527,7 +47873,7 @@ exports.supersets = supersets;
 exports.subsets = subsets;
 exports.tokenize = tokenize$1;
 
-},{"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],291:[function(require,module,exports){
+},{"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],315:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45899,7 +48245,7 @@ exports.scale = scale;
 exports.chord = chord;
 exports.pcset = pcset;
 
-},{"tonal-pcset":295}],292:[function(require,module,exports){
+},{"tonal-pcset":319}],316:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46178,7 +48524,7 @@ exports.subtract = subtract;
 exports.interval = interval;
 exports.semitones = semitones;
 
-},{"tonal-interval":293,"tonal-note":294}],293:[function(require,module,exports){
+},{"tonal-interval":317,"tonal-note":318}],317:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46519,7 +48865,7 @@ exports.simplify = simplify;
 exports.invert = invert;
 exports.fromSemitones = fromSemitones;
 
-},{}],294:[function(require,module,exports){
+},{}],318:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46934,7 +49280,7 @@ exports.fromMidi = fromMidi;
 exports.simplify = simplify;
 exports.enharmonic = enharmonic;
 
-},{}],295:[function(require,module,exports){
+},{}],319:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47163,7 +49509,7 @@ exports.isSupersetOf = isSupersetOf;
 exports.includes = includes;
 exports.filter = filter;
 
-},{"tonal-array":289,"tonal-interval":293,"tonal-note":294}],296:[function(require,module,exports){
+},{"tonal-array":313,"tonal-interval":317,"tonal-note":318}],320:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47400,7 +49746,7 @@ exports.toScale = toScale;
 exports.supersets = supersets;
 exports.subsets = subsets;
 
-},{"tonal-array":289,"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],297:[function(require,module,exports){
+},{"tonal-array":313,"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],321:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47538,7 +49884,7 @@ exports.freq = freq$1;
 exports.chord = chord$1;
 exports.scale = scale$1;
 
-},{"tonal-array":289,"tonal-chord":290,"tonal-dictionary":291,"tonal-distance":292,"tonal-interval":293,"tonal-note":294,"tonal-pcset":295,"tonal-scale":296}],298:[function(require,module,exports){
+},{"tonal-array":313,"tonal-chord":314,"tonal-dictionary":315,"tonal-distance":316,"tonal-interval":317,"tonal-note":318,"tonal-pcset":319,"tonal-scale":320}],322:[function(require,module,exports){
 (function(root, factory){
 
 	//UMD
@@ -71921,7 +74267,7 @@ exports.scale = scale$1;
 	
 	return Tone;
 }));
-},{}],299:[function(require,module,exports){
+},{}],323:[function(require,module,exports){
 (function (global,Buffer){
 'use strict'
 
@@ -72138,7 +74484,7 @@ exports.clearCache = function clearCache() {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"bit-twiddle":249,"buffer":251,"dup":256}],300:[function(require,module,exports){
+},{"bit-twiddle":273,"buffer":275,"dup":280}],324:[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -72197,7 +74543,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],301:[function(require,module,exports){
+},{}],325:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72245,7 +74591,7 @@ var BinaryCounter = (function (_super) {
 }(AuxiliaryInput));
 exports.BinaryCounter = BinaryCounter;
 
-},{"@tensorflow/tfjs-core":68}],302:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],326:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72439,7 +74785,7 @@ var PitchChordEncoder = (function (_super) {
 }(ChordEncoder));
 exports.PitchChordEncoder = PitchChordEncoder;
 
-},{"./constants":303,"@tensorflow/tfjs-core":68,"tonal":297}],303:[function(require,module,exports){
+},{"./constants":327,"@tensorflow/tfjs-core":68,"tonal":321}],327:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 null;
@@ -72467,7 +74813,7 @@ exports.HI_CLICK_PITCH = 90;
 exports.LO_CLICK_CLASS = 9;
 exports.HI_CLICK_CLASS = 10;
 
-},{}],304:[function(require,module,exports){
+},{}],328:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73039,7 +75385,7 @@ var MultitrackConverter = (function (_super) {
 }(DataConverter));
 exports.MultitrackConverter = MultitrackConverter;
 
-},{"../protobuf/index":320,"./constants":303,"./performance":308,"./sequences":311,"@tensorflow/tfjs-core":68}],305:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./performance":332,"./sequences":335,"@tensorflow/tfjs-core":68}],329:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -73064,7 +75410,7 @@ __export(require("./player"));
 __export(require("./recorder"));
 __export(require("./visualizer"));
 
-},{"./aux_inputs":301,"./chords":302,"./constants":303,"./data":304,"./logging":306,"./midi_io":307,"./performance":308,"./player":309,"./recorder":310,"./sequences":311,"./visualizer":313}],306:[function(require,module,exports){
+},{"./aux_inputs":325,"./chords":326,"./constants":327,"./data":328,"./logging":330,"./midi_io":331,"./performance":332,"./player":333,"./recorder":334,"./sequences":335,"./visualizer":337}],330:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Level;
@@ -73095,7 +75441,7 @@ function logWithDuration(msg, startTime, prefix, level) {
 }
 exports.logWithDuration = logWithDuration;
 
-},{}],307:[function(require,module,exports){
+},{}],331:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73241,7 +75587,7 @@ function sequenceProtoToMidi(ns) {
 }
 exports.sequenceProtoToMidi = sequenceProtoToMidi;
 
-},{"../protobuf":320,"./constants":303,"./sequences":311,"midiconvert":262}],308:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"./sequences":335,"midiconvert":286}],332:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var index_1 = require("../protobuf/index");
@@ -73444,7 +75790,7 @@ var Performance = (function () {
 }());
 exports.Performance = Performance;
 
-},{"../protobuf/index":320,"./constants":303,"./sequences":311}],309:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./sequences":335}],333:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73856,7 +76202,7 @@ var PlayerWithClick = (function (_super) {
 }(Player));
 exports.PlayerWithClick = PlayerWithClick;
 
-},{".":305,"./constants":303,"./data":304,"./soundfont":312,"tone":298}],310:[function(require,module,exports){
+},{".":329,"./constants":327,"./data":328,"./soundfont":336,"tone":322}],334:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74082,7 +76428,7 @@ var Recorder = (function () {
 }());
 exports.Recorder = Recorder;
 
-},{"../protobuf":320,"./constants":303,"tone":298}],311:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"tone":322}],335:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74353,7 +76699,7 @@ function mergeInstruments(ns) {
 }
 exports.mergeInstruments = mergeInstruments;
 
-},{"../protobuf/index":320,"./constants":303}],312:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327}],336:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74611,7 +76957,7 @@ var SoundFont = (function () {
 }());
 exports.SoundFont = SoundFont;
 
-},{"./constants":303,"tone":298}],313:[function(require,module,exports){
+},{"./constants":327,"tone":322}],337:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require(".");
@@ -74703,7 +77049,7 @@ var Visualizer = (function () {
 }());
 exports.Visualizer = Visualizer;
 
-},{".":305,"./constants":303}],314:[function(require,module,exports){
+},{".":329,"./constants":327}],338:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -74717,7 +77063,7 @@ __export(require("./music_vae"));
 __export(require("./protobuf"));
 __export(require("./transcription"));
 
-},{"./core":305,"./music_rnn":316,"./music_vae":318,"./protobuf":320,"./transcription":324,"@tensorflow/tfjs":246}],315:[function(require,module,exports){
+},{"./core":329,"./music_rnn":340,"./music_vae":342,"./protobuf":344,"./transcription":348,"@tensorflow/tfjs":270}],339:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tf = require("@tensorflow/tfjs-core");
@@ -74781,13 +77127,13 @@ var AttentionWrapper = (function () {
 }());
 exports.AttentionWrapper = AttentionWrapper;
 
-},{"@tensorflow/tfjs-core":68}],316:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],340:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.MusicRNN = model_1.MusicRNN;
 
-},{"./model":317}],317:[function(require,module,exports){
+},{"./model":341}],341:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -75086,7 +77432,7 @@ var MusicRNN = (function () {
 }());
 exports.MusicRNN = MusicRNN;
 
-},{"../core/aux_inputs":301,"../core/chords":302,"../core/data":304,"../core/logging":306,"../core/sequences":311,"./attention":315,"@tensorflow/tfjs-core":68}],318:[function(require,module,exports){
+},{"../core/aux_inputs":325,"../core/chords":326,"../core/data":328,"../core/logging":330,"../core/sequences":335,"./attention":339,"@tensorflow/tfjs-core":68}],342:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
@@ -75094,7 +77440,7 @@ exports.Decoder = model_1.Decoder;
 exports.Encoder = model_1.Encoder;
 exports.MusicVAE = model_1.MusicVAE;
 
-},{"./model":319}],319:[function(require,module,exports){
+},{"./model":343}],343:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -75838,14 +78184,14 @@ var MusicVAE = (function () {
 }());
 exports.MusicVAE = MusicVAE;
 
-},{"../core/chords":302,"../core/constants":303,"../core/data":304,"../core/logging":306,"@tensorflow/tfjs-core":68}],320:[function(require,module,exports){
+},{"../core/chords":326,"../core/constants":327,"../core/data":328,"../core/logging":330,"@tensorflow/tfjs-core":68}],344:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var proto_1 = require("./proto");
 var NoteSequence = proto_1.tensorflow.magenta.NoteSequence;
 exports.NoteSequence = NoteSequence;
 
-},{"./proto":321}],321:[function(require,module,exports){
+},{"./proto":345}],345:[function(require,module,exports){
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
@@ -81556,7 +83902,7 @@ $root.tensorflow = (function() {
 
 module.exports = $root;
 
-},{"protobufjs/minimal":270}],322:[function(require,module,exports){
+},{"protobufjs/minimal":294}],346:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -81935,7 +84281,7 @@ function max(arr) {
     return arr.reduce(function (a, b) { return Math.max(a, b); });
 }
 
-},{"../core/logging":306,"./constants":323,"fft.js":257,"ndarray":268,"ndarray-resample":266}],323:[function(require,module,exports){
+},{"../core/logging":330,"./constants":347,"fft.js":281,"ndarray":292,"ndarray-resample":290}],347:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SAMPLE_RATE = 16000;
@@ -81946,13 +84292,13 @@ exports.MIN_MIDI_PITCH = 21;
 exports.MAX_MIDI_PITCH = 108;
 exports.MIDI_PITCHES = exports.MAX_MIDI_PITCH - exports.MIN_MIDI_PITCH + 1;
 
-},{}],324:[function(require,module,exports){
+},{}],348:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.OnsetsAndFrames = model_1.OnsetsAndFrames;
 
-},{"./model":325}],325:[function(require,module,exports){
+},{"./model":349}],349:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82318,7 +84664,7 @@ var Lstm = (function () {
     return Lstm;
 }());
 
-},{"../core/logging":306,"./audio_utils":322,"./constants":323,"./transcription_utils":326,"@tensorflow/tfjs":246}],326:[function(require,module,exports){
+},{"../core/logging":330,"./audio_utils":346,"./constants":347,"./transcription_utils":350,"@tensorflow/tfjs":270}],350:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82488,4 +84834,4 @@ function pianorollToNoteSequence(frameProbs, onsetProbs, velocityValues, onsetTh
 }
 exports.pianorollToNoteSequence = pianorollToNoteSequence;
 
-},{"../protobuf":320,"./constants":323,"@tensorflow/tfjs":246}]},{},[2]);
+},{"../protobuf":344,"./constants":347,"@tensorflow/tfjs":270}]},{},[2]);

--- a/docs/music/demos/music_vae_bundle.js
+++ b/docs/music/demos/music_vae_bundle.js
@@ -418,7 +418,7 @@ function notesMatch(aNotes, bNotes) {
 }
 exports.notesMatch = notesMatch;
 
-},{"../src/index":315,"file-saver":259}],2:[function(require,module,exports){
+},{"../src/index":339,"file-saver":283}],2:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -827,7 +827,7 @@ catch (err) {
     console.error(err);
 }
 
-},{"../src/index":315,"./common":1,"@tensorflow/tfjs-core":68,"clone":252}],3:[function(require,module,exports){
+},{"../src/index":339,"./common":1,"@tensorflow/tfjs-core":68,"clone":276}],3:[function(require,module,exports){
 "use strict";
 module.exports = asPromise;
 
@@ -3577,7 +3577,7 @@ var FrozenModel = (function () {
         });
     };
     FrozenModel.prototype.predict = function (inputs, config) {
-        return this.execute(inputs, this.outputNodes);
+        return this.execute_(inputs, true, this.outputNodes);
     };
     FrozenModel.prototype.constructTensorMap = function (inputs) {
         var inputArray = inputs instanceof tfc.Tensor ? [inputs] : inputs;
@@ -3592,6 +3592,10 @@ var FrozenModel = (function () {
         }, {});
     };
     FrozenModel.prototype.execute = function (inputs, outputs) {
+        return this.execute_(inputs, false, outputs);
+    };
+    FrozenModel.prototype.execute_ = function (inputs, strictInputCheck, outputs) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         outputs = outputs || this.outputNodes;
         if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
             inputs = this.constructTensorMap(inputs);
@@ -3600,7 +3604,7 @@ var FrozenModel = (function () {
             throw new Error('The model contains control flow or dynamic shape ops, ' +
                 'please use executeAsync method');
         }
-        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), outputs);
+        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
         var keys = Object.keys(result);
         return (Array.isArray(outputs) && outputs.length > 1) ?
             outputs.map(function (node) { return result[node]; }) :
@@ -3714,8 +3718,9 @@ var execution_context_1 = require("./execution_context");
 var GraphExecutor = (function () {
     function GraphExecutor(graph) {
         this.graph = graph;
-        this.compiledOrder = [];
+        this.compiledMap = new Map();
         this._weightMap = {};
+        this.SEPERATOR = ',';
         this.placeholders = graph.placeholders;
         this._outputs = graph.outputs;
         this.compile();
@@ -3790,16 +3795,23 @@ var GraphExecutor = (function () {
         enumerable: true,
         configurable: true
     });
-    GraphExecutor.prototype.compile = function () {
+    GraphExecutor.prototype.compile = function (startNodes) {
         if (this.graph.withControlFlow || this.graph.withDynamicShape) {
             return;
         }
-        var stack = this.graph.inputs.slice();
+        var compiledOrder = [];
+        var inputs = startNodes || this.graph.placeholders;
+        var sortedNodeNames = inputs.map(function (node) { return node.name; }).sort();
+        var nameKey = sortedNodeNames.join(this.SEPERATOR);
+        if (this.compiledMap.get(nameKey)) {
+            return;
+        }
+        var stack = inputs.concat(this.graph.weights);
         var visited = {};
         while (stack.length > 0) {
             var node = stack.pop();
             visited[node.name] = true;
-            this.compiledOrder.push(node);
+            compiledOrder.push(node);
             node.children.forEach(function (childNode) {
                 if (!visited[childNode.name] && childNode.inputNames.every(function (name) {
                     var nodeName = utils_1.getNodeNameAndIndex(name)[0];
@@ -3809,19 +3821,33 @@ var GraphExecutor = (function () {
                 }
             });
         }
+        this.compiledMap.set(nameKey, compiledOrder);
     };
-    GraphExecutor.prototype.execute = function (inputs, outputs) {
+    GraphExecutor.prototype.execute = function (inputs, strictInputCheck, outputs) {
         var _this = this;
-        this.checkInput(inputs);
-        this.checkInputShapeAndType(inputs);
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
+        var names = Object.keys(inputs).sort();
+        this.checkInput(inputs, strictInputCheck);
+        this.checkInputShapeAndType(inputs, strictInputCheck);
+        this.compile(names.map(function (name) { return _this.graph.nodes[name]; }));
+        var outputNames = this.calculateOutputs(outputs);
+        this.checkOutput(this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
         var tensorArrayMap = {};
         var result = tfjs_core_1.tidy(function () {
             var context = new execution_context_1.ExecutionContext(_this._weightMap, tensorArrayMap);
-            var tensors = _this.compiledOrder.reduce(function (map, node) {
-                map[node.name] = operation_executor_1.executeOp(node, map, context);
-                return map;
-            }, __assign({}, _this.weightMap, inputs));
-            return _this.findOutputs(tensors, context, outputs);
+            var tensorMap = __assign({}, _this.weightMap, inputs);
+            var compiledNodes = _this.compiledMap.get(names.join(_this.SEPERATOR));
+            for (var i = 0; i < compiledNodes.length; i++) {
+                var node = compiledNodes[i];
+                if (!tensorMap[node.name]) {
+                    tensorMap[node.name] =
+                        operation_executor_1.executeOp(node, tensorMap, context);
+                }
+                if (outputNames.every(function (name) { return !!tensorMap[name]; })) {
+                    break;
+                }
+            }
+            return _this.findOutputs(tensorMap, context, outputNames);
         });
         return result;
     };
@@ -3832,8 +3858,8 @@ var GraphExecutor = (function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        this.checkInput(inputs);
-                        this.checkInputShapeAndType(inputs);
+                        this.checkInput(inputs, false);
+                        this.checkInputShapeAndType(inputs, false);
                         tensorArrayMap = {};
                         context = new execution_context_1.ExecutionContext(this._weightMap, tensorArrayMap);
                         return [4, this.executeWithControlFlow(inputs, context)];
@@ -3860,11 +3886,14 @@ var GraphExecutor = (function () {
     };
     GraphExecutor.prototype.executeWithControlFlow = function (inputs, context) {
         return __awaiter(this, void 0, void 0, function () {
-            var stack, tensorMap, added, promises;
+            var _this = this;
+            var names, inputNodes, stack, tensorMap, added, promises;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        stack = this.graph.inputs.map(function (node) {
+                        names = Object.keys(inputs);
+                        inputNodes = names.map(function (name) { return _this.graph.nodes[name]; });
+                        stack = inputNodes.concat(this.graph.weights).map(function (node) {
                             return { node: node, contexts: context.currentContext };
                         });
                         tensorMap = __assign({}, this.weightMap, inputs);
@@ -3872,7 +3901,7 @@ var GraphExecutor = (function () {
                         _a.label = 1;
                     case 1:
                         if (!(stack.length > 0)) return [3, 3];
-                        promises = this.processStack(stack, context, tensorMap, added);
+                        promises = this.processStack(inputNodes, stack, context, tensorMap, added);
                         return [4, Promise.all(promises)];
                     case 2:
                         _a.sent();
@@ -3882,7 +3911,7 @@ var GraphExecutor = (function () {
             });
         });
     };
-    GraphExecutor.prototype.processStack = function (stack, context, tensorMap, added) {
+    GraphExecutor.prototype.processStack = function (inputNodes, stack, context, tensorMap, added) {
         var _this = this;
         var promises = [];
         var _loop_1 = function () {
@@ -3893,21 +3922,26 @@ var GraphExecutor = (function () {
                 utils_1.getParamValue('isConstant', item.node, tensorMap, context)) {
                 nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
             }
-            var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
-            if (!nodeName) {
-                nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
-            }
-            var currentContext = context.currentContext;
-            if (tensors instanceof Promise) {
-                promises.push(tensors.then(function (t) {
-                    tensorMap[nodeName] = t;
-                    context.currentContext = currentContext;
-                    _this.processChildNodes(item.node, stack, context, tensorMap, added);
-                    return t;
-                }));
+            if (inputNodes.indexOf(item.node) === -1) {
+                var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
+                if (!nodeName) {
+                    nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
+                }
+                var currentContext_1 = context.currentContext;
+                if (tensors instanceof Promise) {
+                    promises.push(tensors.then(function (t) {
+                        tensorMap[nodeName] = t;
+                        context.currentContext = currentContext_1;
+                        _this.processChildNodes(item.node, stack, context, tensorMap, added);
+                        return t;
+                    }));
+                }
+                else {
+                    tensorMap[nodeName] = tensors;
+                    this_1.processChildNodes(item.node, stack, context, tensorMap, added);
+                }
             }
             else {
-                tensorMap[nodeName] = tensors;
                 this_1.processChildNodes(item.node, stack, context, tensorMap, added);
             }
         };
@@ -3938,11 +3972,14 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+    GraphExecutor.prototype.calculateOutputs = function (outputs) {
         if (outputs && !(outputs instanceof Array)) {
             outputs = [outputs];
         }
-        var requestedOutputs = (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+        return (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+    };
+    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+        var requestedOutputs = this.calculateOutputs(outputs);
         return requestedOutputs.reduce(function (map, name) {
             map[name] = utils_1.getTensor(name, tensorMap, context);
             return map;
@@ -3953,9 +3990,14 @@ var GraphExecutor = (function () {
         Object.keys(this.weightMap)
             .forEach(function (key) { return _this.weightMap[key].forEach(function (tensor) { return tensor.dispose(); }); });
     };
-    GraphExecutor.prototype.checkInputShapeAndType = function (inputs) {
+    GraphExecutor.prototype.checkInputShapeAndType = function (inputs, strictInputCheck) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         this.placeholders.forEach(function (node) {
-            var input = inputs[node.name][0];
+            var inputTensors = inputs[node.name];
+            if (!strictInputCheck && !inputTensors) {
+                return;
+            }
+            var input = inputTensors[0];
             if (node.params['shape'] && node.params['shape'].value) {
                 var shape_1 = node.params['shape'].value;
                 var match = shape_1.length === input.shape.length &&
@@ -3967,8 +4009,9 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.checkInput = function (inputs) {
+    GraphExecutor.prototype.checkInput = function (inputs, strictInputCheck) {
         var _this = this;
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         var inputKeys = Object.keys(inputs);
         var missing = [];
         var extra = [];
@@ -3980,14 +4023,31 @@ var GraphExecutor = (function () {
             if (_this.inputNodes.indexOf(name) === -1)
                 extra.push(name);
         });
-        if (missing.length > 0) {
+        var notInGraph = extra.filter(function (name) { return !_this.graph.nodes[name]; });
+        if (missing.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has the keys " +
                 ("[" + inputKeys + "], but is missing the required keys: [" + missing + "]."));
         }
-        if (extra.length > 0) {
+        if (extra.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has " +
                 ("unused keys: [" + extra + "]. Please provide only the following keys: ") +
                 ("[" + this.inputNodes + "]."));
+        }
+        if (notInGraph.length > 0) {
+            throw new Error("The dict provided in model.execute(dict) has " +
+                ("keys: [" + notInGraph + "] not part of model graph."));
+        }
+    };
+    GraphExecutor.prototype.checkOutput = function (compiledNodes, outputs) {
+        var compiledNodeNames = compiledNodes.map(function (node) { return node.name; });
+        var extra = [];
+        outputs.forEach(function (name) {
+            if (compiledNodeNames.indexOf(name) === -1)
+                extra.push(name);
+        });
+        if (extra.length > 0) {
+            throw new Error("The following outputs are not be generated by the execution: " +
+                ("[" + extra + "]."));
         }
     };
     return GraphExecutor;
@@ -4703,6 +4763,9 @@ exports.executeOp = function (node, tensorMap, context) {
             return [snapshot.clone()];
         case 'shape':
             return [tfc.tensor1d(utils_1.getParamValue('x', node, tensorMap, context).shape, 'int32')];
+        case 'shapeN':
+            return utils_1.getParamValue('x', node, tensorMap, context)
+                .map(function (t) { return tfc.tensor1d(t.shape); });
         case 'size':
             return [tfc.scalar(utils_1.getParamValue('x', node, tensorMap, context).size, 'int32')];
         case 'rank':
@@ -4745,6 +4808,15 @@ exports.executeOp = function (node, tensorMap, context) {
             var size = utils_1.getParamValue('size', node, tensorMap, context);
             var alignCorners = utils_1.getParamValue('alignCorners', node, tensorMap, context);
             return [tfc.image.resizeNearestNeighbor(images, [size[0], size[1]], alignCorners)];
+        }
+        case 'cropAndResize': {
+            var image = utils_1.getParamValue('image', node, tensorMap, context);
+            var boxes = utils_1.getParamValue('boxes', node, tensorMap, context);
+            var boxInd = utils_1.getParamValue('boxInd', node, tensorMap, context);
+            var cropSize = utils_1.getParamValue('cropSize', node, tensorMap, context);
+            var method = utils_1.getParamValue('method', node, tensorMap, context);
+            var extrapolationValue = utils_1.getParamValue('extrapolationValue', node, tensorMap, context);
+            return [tfc.image.cropAndResize(image, boxes, boxInd, cropSize, method, extrapolationValue)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4878,6 +4950,11 @@ exports.executeOp = function (node, tensorMap, context) {
         case 'argMin': {
             var axis = utils_1.getParamValue('axis', node, tensorMap, context);
             return [tfc.argMin(utils_1.getParamValue('x', node, tensorMap, context), axis)];
+        }
+        case 'prod': {
+            var axis = utils_1.getParamValue('axis', node, tensorMap, context);
+            var keepDims = utils_1.getParamValue('keepDims', node, tensorMap, context);
+            return [tfc.prod(utils_1.getParamValue('x', node, tensorMap, context), axis, keepDims)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -5234,6 +5311,20 @@ exports.json = [
     },
     {
         'tfOpName': 'Mod',
+        'dlOpName': 'mod',
+        'category': 'arithmetic',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'FloorMod',
         'dlOpName': 'mod',
         'category': 'arithmetic',
         'params': [
@@ -6393,6 +6484,17 @@ exports.json = [
         'params': [{ 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' }]
     },
     {
+        'tfOpName': 'ShapeN',
+        'dlOpName': 'shapeN',
+        'category': 'graph',
+        'params': [{
+                'tfInputIndex': 0,
+                'tfInputParamLength': 0,
+                'dlParamName': 'x',
+                'type': 'tensors'
+            }]
+    },
+    {
         'tfOpName': 'Print',
         'dlOpName': 'print',
         'category': 'graph',
@@ -6474,6 +6576,22 @@ exports.json = [
                 'dlParamName': 'dtype',
                 'type': 'dtype',
                 'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'CropAndResize',
+        'dlOpName': 'cropAndResize',
+        'category': 'image',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'image', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'boxes', 'type': 'tensor' },
+            { 'tfInputIndex': 2, 'dlParamName': 'boxInd', 'type': 'tensor' },
+            { 'tfInputIndex': 3, 'dlParamName': 'cropSize', 'type': 'number[]' },
+            { 'tfParamName': 'method', 'dlParamName': 'method', 'type': 'string' }, {
+                'tfParamName': 'extrapolation_value',
+                'dlParamName': 'extrapolationValue',
+                'type': 'number'
             }
         ]
     }
@@ -6643,6 +6761,32 @@ exports.json = [
             },
             {
                 'tfParamName': 'transpose_b',
+                'dlParamName': 'transposeB',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'BatchMatMul',
+        'dlOpName': 'matMul',
+        'category': 'matrices',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'adj_x',
+                'dlParamName': 'transposeA',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'adj_y',
                 'dlParamName': 'transposeB',
                 'type': 'bool',
                 'defaultValue': false
@@ -6840,6 +6984,19 @@ exports.json = [
         'params': [
             { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
             { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number' }
+        ]
+    },
+    {
+        'tfOpName': 'Prod',
+        'dlOpName': 'prod',
+        'category': 'reduction',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number[]' }, {
+                'tfParamName': 'keep_dims',
+                'dlParamName': 'keepDims',
+                'type': 'bool'
+            }
         ]
     }
 ];
@@ -7048,6 +7205,21 @@ exports.json = [
                 'dlParamName': 'numOrSizeSplits',
                 'type': 'number',
                 'defaultValue': 1
+            }
+        ]
+    },
+    {
+        'tfOpName': 'SplitV',
+        'dlOpName': 'split',
+        'category': 'slice_join',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'numOrSizeSplits', 'type': 'number[]' },
+            {
+                'tfInputIndex': 2,
+                'dlParamName': 'axis',
+                'type': 'number',
+                'defaultValue': 0
             }
         ]
     }
@@ -7266,6 +7438,7 @@ var OperationMapper = (function () {
         var withControlFlow = false;
         var withDynamicShape = false;
         var placeholders = [];
+        var weights = [];
         var nodes = tfNodes.reduce(function (map, node) {
             map[node.name] = _this.mapNode(node);
             if (_this.isControlFlow(node))
@@ -7274,6 +7447,8 @@ var OperationMapper = (function () {
                 withDynamicShape = true;
             if (node.op === 'Placeholder')
                 placeholders.push(map[node.name]);
+            if (node.op === 'Const')
+                weights.push(map[node.name]);
             return map;
         }, {});
         var inputs = [];
@@ -7297,6 +7472,7 @@ var OperationMapper = (function () {
             nodes: nodes,
             inputs: inputs,
             outputs: outputs,
+            weights: weights,
             placeholders: placeholders,
             withControlFlow: withControlFlow,
             withDynamicShape: withDynamicShape
@@ -7434,7 +7610,7 @@ exports.OperationMapper = OperationMapper;
 },{"../data/compiled_api":10,"./executors/utils":31,"./op_list/arithmetic":32,"./op_list/basic_math":33,"./op_list/control":34,"./op_list/convolution":35,"./op_list/creation":36,"./op_list/dynamic":37,"./op_list/evaluation":38,"./op_list/graph":39,"./op_list/image":40,"./op_list/logical":41,"./op_list/matrices":42,"./op_list/normalization":43,"./op_list/reduction":44,"./op_list/slice_join":45,"./op_list/transformation":46}],49:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.5.9';
+var version = '0.6.5';
 exports.version = version;
 
 },{}],50:[function(require,module,exports){
@@ -9373,18 +9549,24 @@ var Engine = (function () {
         this.safeMode = safeMode;
         this.debugMode = debugMode;
         this.registeredVariables = {};
-        this.refCounter = new WeakMap();
         this.nextTapeNodeId = 0;
         this.numBytes = 0;
         this.numTensors = 0;
         this.numDataBuffers = 0;
+        this.profiling = false;
         this.gradientScopeCount = 0;
         this.customGradientDepth = 0;
         this.keepTensors = new Set();
+        this.tensorInfo = new WeakMap();
         this.activeScope = { track: [], name: 'default scope' };
         this.scopeStack = [this.activeScope];
         this.profiler = new profiler_1.Profiler(backend);
+        this.activeProfile =
+            { newBytes: 0, newTensors: 0, peakBytes: 0, kernels: [], result: null };
     }
+    Engine.prototype.moveData = function (dataId) {
+        this.write(dataId, this.readSync(dataId));
+    };
     Engine.prototype.tidy = function (nameOrFn, fn, gradMode) {
         var _this = this;
         if (gradMode === void 0) { gradMode = false; }
@@ -9436,6 +9618,8 @@ var Engine = (function () {
             return x;
         };
         var scopeName = this.activeScope.name;
+        var startingBytecount = this.numBytes;
+        var startingNumTensors = this.numTensors;
         this.scopedRun(function () { return _this.customGradientDepth++; }, function () { return _this.customGradientDepth--; }, function () {
             if (!_this.debugMode()) {
                 result = forwardFunc(_this.backend, saveFunc);
@@ -9457,10 +9641,25 @@ var Engine = (function () {
             }
             this.activeTape.push(tapeNode);
         }
+        if (this.profiling) {
+            this.activeProfile.kernels.push({
+                name: scopeName,
+                bytesAdded: this.numBytes - startingBytecount,
+                totalBytesSnapshot: this.numBytes,
+                tensorsAdded: this.numTensors - startingNumTensors,
+                totalTensorsSnapshot: this.numTensors,
+                inputShapes: Object.keys(inputs).map(function (key) { return inputs[key].shape; }),
+                outputShape: Array.isArray(result) ?
+                    result.map(function (item) { return item.shape; }) :
+                    result.shape
+            });
+        }
         return result;
     };
     Engine.prototype.registerTensor = function (a) {
-        var refCount = this.refCounter.has(a.dataId) ? this.refCounter.get(a.dataId) : 0;
+        var refCount = this.tensorInfo.has(a.dataId) ?
+            this.tensorInfo.get(a.dataId).refCount :
+            0;
         this.numTensors++;
         if (refCount === 0) {
             this.numDataBuffers++;
@@ -9468,9 +9667,10 @@ var Engine = (function () {
                 this.numBytes +=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.set(a.dataId, { backend: this.backend, dtype: a.dtype, shape: a.shape, refCount: 0 });
             this.backend.register(a.dataId, a.shape, a.dtype);
         }
-        this.refCounter.set(a.dataId, refCount + 1);
+        this.tensorInfo.get(a.dataId).refCount++;
         if (!(a instanceof tensor_1.Variable)) {
             this.track(a);
         }
@@ -9482,25 +9682,26 @@ var Engine = (function () {
         this.registeredVariables[v.name] = v;
     };
     Engine.prototype.disposeTensor = function (a) {
-        if (!this.refCounter.has(a.dataId)) {
+        if (!this.tensorInfo.has(a.dataId)) {
             return;
         }
         if (this.keepTensors.has(a.id)) {
             this.keepTensors.delete(a.id);
         }
         this.numTensors--;
-        var refCount = this.refCounter.get(a.dataId);
+        var refCount = this.tensorInfo.get(a.dataId).refCount;
         if (refCount <= 1) {
-            this.refCounter.delete(a.dataId);
-            this.backend.disposeData(a.dataId);
+            var info = this.tensorInfo.get(a.dataId);
+            info.backend.disposeData(a.dataId);
             this.numDataBuffers--;
             if (a.dtype !== 'complex64') {
                 this.numBytes -=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.delete(a.dataId);
         }
         else {
-            this.refCounter.set(a.dataId, refCount - 1);
+            this.tensorInfo.get(a.dataId).refCount--;
         }
     };
     Engine.prototype.disposeVariables = function () {
@@ -9516,6 +9717,23 @@ var Engine = (function () {
         info.numDataBuffers = this.numDataBuffers;
         info.numBytes = this.numBytes;
         return info;
+    };
+    Engine.prototype.profile = function (query) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startBytes, startNumTensors;
+            return __generator(this, function (_a) {
+                this.profiling = true;
+                startBytes = this.numBytes;
+                startNumTensors = this.numTensors;
+                this.activeProfile.kernels = [];
+                this.activeProfile.result = query();
+                this.profiling = false;
+                this.activeProfile.peakBytes = Math.max.apply(Math, this.activeProfile.kernels.map(function (d) { return d.totalBytesSnapshot; }));
+                this.activeProfile.newBytes = this.numBytes - startBytes;
+                this.activeProfile.newTensors = this.numTensors - startNumTensors;
+                return [2, this.activeProfile];
+            });
+        });
     };
     Engine.prototype.shouldRecord = function () {
         return this.activeTape != null && this.customGradientDepth === 0;
@@ -9661,13 +9879,21 @@ var Engine = (function () {
         };
     };
     Engine.prototype.write = function (dataId, values) {
+        var info = this.tensorInfo.get(dataId);
+        if (this.backend !== info.backend) {
+            info.backend.disposeData(dataId);
+            info.backend = this.backend;
+            this.backend.register(dataId, info.shape, info.dtype);
+        }
         this.backend.write(dataId, values);
     };
     Engine.prototype.readSync = function (dataId) {
-        return this.backend.readSync(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.readSync(dataId);
     };
     Engine.prototype.read = function (dataId) {
-        return this.backend.read(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.read(dataId);
     };
     Engine.prototype.fromPixels = function (pixels, numChannels) {
         return this.backend.fromPixels(pixels, numChannels);
@@ -9704,7 +9930,7 @@ function ones(shape) {
     return tensor_1.Tensor.make(shape, { values: values });
 }
 
-},{"./profiler":184,"./tape":186,"./tensor":187,"./tensor_util":189,"./util":194}],64:[function(require,module,exports){
+},{"./profiler":204,"./tape":206,"./tensor":207,"./tensor_util":209,"./util":214}],64:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -9720,7 +9946,6 @@ var TEST_EPSILON_FLOAT32 = 1e-3;
 var Environment = (function () {
     function Environment(features) {
         this.features = {};
-        this.engines = {};
         this.registry = {};
         if (features != null) {
             this.features = features;
@@ -9736,10 +9961,11 @@ var Environment = (function () {
         if (!(backendName in exports.ENV.registry)) {
             throw new Error("Backend name '" + backendName + "' not found in registry");
         }
-        exports.ENV.initBackend(backendName, safeMode);
+        exports.ENV.engine.backend = exports.ENV.findBackend(backendName);
+        exports.ENV.backendName = backendName;
     };
     Environment.getBackend = function () {
-        exports.ENV.initDefaultBackend();
+        exports.ENV.initEngine();
         return exports.ENV.backendName;
     };
     Environment.disposeVariables = function () {
@@ -9747,6 +9973,9 @@ var Environment = (function () {
     };
     Environment.memory = function () {
         return exports.ENV.engine.memory();
+    };
+    Environment.profile = function (f) {
+        return exports.ENV.engine.profile(f);
     };
     Environment.tidy = function (nameOrFn, fn, gradMode) {
         if (gradMode === void 0) { gradMode = false; }
@@ -9803,6 +10032,18 @@ var Environment = (function () {
         else if (feature === 'IS_CHROME') {
             return environment_util_1.isChrome();
         }
+        else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+            return false;
+        }
+        else if (feature === 'WEBGL_CONV_IM2COL') {
+            return false;
+        }
+        else if (feature === 'WEBGL_PAGING_ENABLED') {
+            return this.get('IS_BROWSER') && !this.get('PROD');
+        }
+        else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
+            return environment_util_1.getWebGLMaxTextureSize(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+        }
         else if (feature === 'IS_TEST') {
             return false;
         }
@@ -9812,9 +10053,6 @@ var Environment = (function () {
         else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
             var webGLVersion = this.get('WEBGL_VERSION');
             if (webGLVersion === 0) {
-                return 0;
-            }
-            if (webGLVersion > 0) {
                 return 0;
             }
             return environment_util_1.getWebGLDisjointQueryTimerVersion(webGLVersion, this.get('IS_BROWSER'));
@@ -9844,6 +10082,10 @@ var Environment = (function () {
         else if (feature === 'WEBGL_FENCE_API_ENABLED') {
             return environment_util_1.isWebGLFenceEnabled(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
         }
+        else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
+            var useUniforms = this.get('WEBGL_RENDER_FLOAT32_ENABLED');
+            return useUniforms ? 4 : 0;
+        }
         else if (feature === 'TEST_EPSILON') {
             return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
                 TEST_EPSILON_FLOAT16;
@@ -9851,6 +10093,12 @@ var Environment = (function () {
         else if (feature === 'EPSILON') {
             return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
                 EPSILON_FLOAT16;
+        }
+        else if (feature === 'PROD') {
+            return false;
+        }
+        else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
+            return !this.get('PROD');
         }
         throw new Error("Unknown feature " + feature + ".");
     };
@@ -9861,20 +10109,6 @@ var Environment = (function () {
         this.features = environment_util_1.getFeaturesFromURL();
         if (this.globalEngine != null) {
             this.globalEngine = null;
-        }
-    };
-    Environment.prototype.initBackend = function (backendName, safeMode) {
-        var _this = this;
-        if (safeMode === void 0) { safeMode = false; }
-        this.backendName = backendName;
-        if (this.engines[backendName]) {
-            this.globalEngine = this.engines[backendName];
-        }
-        else {
-            var backend = this.findBackend(backendName);
-            this.globalEngine =
-                new engine_1.Engine(backend, safeMode, function () { return _this.get('DEBUG'); });
-            this.engines[backendName] = this.globalEngine;
         }
     };
     Object.defineProperty(Environment.prototype, "backend", {
@@ -9902,6 +10136,7 @@ var Environment = (function () {
         }
         try {
             var backend = factory();
+            backend.setDataMover({ moveData: function (dataId) { return _this.engine.moveData(dataId); } });
             this.registry[name] = { backend: backend, priority: priority };
             return true;
         }
@@ -9917,21 +10152,22 @@ var Environment = (function () {
         }
         this.registry[name].backend.dispose();
         delete this.registry[name];
-        if (name in this.engines) {
-            delete this.engines[name];
-        }
     };
     Object.defineProperty(Environment.prototype, "engine", {
         get: function () {
-            this.initDefaultBackend();
+            this.initEngine();
             return this.globalEngine;
         },
         enumerable: true,
         configurable: true
     });
-    Environment.prototype.initDefaultBackend = function () {
+    Environment.prototype.initEngine = function () {
+        var _this = this;
         if (this.globalEngine == null) {
-            this.initBackend(this.get('BACKEND'), false);
+            this.backendName = this.get('BACKEND');
+            var backend = this.findBackend(this.backendName);
+            this.globalEngine =
+                new engine_1.Engine(backend, false, function () { return _this.get('DEBUG'); });
         }
     };
     return Environment;
@@ -9961,7 +10197,7 @@ function getOrMakeEnvironment() {
 exports.ENV = getOrMakeEnvironment();
 
 }).call(this,require('_process'))
-},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":187,"./tensor_util":189,"_process":270}],65:[function(require,module,exports){
+},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":207,"./tensor_util":209,"_process":294}],65:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Type;
@@ -9971,14 +10207,23 @@ var Type;
     Type[Type["STRING"] = 2] = "STRING";
 })(Type = exports.Type || (exports.Type = {}));
 exports.URL_PROPERTIES = [
-    { name: 'DEBUG', type: Type.BOOLEAN }, { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'DEBUG', type: Type.BOOLEAN },
+    { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN },
+    { name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN },
+    { name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER },
+    { name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN },
     { name: 'WEBGL_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_RENDER_FLOAT32_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DOWNLOAD_FLOAT_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_FENCE_API_ENABLED', type: Type.BOOLEAN },
-    { name: 'BACKEND', type: Type.STRING }, { name: 'EPSILON', type: Type.NUMBER }
+    { name: 'WEBGL_SIZE_UPLOAD_UNIFORM', type: Type.NUMBER },
+    { name: 'BACKEND', type: Type.STRING },
+    { name: 'EPSILON', type: Type.NUMBER },
+    { name: 'PROD', type: Type.BOOLEAN },
+    { name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN },
 ];
 function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     var gl;
@@ -9995,6 +10240,15 @@ function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     return false;
 }
 exports.isWebGLVersionEnabled = isWebGLVersionEnabled;
+var MAX_TEXTURE_SIZE;
+function getWebGLMaxTextureSize(webGLVersion, isBrowser) {
+    if (MAX_TEXTURE_SIZE == null) {
+        var gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+        MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    }
+    return MAX_TEXTURE_SIZE;
+}
+exports.getWebGLMaxTextureSize = getWebGLMaxTextureSize;
 function getWebGLDisjointQueryTimerVersion(webGLVersion, isBrowser) {
     if (webGLVersion === 0) {
         return 0;
@@ -10183,6 +10437,7 @@ exports.tidy = environment_1.Environment.tidy;
 exports.keep = environment_1.Environment.keep;
 exports.dispose = environment_1.Environment.dispose;
 exports.time = environment_1.Environment.time;
+exports.profile = environment_1.Environment.profile;
 
 },{"./environment":64,"./gradients":67}],67:[function(require,module,exports){
 "use strict";
@@ -10297,7 +10552,7 @@ function checkGrads(grads) {
     }
 }
 
-},{"./environment":64,"./tensor":187,"./util":194}],68:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],68:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -10312,6 +10567,8 @@ exports.environment = environment;
 var environment_1 = require("./environment");
 var io = require("./io/io");
 exports.io = io;
+var math = require("./math");
+exports.math = math;
 var serialization = require("./serialization");
 exports.serialization = serialization;
 var tensor_1 = require("./tensor");
@@ -10358,10 +10615,12 @@ exports.setBackend = environment_1.Environment.setBackend;
 exports.getBackend = environment_1.Environment.getBackend;
 exports.disposeVariables = environment_1.Environment.disposeVariables;
 exports.memory = environment_1.Environment.memory;
+var backend_1 = require("./kernels/backend");
+exports.DataStorage = backend_1.DataStorage;
 var ops = require("./ops/ops");
 tensor_1.setOpHandler(ops);
 
-},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend_cpu":80,"./kernels/backend_webgl":82,"./ops/loss_ops":150,"./ops/ops":157,"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer":180,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183,"./serialization":185,"./tensor":187,"./test_util":191,"./train":192,"./types":193,"./util":194,"./version":195,"./webgl":196}],69:[function(require,module,exports){
+},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend":80,"./kernels/backend_cpu":81,"./kernels/backend_webgl":83,"./math":145,"./ops/loss_ops":165,"./ops/ops":172,"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer":200,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203,"./serialization":205,"./tensor":207,"./test_util":211,"./train":212,"./types":213,"./util":214,"./version":215,"./webgl":216}],69:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10853,7 +11112,7 @@ function browserHTTPRequest(path, requestInit) {
 }
 exports.browserHTTPRequest = browserHTTPRequest;
 
-},{"../util":194,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11434,7 +11693,7 @@ function getModelArtifactsInfoForJSON(modelArtifacts) {
 exports.getModelArtifactsInfoForJSON = getModelArtifactsInfoForJSON;
 
 }).call(this,require("buffer").Buffer)
-},{"../ops/tensor_ops":171,"../util":194,"./types":78,"buffer":251}],74:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214,"./types":78,"buffer":275}],74:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11682,7 +11941,7 @@ if (environment_1.ENV.get('IS_BROWSER')) {
     }
 }
 
-},{"../environment":64,"../util":194,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
+},{"../environment":64,"../util":214,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11886,7 +12145,7 @@ function moveModel(sourceURL, destURL) {
 }
 exports.moveModel = moveModel;
 
-},{"../util":194,"./router_registry":77}],76:[function(require,module,exports){
+},{"../util":214,"./router_registry":77}],76:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -12195,7 +12454,34 @@ function loadWeights(manifest, filePathPrefix, weightNames, requestOptions) {
 }
 exports.loadWeights = loadWeights;
 
-},{"../util":194,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var DataStorage = (function () {
+    function DataStorage(dataMover) {
+        this.dataMover = dataMover;
+        this.data = new WeakMap();
+    }
+    DataStorage.prototype.get = function (dataId) {
+        if (!this.data.has(dataId)) {
+            this.dataMover.moveData(dataId);
+        }
+        return this.data.get(dataId);
+    };
+    DataStorage.prototype.set = function (dataId, value) {
+        this.data.set(dataId, value);
+    };
+    DataStorage.prototype.has = function (dataId) {
+        return this.data.has(dataId);
+    };
+    DataStorage.prototype.delete = function (dataId) {
+        return this.data.delete(dataId);
+    };
+    return DataStorage;
+}());
+exports.DataStorage = DataStorage;
+
+},{}],81:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -12241,14 +12527,17 @@ var axis_util = require("../ops/axis_util");
 var broadcast_util = require("../ops/broadcast_util");
 var concat_util = require("../ops/concat_util");
 var erf_util = require("../ops/erf_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var ops = require("../ops/ops");
 var ops_1 = require("../ops/ops");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var selu_util = require("../ops/selu_util");
 var slice_util_1 = require("../ops/slice_util");
 var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -12258,12 +12547,14 @@ var where_impl_1 = require("./where_impl");
 var MathBackendCPU = (function () {
     function MathBackendCPU() {
         this.blockSize = 48;
-        this.data = new WeakMap();
         this.firstUse = true;
         if (environment_1.ENV.get('IS_BROWSER')) {
             this.canvas = document.createElement('canvas');
         }
     }
+    MathBackendCPU.prototype.setDataMover = function (dataMover) {
+        this.data = new backend_1.DataStorage(dataMover);
+    };
     MathBackendCPU.prototype.register = function (dataId, shape, dtype) {
         if (this.firstUse) {
             this.firstUse = false;
@@ -12289,7 +12580,6 @@ var MathBackendCPU = (function () {
         if (values == null) {
             throw new Error('MathBackendCPU.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         this.data.get(dataId).values = values;
     };
     MathBackendCPU.prototype.fromPixels = function (pixels, numChannels) {
@@ -12352,7 +12642,6 @@ var MathBackendCPU = (function () {
         });
     };
     MathBackendCPU.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var _a = this.data.get(dataId), dtype = _a.dtype, complexTensors = _a.complexTensors;
         if (dtype === 'complex64') {
             var realValues = complexTensors.real.dataSync();
@@ -12386,13 +12675,6 @@ var MathBackendCPU = (function () {
         return {
             unreliable: true
         };
-    };
-    MathBackendCPU.prototype.throwIfNoData = function (dataId) {
-        if (!this.data.has(dataId)) {
-            throw new Error("CPU backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
     };
     MathBackendCPU.prototype.complex = function (real, imag) {
         var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
@@ -12613,6 +12895,24 @@ var MathBackendCPU = (function () {
                 sum += aVals[offset + j];
             }
             vals[i] = sum;
+        }
+        return result;
+    };
+    MathBackendCPU.prototype.prod = function (x, axes) {
+        this.assertNotComplex(x, 'sum');
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var resultDtype = types_1.upcastType(x.dtype, 'int32');
+        var result = ops.zeros(outShape, resultDtype);
+        var reduceSize = util.sizeFromShape(reduceShape);
+        var vals = result.dataSync();
+        var aVals = x.dataSync();
+        for (var i = 0; i < vals.length; ++i) {
+            var offset = i * reduceSize;
+            var prod = 1;
+            for (var j = 0; j < reduceSize; ++j) {
+                prod *= aVals[offset + j];
+            }
+            vals[i] = prod;
         }
         return result;
     };
@@ -13109,11 +13409,19 @@ var MathBackendCPU = (function () {
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
     MathBackendCPU.prototype.abs = function (x) {
-        this.assertNotComplex(x, 'abs');
         var resultValues = new Float32Array(x.size);
         var values = x.dataSync();
-        for (var i = 0; i < values.length; ++i) {
-            resultValues[i] = Math.abs(values[i]);
+        if (x.dtype === 'complex64') {
+            for (var i = 0; i < x.size; ++i) {
+                var real = values[i * 2];
+                var imag = values[i * 2 + 1];
+                resultValues[i] = Math.sqrt(real * real + imag * imag);
+            }
+        }
+        else {
+            for (var i = 0; i < values.length; ++i) {
+                resultValues[i] = Math.abs(values[i]);
+            }
         }
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
@@ -13672,8 +13980,10 @@ var MathBackendCPU = (function () {
         this.assertNotComplex(x, 'pool');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var y = ops.buffer(convInfo.outShape, 'float32');
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
@@ -13684,16 +13994,16 @@ var MathBackendCPU = (function () {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
                     var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
                         var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var minMaxValue = initialValue;
                         var avgValue = 0;
                         var count = 0;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var pixel = x.get(b, xR, xC, d);
                                 if ((poolType === 'max' && pixel > minMaxValue)) {
                                     minMaxValue = pixel;
@@ -13721,30 +14031,38 @@ var MathBackendCPU = (function () {
         var maxPositions = ops.buffer(convInfo.outShape, 'int32');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
-                    var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMin = xRCorner;
+                    while (xRMin < 0) {
+                        xRMin += dilationHeight;
+                    }
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
-                        var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMin = xCCorner;
+                        while (xCMin < 0) {
+                            xCMin += dilationWidth;
+                        }
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var maxValue = Number.NEGATIVE_INFINITY;
                         var maxPosition = -1;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
                             var wR = xR - xRCorner;
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var wC = xC - xCCorner;
                                 var pixel = x.get(b, xR, xC, d);
                                 if (pixel > maxValue) {
                                     maxValue = pixel;
-                                    maxPosition = wR * filterWidth + wC;
+                                    maxPosition = wR * effectiveFilterWidth + wC;
                                 }
                             }
                         }
@@ -13760,10 +14078,12 @@ var MathBackendCPU = (function () {
         var maxPositions = this.maxPoolPositions(x, convInfo);
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
@@ -13772,21 +14092,21 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
                                     continue;
                                 }
-                                var maxPos = filterHeight * filterWidth - 1 -
-                                    maxPositions.get(b, dyR, dyC, d);
-                                var curPos = wR * filterWidth + wC;
+                                var maxPos = effectiveFilterHeight * effectiveFilterWidth -
+                                    1 - maxPositions.get(b, dyR, dyC, d);
+                                var curPos = wR * effectiveFilterWidth + wC;
                                 var mask = maxPos === curPos ? 1 : 0;
                                 if (mask === 0) {
                                     continue;
@@ -13808,8 +14128,12 @@ var MathBackendCPU = (function () {
         var strideWidth = convInfo.strideWidth;
         var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         var avgMultiplier = 1 / (filterHeight * filterWidth);
         for (var b = 0; b < convInfo.batchSize; ++b) {
@@ -13819,13 +14143,13 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
@@ -13855,7 +14179,8 @@ var MathBackendCPU = (function () {
     MathBackendCPU.prototype.resizeBilinear = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeBilinear');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var result = new Float32Array(util.sizeFromShape([batch, newHeight, newWidth, numChannels]));
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13864,37 +14189,46 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var outputIdx = 0;
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
         for (var b = 0; b < batch; b++) {
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceRowFloor = Math.floor(sourceFracRow);
+                var rowFrac = sourceFracRow - sourceRowFloor;
+                var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
+                var topRowOffset = b * x.strides[0] + sourceRowFloor * x.strides[1];
+                var botRowOffset = b * x.strides[0] + sourceRowCeil * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceColFloor = Math.floor(sourceFracCol);
+                    var colFrac = sourceFracCol - sourceColFloor;
+                    var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
+                    var topLeftOffest = topRowOffset + sourceColFloor * x.strides[2];
+                    var botLeftOffset = botRowOffset + sourceColFloor * x.strides[2];
+                    var topRightOffset = topRowOffset + +sourceColCeil * x.strides[2];
+                    var botRightOffest = botRowOffset + sourceColCeil * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceRowFloor = Math.floor(sourceFracRow);
-                        var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
-                        var sourceColFloor = Math.floor(sourceFracCol);
-                        var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
-                        var topLeft = x.get(b, sourceRowFloor, sourceColFloor, d);
-                        var bottomLeft = x.get(b, sourceRowCeil, sourceColFloor, d);
-                        var topRight = x.get(b, sourceRowFloor, sourceColCeil, d);
-                        var bottomRight = x.get(b, sourceRowCeil, sourceColCeil, d);
-                        var rowFrac = sourceFracRow - sourceRowFloor;
-                        var colFrac = sourceFracCol - sourceColFloor;
+                        var topLeft = xValues[topLeftOffest + d];
+                        var bottomLeft = xValues[botLeftOffset + d];
+                        var topRight = xValues[topRightOffset + d];
+                        var bottomRight = xValues[botRightOffest + d];
                         var top_1 = topLeft + (topRight - topLeft) * colFrac;
                         var bottom = bottomLeft + (bottomRight - bottomLeft) * colFrac;
                         var newValue = top_1 + (bottom - top_1) * rowFrac;
-                        output.set(newValue, b, r, c, d);
+                        result[outputIdx++] = newValue;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(result, [batch, newHeight, newWidth, numChannels]);
     };
     MathBackendCPU.prototype.resizeBilinearBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeBilinearBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13905,11 +14239,16 @@ var MathBackendCPU = (function () {
         ];
         var heightScale = effectiveXSize[0] / effectiveYSize[0];
         var widthScale = effectiveXSize[1] / effectiveYSize[1];
+        var dyValues = dy.dataSync();
+        var offset = 0;
         for (var b = 0; b < batch; b++) {
+            var bOffset = b * x.strides[0];
             for (var r = 0; r < yHeight; r++) {
                 var dxR = r * heightScale;
                 var topDxRIndex = Math.floor(dxR);
                 var bottomDxRIndex = Math.min(Math.ceil(dxR), xHeight - 1);
+                var topDxROffset = bOffset + topDxRIndex * x.strides[1];
+                var bottomDxROffset = bOffset + bottomDxRIndex * x.strides[1];
                 var dxRLerp = dxR - topDxRIndex;
                 var inverseDxRLerp = 1.0 - dxRLerp;
                 for (var c = 0; c < yWidth; c++) {
@@ -13918,30 +14257,33 @@ var MathBackendCPU = (function () {
                     var rightDxCIndex = Math.min(Math.ceil(dxC), xWidth - 1);
                     var dxCLerp = dxC - leftDxCIndex;
                     var inverseDxCLerp = 1.0 - dxCLerp;
+                    var topLeftRCOffset = topDxROffset + leftDxCIndex * x.strides[2];
+                    var topRightRCOffset = topDxROffset + rightDxCIndex * x.strides[2];
+                    var bottomLeftRCOffset = bottomDxROffset + leftDxCIndex * x.strides[2];
+                    var bottomRightRCOffset = bottomDxROffset + rightDxCIndex * x.strides[2];
+                    var inverseDxRLerpTimesInverseDxCLerp = inverseDxRLerp * inverseDxCLerp;
+                    var inverseDxRLerpTimesDxCLerp = inverseDxRLerp * dxCLerp;
+                    var dxRLerpTimesInverseDxCLerp = dxRLerp * inverseDxCLerp;
+                    var dxRLerpTimesDxCLerp = dxRLerp * dxCLerp;
                     for (var d = 0; d < depth; d++) {
-                        var dyVal = dy.get(b, r, c, d);
-                        var topLeft = output.get(b, topDxRIndex, leftDxCIndex, d);
-                        topLeft += dyVal * inverseDxRLerp * inverseDxCLerp;
-                        output.set(topLeft, b, topDxRIndex, leftDxCIndex, d);
-                        var topRight = output.get(b, topDxRIndex, rightDxCIndex, d);
-                        topRight += dyVal * inverseDxRLerp * dxCLerp;
-                        output.set(topRight, b, topDxRIndex, rightDxCIndex, d);
-                        var bottomLeft = output.get(b, bottomDxRIndex, leftDxCIndex, d);
-                        bottomLeft += dyVal * dxRLerp * inverseDxCLerp;
-                        output.set(bottomLeft, b, bottomDxRIndex, leftDxCIndex, d);
-                        var bottomRight = output.get(b, bottomDxRIndex, rightDxCIndex, d);
-                        bottomRight += dyVal * dxRLerp * dxCLerp;
-                        output.set(bottomRight, b, bottomDxRIndex, rightDxCIndex, d);
+                        var dyVal = dyValues[offset++];
+                        output[topLeftRCOffset + d] +=
+                            dyVal * inverseDxRLerpTimesInverseDxCLerp;
+                        output[topRightRCOffset + d] += dyVal * inverseDxRLerpTimesDxCLerp;
+                        output[bottomLeftRCOffset + d] +=
+                            dyVal * dxRLerpTimesInverseDxCLerp;
+                        output[bottomRightRCOffset + d] += dyVal * dxRLerpTimesDxCLerp;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, [batch, xWidth, xHeight, depth], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighbor = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeNearestNeighbor');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var output = new Float32Array(batch * newHeight * newWidth * numChannels);
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13950,29 +14292,36 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
+        var outputOffset = 0;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                    Math.floor(sourceFracRow));
+                var rowOffset = batchOffset + sourceNearestRow * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
+                        Math.floor(sourceFracCol));
+                    var colOffset = rowOffset + sourceNearestCol * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                            Math.floor(sourceFracRow));
-                        var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
-                            Math.floor(sourceFracCol));
-                        var newValue = x.get(b, sourceNearestRow, sourceNearestCol, d);
-                        output.set(newValue, b, r, c, d);
+                        var newVal = xValues[colOffset + d];
+                        output[outputOffset++] = newVal;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(output, [batch, newHeight, newWidth, numChannels], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighborBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeNearestNeighborBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
+        var dyValues = dy.dataSync();
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13988,41 +14337,49 @@ var MathBackendCPU = (function () {
         var winHeight = (Math.ceil(invHeightScale) * 2) + 2;
         var winWidth = (Math.ceil(invWidthScale) * 2) + 2;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < xHeight; r++) {
+                var rowOffset = batchOffset + r * x.strides[1];
+                var startRLerp = Math.floor(r * invHeightScale);
+                var startDyR = Math.floor(startRLerp - (winHeight / 2));
                 for (var c = 0; c < xWidth; c++) {
-                    var startRLerp = Math.floor(r * invHeightScale);
-                    var startDyR = Math.floor(startRLerp - (winHeight / 2));
+                    var colOffset = rowOffset + c * x.strides[2];
                     var startCLerp = Math.floor(c * invWidthScale);
                     var startDyC = Math.floor(startCLerp - (winWidth / 2));
                     for (var d = 0; d < depth; d++) {
                         var accum = 0;
-                        for (var dyROffset = 0; dyROffset < winHeight; dyROffset++) {
-                            var dyR = dyROffset + startDyR;
+                        for (var dyRIndex = 0; dyRIndex < winHeight; dyRIndex++) {
+                            var dyR = dyRIndex + startDyR;
                             if (dyR < 0 || dyR >= yHeight) {
                                 continue;
                             }
-                            for (var dyCOffSet = 0; dyCOffSet < winWidth; dyCOffSet++) {
-                                var dyC = dyCOffSet + startDyC;
+                            var dyROffset = batchOffset + dyR * dy.strides[1];
+                            var sourceFracRow = dyR * heightScale;
+                            var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                                Math.floor(sourceFracRow));
+                            if (r !== sourceNearestRow) {
+                                continue;
+                            }
+                            for (var dyCIndex = 0; dyCIndex < winWidth; dyCIndex++) {
+                                var dyC = dyCIndex + startDyC;
                                 if (dyC < 0 || dyC >= yWidth) {
                                     continue;
                                 }
-                                var sourceFracRow = effectiveXSize[0] * (dyR / effectiveYSize[0]);
-                                var sourceFracCol = effectiveXSize[1] * (dyC / effectiveYSize[1]);
-                                var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                                    Math.floor(sourceFracRow));
+                                var dyCOffset = dyROffset + dyC * dy.strides[2];
+                                var sourceFracCol = dyC * widthScale;
                                 var sourceNearestCol = Math.min(xWidth - 1, alignCorners ? Math.round(sourceFracCol) :
                                     Math.floor(sourceFracCol));
-                                if (r === sourceNearestRow && c === sourceNearestCol) {
-                                    accum += dy.get(b, dyR, dyC, d);
+                                if (c === sourceNearestCol) {
+                                    accum += dyValues[dyCOffset + d];
                                 }
                             }
                         }
-                        output.set(accum, b, r, c, d);
+                        output[colOffset + d] = accum;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, x.shape, x.dtype);
     };
     MathBackendCPU.prototype.batchNormalization = function (x, mean, variance, varianceEpsilon, scale, offset) {
         this.assertNotComplex([x, mean, variance, scale, offset], 'batchNormalization');
@@ -14162,6 +14519,61 @@ var MathBackendCPU = (function () {
         var scoresVals = scores.dataSync();
         return non_max_suppression_impl_1.nonMaxSuppressionImpl(boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
     };
+    MathBackendCPU.prototype.fft = function (input) {
+        if (input.shape[0] !== 1) {
+            throw new Error("tf.fft() on CPU only supports vectors.");
+        }
+        var input1D = input.as1D();
+        var n = input1D.size;
+        if (this.isExponentOf2(n)) {
+            return this.fftRadix2(input1D, n).as2D(input.shape[0], input.shape[1]);
+        }
+        else {
+            var data = input.dataSync();
+            var rawOutput = this.fourierTransformByMatmul(data, n);
+            var output = complex_util.splitRealAndImagArrays(rawOutput);
+            return ops.complex(output.real, output.imag)
+                .as2D(input.shape[0], input.shape[1]);
+        }
+    };
+    MathBackendCPU.prototype.isExponentOf2 = function (size) {
+        return (size & size - 1) === 0;
+    };
+    MathBackendCPU.prototype.fftRadix2 = function (input, size) {
+        if (size === 1) {
+            return input;
+        }
+        var data = input.dataSync();
+        var half = size / 2;
+        var evenComplex = complex_util.complexWithEvenIndex(data);
+        var evenTensor = ops.complex(evenComplex.real, evenComplex.imag).as1D();
+        var oddComplex = complex_util.complexWithOddIndex(data);
+        var oddTensor = ops.complex(oddComplex.real, oddComplex.imag).as1D();
+        evenTensor = this.fftRadix2(evenTensor, half);
+        oddTensor = this.fftRadix2(oddTensor, half);
+        var e = complex_util.exponents(size);
+        var exponent = ops.complex(e.real, e.imag).mul(oddTensor);
+        var addPart = evenTensor.add(exponent);
+        var subPart = evenTensor.sub(exponent);
+        var realTensor = ops.real(addPart).concat(ops.real(subPart));
+        var imagTensor = ops.imag(addPart).concat(ops.imag(subPart));
+        return ops.complex(realTensor, imagTensor).as1D();
+    };
+    MathBackendCPU.prototype.fourierTransformByMatmul = function (data, size) {
+        var ret = new Float32Array(size * 2);
+        for (var r = 0; r < size; r++) {
+            var real = 0.0;
+            var imag = 0.0;
+            for (var c = 0; c < size; c++) {
+                var e = complex_util.exponent(r * c, size);
+                var term = complex_util.getComplexWithIndex(data, c);
+                real += term.real * e.real - term.imag * e.imag;
+                imag += term.real * e.imag + term.imag * e.real;
+            }
+            complex_util.assignToTypedArray(ret, real, imag, r);
+        }
+        return ret;
+    };
     MathBackendCPU.prototype.depthToSpace = function (x, blockSize, dataFormat) {
         util.assert(dataFormat === 'NHWC', "Only NHWC dataFormat supported on CPU for depthToSpace. Got " + dataFormat);
         util.assert(blockSize > 1, "blockSize should be > 1 for depthToSpace, but was: " + blockSize);
@@ -14295,9 +14707,7 @@ var MathBackendCPU = (function () {
             var heightScale = (cropHeight > 1) ?
                 (y2 - y1) * (imageHeight - 1) / (cropHeight - 1) :
                 0;
-            var widthScale = (cropWidth > 1) ?
-                (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) :
-                0;
+            var widthScale = (cropWidth > 1) ? (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) : 0;
             for (var y = 0; y < cropHeight; y++) {
                 var yInd = (cropHeight > 1) ?
                     y1 * (imageHeight - 1) + y * (heightScale) :
@@ -14305,8 +14715,7 @@ var MathBackendCPU = (function () {
                 if (yInd < 0 || yInd > imageHeight - 1) {
                     for (var x = 0; x < cropWidth; x++) {
                         for (var c = 0; c < numChannels; c++) {
-                            var ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = extrapolationValue;
                         }
                     }
@@ -14322,8 +14731,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14346,8 +14754,7 @@ var MathBackendCPU = (function () {
                             var bottomRight = imageVals[ind];
                             var top_2 = topLeft + (topRight - topLeft) * xLerp;
                             var bottom = bottomLeft + (bottomRight - bottomLeft) * xLerp;
-                            ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = top_2 + ((bottom - top_2) * yLerp);
                         }
                     }
@@ -14359,8 +14766,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14368,10 +14774,9 @@ var MathBackendCPU = (function () {
                         var closestX = Math.round(xInd);
                         var closestY = Math.round(yInd);
                         for (var c = 0; c < numChannels; c++) {
-                            var inInd = c + closestX * inStride[2]
-                                + closestY * inStride[1] + bInd * inStride[0];
-                            var outInd = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var inInd = c + closestX * inStride[2] +
+                                closestY * inStride[1] + bInd * inStride[0];
+                            var outInd = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[outInd] = imageVals[inInd];
                         }
                     }
@@ -14380,12 +14785,84 @@ var MathBackendCPU = (function () {
         }
         return output.toTensor();
     };
+    MathBackendCPU.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        return this.scatter(sparseIndices, sparseValues, outputShape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        if (numSlices === 0) {
+            return ops_1.tensor([], resultShape, x.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer([numSlices, sliceSize], x.dtype);
+        var indicesData = indices.dataSync();
+        var xData = x.dataSync();
+        for (var i = 0; i < numSlices; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                flattenIndex += dim * strides[j];
+                index.push(dim);
+            }
+            if (flattenIndex < 0 || flattenIndex >= x.size / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + x.shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                buffer.values[i * sliceSize + k] = xData[flattenIndex * sliceSize + k];
+            }
+        }
+        return buffer.toTensor().reshape(resultShape);
+    };
+    MathBackendCPU.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var defaultValue = ops_1.scalar(0);
+        var sumDupeIndices = true;
+        return this.scatter(indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.scatter = function (indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices) {
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var indicesData = indices.dataSync();
+        var updatesData = updates.dataSync();
+        if (outputSize === 0) {
+            return ops_1.tensor([], shape, updates.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer(flattenShape, updates.dtype);
+        buffer.values.fill(defaultValue.dataSync()[0]);
+        for (var i = 0; i < numUpdates; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                index.push(dim);
+                flattenIndex += dim * strides[j];
+            }
+            if (flattenIndex < 0 || flattenIndex >= outputSize / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                if (sumDupeIndices) {
+                    buffer.values[flattenIndex * sliceSize + k] +=
+                        updatesData[i * sliceSize + k];
+                }
+                else {
+                    buffer.values[flattenIndex * sliceSize + k] = updates.rank === 0 ?
+                        updatesData[0] :
+                        updatesData[i * sliceSize + k];
+                }
+            }
+        }
+        return buffer.toTensor().reshape(shape);
+    };
     return MathBackendCPU;
 }());
 exports.MathBackendCPU = MathBackendCPU;
 environment_1.ENV.registerBackend('cpu', function () { return new MathBackendCPU(); }, 1, tensor_1.setTensorTracker);
 
-},{"../environment":64,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/broadcast_util":139,"../ops/concat_util":143,"../ops/erf_util":146,"../ops/ops":157,"../ops/selu_util":166,"../ops/slice_util":168,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./where_impl":132,"seedrandom":282}],81:[function(require,module,exports){
+},{"../environment":64,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/broadcast_util":151,"../ops/concat_util":155,"../ops/erf_util":159,"../ops/gather_nd_util":161,"../ops/ops":172,"../ops/scatter_nd_util":180,"../ops/selu_util":183,"../ops/slice_util":185,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./where_impl":143,"seedrandom":306}],82:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -14431,7 +14908,7 @@ function reshapeTensor(x, shape) {
 }
 exports.reshapeTensor = reshapeTensor;
 
-},{"../ops/tensor_ops":171,"../tensor":187,"../util":194}],82:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../tensor":207,"../util":214}],83:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14475,7 +14952,9 @@ var log_1 = require("../log");
 var array_ops_util = require("../ops/array_ops_util");
 var axis_util = require("../ops/axis_util");
 var concat_util_1 = require("../ops/concat_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var reduce_util = require("../ops/reduce_util");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var segment_util = require("../ops/segment_util");
 var slice_util_1 = require("../ops/slice_util");
 var softmax_1 = require("../ops/softmax");
@@ -14484,6 +14963,7 @@ var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util_1 = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -14492,31 +14972,39 @@ var topk_impl_1 = require("./topk_impl");
 var argminmax_gpu_1 = require("./webgl/argminmax_gpu");
 var avg_pool_backprop_gpu_1 = require("./webgl/avg_pool_backprop_gpu");
 var batchnorm_gpu_1 = require("./webgl/batchnorm_gpu");
+var batchnorm_packed_gpu_1 = require("./webgl/batchnorm_packed_gpu");
 var binaryop_complex_gpu = require("./webgl/binaryop_complex_gpu");
 var binaryop_complex_gpu_1 = require("./webgl/binaryop_complex_gpu");
 var binaryop_gpu = require("./webgl/binaryop_gpu");
 var binaryop_gpu_1 = require("./webgl/binaryop_gpu");
 var clip_gpu_1 = require("./webgl/clip_gpu");
+var complex_abs_gpu_1 = require("./webgl/complex_abs_gpu");
 var concat_gpu_1 = require("./webgl/concat_gpu");
 var conv_backprop_gpu_1 = require("./webgl/conv_backprop_gpu");
 var conv_backprop_gpu_depthwise_1 = require("./webgl/conv_backprop_gpu_depthwise");
 var conv_gpu_1 = require("./webgl/conv_gpu");
-var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var conv_gpu_depthwise_1 = require("./webgl/conv_gpu_depthwise");
+var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var cumsum_gpu_1 = require("./webgl/cumsum_gpu");
 var depth_to_space_gpu_1 = require("./webgl/depth_to_space_gpu");
 var encode_float_gpu_1 = require("./webgl/encode_float_gpu");
+var fft_gpu = require("./webgl/fft_gpu");
+var fft_gpu_1 = require("./webgl/fft_gpu");
 var from_pixels_gpu_1 = require("./webgl/from_pixels_gpu");
 var gather_gpu_1 = require("./webgl/gather_gpu");
+var gather_nd_gpu_1 = require("./webgl/gather_nd_gpu");
 var gpgpu_context_1 = require("./webgl/gpgpu_context");
 var gpgpu_math = require("./webgl/gpgpu_math");
 var gpgpu_util = require("./webgl/gpgpu_util");
+var im2col_gpu_1 = require("./webgl/im2col_gpu");
 var lrn_gpu_1 = require("./webgl/lrn_gpu");
 var lrn_grad_gpu_1 = require("./webgl/lrn_grad_gpu");
 var max_pool_backprop_gpu_1 = require("./webgl/max_pool_backprop_gpu");
 var mulmat_gpu_1 = require("./webgl/mulmat_gpu");
+var mulmat_packed_gpu_1 = require("./webgl/mulmat_packed_gpu");
 var multinomial_gpu_1 = require("./webgl/multinomial_gpu");
 var onehot_gpu_1 = require("./webgl/onehot_gpu");
+var pack_gpu_1 = require("./webgl/pack_gpu");
 var pad_gpu_1 = require("./webgl/pad_gpu");
 var pool_gpu_1 = require("./webgl/pool_gpu");
 var reduce_gpu_1 = require("./webgl/reduce_gpu");
@@ -14525,6 +15013,7 @@ var resize_bilinear_gpu_1 = require("./webgl/resize_bilinear_gpu");
 var resize_nearest_neighbor_backprop_gpu_1 = require("./webgl/resize_nearest_neighbor_backprop_gpu");
 var resize_nearest_neighbor_gpu_1 = require("./webgl/resize_nearest_neighbor_gpu");
 var reverse_gpu_1 = require("./webgl/reverse_gpu");
+var scatter_gpu_1 = require("./webgl/scatter_gpu");
 var segment_gpu_1 = require("./webgl/segment_gpu");
 var select_gpu_1 = require("./webgl/select_gpu");
 var slice_gpu_1 = require("./webgl/slice_gpu");
@@ -14535,16 +15024,16 @@ var tile_gpu_1 = require("./webgl/tile_gpu");
 var transpose_gpu_1 = require("./webgl/transpose_gpu");
 var unary_op = require("./webgl/unaryop_gpu");
 var unaryop_gpu_1 = require("./webgl/unaryop_gpu");
+var unpack_gpu_1 = require("./webgl/unpack_gpu");
 var webgl_util = require("./webgl/webgl_util");
 var where_impl_1 = require("./where_impl");
 var BEFORE_PAGING_CONSTANT = 300;
-exports.SIZE_UPLOAD_UNIFORM = 32;
+exports.SIZE_UPLOAD_UNIFORM = 4;
 var MathBackendWebGL = (function () {
     function MathBackendWebGL(gpgpu, delayedStorage) {
         if (delayedStorage === void 0) { delayedStorage = true; }
         this.gpgpu = gpgpu;
         this.delayedStorage = delayedStorage;
-        this.texData = new WeakMap();
         this.pendingRead = new WeakMap();
         this.pendingDisposal = new WeakSet();
         this.lruDataGPU = [];
@@ -14566,9 +15055,12 @@ var MathBackendWebGL = (function () {
         else {
             this.gpgpuCreatedLocally = false;
         }
-        this.NUM_BYTES_BEFORE_PAGING =
-            (window.screen.height * window.screen.width * window.devicePixelRatio) *
-                BEFORE_PAGING_CONSTANT;
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.NUM_BYTES_BEFORE_PAGING =
+                (window.screen.height * window.screen.width *
+                    window.devicePixelRatio) *
+                    BEFORE_PAGING_CONSTANT;
+        }
         this.textureManager = new texture_manager_1.TextureManager(this.gpgpu);
     }
     MathBackendWebGL.prototype.register = function (dataId, shape, dtype) {
@@ -14582,8 +15074,12 @@ var MathBackendWebGL = (function () {
             texture: null,
             complexTensors: null,
             texShape: null,
-            usage: tex_util_1.TextureUsage.RENDER
+            usage: tex_util_1.TextureUsage.RENDER,
+            isPacked: false
         });
+    };
+    MathBackendWebGL.prototype.setDataMover = function (dataMover) {
+        this.texData = new backend_1.DataStorage(dataMover);
     };
     MathBackendWebGL.prototype.fromPixels = function (pixels, numChannels) {
         if (pixels == null) {
@@ -14616,27 +15112,31 @@ var MathBackendWebGL = (function () {
             this.fromPixelsCanvas.getContext('2d').drawImage(pixels, 0, 0, pixels.width, pixels.height);
             pixels = this.fromPixelsCanvas;
         }
-        var tempPixelArray = tensor_1.Tensor.make(texShape, {}, 'int32');
-        this.texData.get(tempPixelArray.dataId).usage = tex_util_1.TextureUsage.PIXELS;
-        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelArray.dataId), pixels);
+        var tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
+        this.texData.get(tempPixelHandle.dataId).usage = tex_util_1.TextureUsage.PIXELS;
+        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelHandle.dataId), pixels);
         var program = new from_pixels_gpu_1.FromPixelsProgram(outShape);
-        var res = this.compileAndRun(program, [tempPixelArray]);
-        tempPixelArray.dispose();
+        var res = this.compileAndRun(program, [tempPixelHandle]);
+        this.disposeData(tempPixelHandle.dataId);
         return res;
+    };
+    MathBackendWebGL.prototype.makeTensorHandle = function (shape, dtype) {
+        var dataId = {};
+        this.register(dataId, shape, dtype);
+        return { dataId: dataId, shape: shape, dtype: dtype };
     };
     MathBackendWebGL.prototype.write = function (dataId, values) {
         if (values == null) {
             throw new Error('MathBackendWebGL.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype;
+        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype, isPacked = texData.isPacked;
         if (dtype === 'complex64') {
             throw new Error("Cannot write to a complex64 dtype. " +
                 "Please use tf.complex(real, imag).");
         }
         if (texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -14647,9 +15147,8 @@ var MathBackendWebGL = (function () {
         }
     };
     MathBackendWebGL.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype, complexTensors = texData.complexTensors;
+        var values = texData.values, dtype = texData.dtype, complexTensors = texData.complexTensors;
         if (values != null) {
             this.cacheOnCPU(dataId);
             return values;
@@ -14666,8 +15165,7 @@ var MathBackendWebGL = (function () {
             result = complex_util_1.mergeRealAndImagArrays(realValues, imagValues);
         }
         else {
-            result =
-                this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+            result = this.getValuesFromTexture(dataId);
         }
         if (shouldTimeProgram) {
             this.downloadWaitMs += performance.now() - start;
@@ -14677,7 +15175,7 @@ var MathBackendWebGL = (function () {
     };
     MathBackendWebGL.prototype.read = function (dataId) {
         return __awaiter(this, void 0, void 0, function () {
-            var subscribers_1, texData, shape, texture, values, texShape, dtype, bufferOrTexture, vals, subscribers;
+            var subscribers_1, texData, texture, values, texShape, bufferOrTexture, vals, subscribers;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14685,9 +15183,8 @@ var MathBackendWebGL = (function () {
                             subscribers_1 = this.pendingRead.get(dataId);
                             return [2, new Promise(function (resolve) { return subscribers_1.push(resolve); })];
                         }
-                        this.throwIfNoData(dataId);
                         texData = this.texData.get(dataId);
-                        shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype;
+                        texture = texData.texture, values = texData.values, texShape = texData.texShape;
                         if (values != null) {
                             this.cacheOnCPU(dataId);
                             return [2, values];
@@ -14703,7 +15200,7 @@ var MathBackendWebGL = (function () {
                     case 1:
                         _a.sent();
                         if (bufferOrTexture instanceof WebGLTexture) {
-                            vals = this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+                            vals = this.getValuesFromTexture(dataId);
                         }
                         else {
                             vals = this.gpgpu.downloadFloat32MatrixFromBuffer(bufferOrTexture, texShape[0], texShape[1]);
@@ -14721,25 +15218,33 @@ var MathBackendWebGL = (function () {
             });
         });
     };
-    MathBackendWebGL.prototype.getValuesFromTexture = function (texture, dataId, dtype, texShape, shape) {
+    MathBackendWebGL.prototype.getValuesFromTexture = function (dataId) {
+        var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype, texture = _a.texture, texShape = _a.texShape;
         if (environment_1.ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
-            return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            if (this.texData.get(dataId).isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                return this.gpgpu.downloadMatrixFromPackedTexture(texture, batch, rows, cols, texShape[0], texShape[1]);
+            }
+            else {
+                return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            }
         }
-        var tmpTarget = tensor_1.Tensor.make(shape, {});
+        var tmpTarget = this.makeTensorHandle(shape, 'float32');
+        tmpTarget.size = util_1.sizeFromShape(shape);
         this.texData.get(tmpTarget.dataId).usage = tex_util_1.TextureUsage.DOWNLOAD;
-        var tmpInput = tensor_1.Tensor.make(shape, { dataId: dataId }, dtype);
         var program = new encode_float_gpu_1.EncodeFloatProgram(shape);
         var pageToCpu = false;
-        this.compileAndRun(program, [tmpInput], tmpTarget, null, pageToCpu);
+        this.compileAndRun(program, [{ shape: shape, dtype: dtype, dataId: dataId }], tmpTarget, null, pageToCpu);
         var tmpData = this.texData.get(tmpTarget.dataId);
         var vals = this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
-        tmpInput.dispose();
-        tmpTarget.dispose();
+        this.disposeData(tmpTarget.dataId);
         return vals;
     };
     MathBackendWebGL.prototype.time = function (f) {
         return __awaiter(this, void 0, void 0, function () {
-            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimers, kernelMs, res;
+            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimerQueries, flattenedActiveTimerNames, kernelMs, res;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14755,22 +15260,26 @@ var MathBackendWebGL = (function () {
                         }
                         this.activeTimers = newActiveTimers;
                         f();
-                        flattenedActiveTimers = util.flatten(this.activeTimers);
+                        flattenedActiveTimerQueries = util.flatten(this.activeTimers.map(function (d) { return d.query; }))
+                            .filter(function (d) { return d != null; });
+                        flattenedActiveTimerNames = util.flatten(this.activeTimers.map(function (d) { return d.name; }))
+                            .filter(function (d) { return d != null; });
                         this.activeTimers = oldActiveTimers;
                         if (outerMostTime) {
                             this.programTimersStack = null;
                         }
-                        return [4, Promise.all(flattenedActiveTimers).then(function (results) {
-                                var sum = 0;
-                                results.forEach(function (result) { return sum += result; });
-                                return sum;
-                            })];
+                        return [4, Promise.all(flattenedActiveTimerQueries)];
                     case 1:
                         kernelMs = _a.sent();
                         res = {
                             uploadWaitMs: this.uploadWaitMs,
                             downloadWaitMs: this.downloadWaitMs,
-                            kernelMs: kernelMs,
+                            kernelMs: util.sum(kernelMs),
+                            getExtraProfileInfo: function () {
+                                return kernelMs.map(function (d, i) { return ({ name: flattenedActiveTimerNames[i], ms: d }); })
+                                    .map(function (d) { return d.name + ": " + d.ms; })
+                                    .join(', ');
+                            },
                             wallMs: null
                         };
                         this.uploadWaitMs = 0;
@@ -14818,9 +15327,9 @@ var MathBackendWebGL = (function () {
             return;
         }
         if (this.texData.has(dataId)) {
-            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors;
+            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors, isPacked = _a.isPacked;
             if (texture != null) {
-                this.releaseTexture(dataId, texture, texShape, usage);
+                this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             }
             if (complexTensors != null) {
                 complexTensors.real.dispose();
@@ -14840,7 +15349,7 @@ var MathBackendWebGL = (function () {
         return this.canvas;
     };
     MathBackendWebGL.prototype.complex = function (real, imag) {
-        var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
+        var result = this.makeOutputArray(real.shape, 'complex64');
         var resultData = this.texData.get(result.dataId);
         resultData.complexTensors = {
             real: environment_1.ENV.engine.keep(real.clone()),
@@ -14897,8 +15406,18 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.batchMatMul = function (a, b, transposeA, transposeB) {
-        var program = new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-        return this.compileAndRun(program, [a, b]);
+        var outerShapeA = transposeA ? a.shape[2] : a.shape[1];
+        var outerShapeB = transposeB ? b.shape[1] : b.shape[2];
+        if (a.shape[0] === 1 && b.shape[0] === 1) {
+            var aSqueezed = a.as2D(a.shape[1], a.shape[2]);
+            var bSqueezed = b.as2D(b.shape[1], b.shape[2]);
+            var program = new mulmat_packed_gpu_1.MatMulPackedProgram(aSqueezed.shape, bSqueezed.shape, [outerShapeA, outerShapeB], transposeA, transposeB);
+            var result = this.unpackTensor(this.compileAndRun(program, [aSqueezed, bSqueezed], this.makePackedTensor(program.outputShape)));
+            return result.reshape([1, result.shape[0], result.shape[1]]);
+        }
+        else {
+            return this.compileAndRun(new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB), [a, b]);
+        }
     };
     MathBackendWebGL.prototype.multiply = function (a, b) {
         if (a.dtype === 'complex64') {
@@ -14935,8 +15454,14 @@ var MathBackendWebGL = (function () {
             scaleShape = scale.shape;
             inputs.push(scale);
         }
-        var program = new batchnorm_gpu_1.BatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
-        return this.compileAndRun(program, inputs);
+        var output = null;
+        var envSpecificBatchNormProgram = batchnorm_gpu_1.BatchNormProgram;
+        if (environment_1.ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
+            output = this.makePackedTensor(x.shape);
+            envSpecificBatchNormProgram = batchnorm_packed_gpu_1.BatchNormPackedProgram;
+        }
+        var program = new envSpecificBatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
+        return this.compileAndRun(program, inputs, output);
     };
     MathBackendWebGL.prototype.localResponseNormalization4D = function (x, radius, bias, alpha, beta) {
         var program = new lrn_gpu_1.LRNProgram(x.shape, radius, bias, alpha, beta);
@@ -15035,6 +15560,13 @@ var MathBackendWebGL = (function () {
         var a2D = x.as2D(-1, inSize);
         var outputDType = types_1.sumOutType(x.dtype);
         return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+    };
+    MathBackendWebGL.prototype.prod = function (x, axes) {
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var inSize = util.sizeFromShape(reduceShape);
+        var a2D = x.as2D(-1, inSize);
+        var outputDType = types_1.sumOutType(x.dtype);
+        return this.reduce(a2D, 'prod', outputDType).reshape(outShape);
     };
     MathBackendWebGL.prototype.unsortedSegmentSum = function (x, segmentIds, numSegments) {
         var axis = 0;
@@ -15343,6 +15875,15 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.abs = function (x) {
+        if (x.dtype === 'complex64') {
+            var xData = this.texData.get(x.dataId);
+            var program_1 = new complex_abs_gpu_1.ComplexAbsProgram(x.shape);
+            var inputs = [
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+            ];
+            return this.compileAndRun(program_1, inputs);
+        }
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.ABS);
         return this.compileAndRun(program, [x]);
     };
@@ -15416,7 +15957,23 @@ var MathBackendWebGL = (function () {
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.STEP(alpha));
         return this.compileAndRun(program, [x]);
     };
+    MathBackendWebGL.prototype.conv2dWithIm2Row = function (x, filter, convInfo) {
+        var filterWidth = convInfo.filterWidth, filterHeight = convInfo.filterHeight, inChannels = convInfo.inChannels, outWidth = convInfo.outWidth, outHeight = convInfo.outHeight;
+        var sharedDim = filterWidth * filterHeight * inChannels;
+        var numCols = outHeight * outWidth;
+        var x2ColShape = [sharedDim, numCols];
+        var xSqueezed = x.squeeze([0]);
+        var w2Row = filter.reshape([sharedDim, -1]);
+        var im2ColProgram = new im2col_gpu_1.Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
+        var im2Col = this.compileAndRun(im2ColProgram, [xSqueezed], this.makePackedTensor(x2ColShape));
+        var matmulProgram = new mulmat_packed_gpu_1.MatMulPackedProgram(im2Col.shape, w2Row.shape, [numCols, convInfo.outChannels], true, false);
+        var product = this.unpackTensor(this.compileAndRun(matmulProgram, [im2Col, w2Row], this.makePackedTensor(matmulProgram.outputShape)));
+        return product.reshape([1, outHeight, outWidth, convInfo.outChannels]);
+    };
     MathBackendWebGL.prototype.conv2d = function (x, filter, convInfo) {
+        if (environment_1.ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
+            return this.conv2dWithIm2Row(x, filter, convInfo);
+        }
         var program = new conv_gpu_1.Conv2DProgram(convInfo);
         return this.compileAndRun(program, [x, filter]);
     };
@@ -15529,14 +16086,69 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.split = function (x, sizeSplits, axis) {
         return split_shared_1.split(x, sizeSplits, axis);
     };
+    MathBackendWebGL.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var flattenIndices = indices.reshape([numUpdates, sliceRank]);
+        var flattenX = updates.reshape([numUpdates, sliceSize]);
+        if (outputSize === 0) {
+            return backend_util.reshapeTensor(tensor_ops_1.tensor([]), shape);
+        }
+        var defaultValue = tensor_ops_1.scalar(0);
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, flattenIndices.rank, flattenX.rank, strides, flattenShape);
+        return this.compileAndRun(program, [flattenX, flattenIndices, defaultValue])
+            .reshape(shape);
+    };
+    MathBackendWebGL.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, sparseIndices.rank, sparseValues.rank, strides, [outputSize, 1], sumDupeIndices);
+        return this.compileAndRun(program, [sparseValues, sparseIndices, defaultValue])
+            .reshape(outputShape);
+    };
+    MathBackendWebGL.prototype.fft = function (x) {
+        var xData = this.texData.get(x.dataId);
+        var realProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
+        var imagProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+        var inputs = [
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+        ];
+        var real = this.compileAndRun(realProgram, inputs);
+        var imag = this.compileAndRun(imagProgram, inputs);
+        var complex = this.complex(real, imag).as2D(x.shape[0], x.shape[1]);
+        real.dispose();
+        imag.dispose();
+        return complex;
+    };
+    MathBackendWebGL.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        var flattenIndices = indices.reshape([numSlices, sliceRank]);
+        var flattenX = x.reshape([x.size / sliceSize, sliceSize]);
+        var program = new gather_nd_gpu_1.GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+        return this.compileAndRun(program, [flattenX, flattenIndices])
+            .reshape(resultShape);
+    };
     MathBackendWebGL.prototype.makeOutputArray = function (shape, dtype) {
         return tensor_1.Tensor.make(shape, {}, dtype);
+    };
+    MathBackendWebGL.prototype.makePackedTensor = function (shape) {
+        var packedTensor = tensor_1.Tensor.make(shape, {});
+        this.texData.get(packedTensor.dataId).isPacked = true;
+        return packedTensor;
+    };
+    MathBackendWebGL.prototype.unpackTensor = function (input) {
+        var program = new unpack_gpu_1.UnpackProgram(input.shape);
+        return this.compileAndRun(program, [input]);
     };
     MathBackendWebGL.prototype.compileAndRun = function (program, inputs, output, customSetup, pageToCpu) {
         var _this = this;
         if (pageToCpu === void 0) { pageToCpu = true; }
         if (output == null) {
-            output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+            output =
+                this.makeOutputArray(program.outputShape, inputs[0].dtype);
         }
         if (output.size === 0) {
             this.texData.get(output.dataId).values =
@@ -15551,13 +16163,29 @@ var MathBackendWebGL = (function () {
             }
             var texData = _this.texData.get(input.dataId);
             if (texData.texture == null &&
-                util.sizeFromShape(input.shape) <= exports.SIZE_UPLOAD_UNIFORM) {
+                !(!texData.isPacked && program.usesPackedTextures) &&
+                util.sizeFromShape(input.shape) <=
+                    environment_1.ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
                 return {
                     shape: input.shape,
                     texData: null,
                     isUniform: true,
                     uniformValues: _this.readSync(input.dataId)
                 };
+            }
+            if (texData.isPacked !== !!program.usesPackedTextures) {
+                var preProcessProgram = void 0;
+                var processedInput = void 0;
+                if (texData.isPacked) {
+                    preProcessProgram = new unpack_gpu_1.UnpackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input]);
+                }
+                else {
+                    preProcessProgram = new pack_gpu_1.PackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input], _this.makePackedTensor(input.shape));
+                }
+                texData = _this.texData.get(processedInput.dataId);
+                input = processedInput;
             }
             _this.uploadToGPU(input.dataId);
             return { shape: input.shape, texData: texData, isUniform: false };
@@ -15578,7 +16206,8 @@ var MathBackendWebGL = (function () {
             query = this.startTimer();
         }
         gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-        if (pageToCpu && this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED') && pageToCpu &&
+            this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
             var numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
             while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
                 var dataId = this.lruDataGPU.shift();
@@ -15589,7 +16218,7 @@ var MathBackendWebGL = (function () {
         }
         if (shouldTimeProgram) {
             query = this.endTimer(query);
-            this.activeTimers.push(this.getQueryTime(query));
+            this.activeTimers.push({ name: program.constructor.name, query: this.getQueryTime(query) });
         }
         return output;
     };
@@ -15628,22 +16257,16 @@ var MathBackendWebGL = (function () {
             return 16;
         });
     };
-    MathBackendWebGL.prototype.throwIfNoData = function (dataId) {
-        if (!this.texData.has(dataId)) {
-            throw new Error("WebGL backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
-    };
     MathBackendWebGL.prototype.uploadToGPU = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage;
+        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (texture != null) {
-            var index = this.lruDataGPU.indexOf(dataId);
-            if (index >= 0) {
-                this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
-                this.lruDataGPU.push(dataId);
+            if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+                var index = this.lruDataGPU.indexOf(dataId);
+                if (index >= 0) {
+                    this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
+                    this.lruDataGPU.push(dataId);
+                }
             }
             return;
         }
@@ -15652,12 +16275,20 @@ var MathBackendWebGL = (function () {
         if (shouldTimeProgram) {
             start = performance.now();
         }
-        var texShape = webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        var texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
         texData.texShape = texShape;
-        var newTexture = this.acquireTexture(dataId, texShape, usage);
+        var newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
         texData.texture = newTexture;
         if (values != null) {
-            this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            if (isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                this.gpgpu.uploadMatrixToPackedTexture(newTexture, batch, rows, cols, typedArrayToFloat32(values, dtype));
+            }
+            else {
+                this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            }
             texData.values = null;
             if (shouldTimeProgram) {
                 this.uploadWaitMs += performance.now() - start;
@@ -15667,9 +16298,9 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.cacheOnCPU = function (dataId, float32Values) {
         var dontKeepCopyOnGPU = this.delayedStorage;
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage;
+        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (dontKeepCopyOnGPU && texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -15678,20 +16309,24 @@ var MathBackendWebGL = (function () {
             texData.values = float32ToTypedArray(float32Values, dtype);
         }
     };
-    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType) {
+    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        var idx = this.lruDataGPU.indexOf(dataId);
-        if (idx >= 0) {
-            this.lruDataGPU.splice(idx, 1);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            var idx = this.lruDataGPU.indexOf(dataId);
+            if (idx >= 0) {
+                this.lruDataGPU.splice(idx, 1);
+            }
         }
         this.numBytesInGPU -= this.computeBytes(shape, dtype);
-        this.textureManager.releaseTexture(texture, texShape, texType);
+        this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
     };
-    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType) {
+    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        this.lruDataGPU.push(dataId);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.lruDataGPU.push(dataId);
+        }
         this.numBytesInGPU += this.computeBytes(shape, dtype);
-        return this.textureManager.acquireTexture(texShape, texType);
+        return this.textureManager.acquireTexture(texShape, texType, isPacked);
     };
     MathBackendWebGL.prototype.computeBytes = function (shape, dtype) {
         return util.sizeFromShape(shape) * util.bytesPerElement(dtype);
@@ -15722,7 +16357,7 @@ function typedArrayToFloat32(a, dtype) {
     return (a instanceof Float32Array) ? a : new Float32Array(a);
 }
 
-},{"../environment":64,"../globals":66,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/concat_util":143,"../ops/reduce_util":160,"../ops/segment_util":165,"../ops/slice_util":168,"../ops/softmax":169,"../ops/tensor_ops":171,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./webgl/argminmax_gpu":87,"./webgl/avg_pool_backprop_gpu":88,"./webgl/batchnorm_gpu":89,"./webgl/binaryop_complex_gpu":90,"./webgl/binaryop_gpu":91,"./webgl/clip_gpu":92,"./webgl/concat_gpu":93,"./webgl/conv_backprop_gpu":94,"./webgl/conv_backprop_gpu_depthwise":95,"./webgl/conv_gpu":96,"./webgl/conv_gpu_depthwise":97,"./webgl/crop_and_resize_gpu":98,"./webgl/cumsum_gpu":99,"./webgl/depth_to_space_gpu":100,"./webgl/encode_float_gpu":101,"./webgl/from_pixels_gpu":102,"./webgl/gather_gpu":103,"./webgl/gpgpu_context":104,"./webgl/gpgpu_math":105,"./webgl/gpgpu_util":106,"./webgl/lrn_gpu":107,"./webgl/lrn_grad_gpu":108,"./webgl/max_pool_backprop_gpu":109,"./webgl/mulmat_gpu":110,"./webgl/multinomial_gpu":111,"./webgl/onehot_gpu":112,"./webgl/pad_gpu":113,"./webgl/pool_gpu":114,"./webgl/reduce_gpu":115,"./webgl/resize_bilinear_backprop_gpu":116,"./webgl/resize_bilinear_gpu":117,"./webgl/resize_nearest_neighbor_backprop_gpu":118,"./webgl/resize_nearest_neighbor_gpu":119,"./webgl/reverse_gpu":120,"./webgl/segment_gpu":121,"./webgl/select_gpu":122,"./webgl/slice_gpu":124,"./webgl/strided_slice_gpu":125,"./webgl/tex_util":126,"./webgl/texture_manager":127,"./webgl/tile_gpu":128,"./webgl/transpose_gpu":129,"./webgl/unaryop_gpu":130,"./webgl/webgl_util":131,"./where_impl":132}],83:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/concat_util":155,"../ops/gather_nd_util":161,"../ops/reduce_util":175,"../ops/scatter_nd_util":180,"../ops/segment_util":182,"../ops/slice_util":185,"../ops/softmax":186,"../ops/tensor_ops":191,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./webgl/argminmax_gpu":89,"./webgl/avg_pool_backprop_gpu":90,"./webgl/batchnorm_gpu":91,"./webgl/batchnorm_packed_gpu":92,"./webgl/binaryop_complex_gpu":93,"./webgl/binaryop_gpu":94,"./webgl/clip_gpu":95,"./webgl/complex_abs_gpu":96,"./webgl/concat_gpu":97,"./webgl/conv_backprop_gpu":98,"./webgl/conv_backprop_gpu_depthwise":99,"./webgl/conv_gpu":100,"./webgl/conv_gpu_depthwise":101,"./webgl/crop_and_resize_gpu":102,"./webgl/cumsum_gpu":103,"./webgl/depth_to_space_gpu":104,"./webgl/encode_float_gpu":105,"./webgl/fft_gpu":106,"./webgl/from_pixels_gpu":107,"./webgl/gather_gpu":108,"./webgl/gather_nd_gpu":109,"./webgl/gpgpu_context":110,"./webgl/gpgpu_math":111,"./webgl/gpgpu_util":112,"./webgl/im2col_gpu":113,"./webgl/lrn_gpu":114,"./webgl/lrn_grad_gpu":115,"./webgl/max_pool_backprop_gpu":116,"./webgl/mulmat_gpu":117,"./webgl/mulmat_packed_gpu":118,"./webgl/multinomial_gpu":119,"./webgl/onehot_gpu":120,"./webgl/pack_gpu":121,"./webgl/pad_gpu":122,"./webgl/pool_gpu":123,"./webgl/reduce_gpu":124,"./webgl/resize_bilinear_backprop_gpu":125,"./webgl/resize_bilinear_gpu":126,"./webgl/resize_nearest_neighbor_backprop_gpu":127,"./webgl/resize_nearest_neighbor_gpu":128,"./webgl/reverse_gpu":129,"./webgl/scatter_gpu":130,"./webgl/segment_gpu":131,"./webgl/select_gpu":132,"./webgl/slice_gpu":134,"./webgl/strided_slice_gpu":135,"./webgl/tex_util":136,"./webgl/texture_manager":137,"./webgl/tile_gpu":138,"./webgl/transpose_gpu":139,"./webgl/unaryop_gpu":140,"./webgl/unpack_gpu":141,"./webgl/webgl_util":142,"./where_impl":143}],84:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function mergeRealAndImagArrays(real, imag) {
@@ -15748,8 +16383,59 @@ function splitRealAndImagArrays(complex) {
     return { real: real, imag: imag };
 }
 exports.splitRealAndImagArrays = splitRealAndImagArrays;
+function complexWithEvenIndex(complex) {
+    var len = Math.ceil(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 0; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithEvenIndex = complexWithEvenIndex;
+function complexWithOddIndex(complex) {
+    var len = Math.floor(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 2; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithOddIndex = complexWithOddIndex;
+function getComplexWithIndex(complex, index) {
+    var real = complex[index * 2];
+    var imag = complex[index * 2 + 1];
+    return { real: real, imag: imag };
+}
+exports.getComplexWithIndex = getComplexWithIndex;
+function assignToTypedArray(data, real, imag, index) {
+    data[index * 2] = real;
+    data[index * 2 + 1] = imag;
+}
+exports.assignToTypedArray = assignToTypedArray;
+function exponents(n) {
+    var real = new Float32Array(n / 2);
+    var imag = new Float32Array(n / 2);
+    for (var i = 0; i < Math.ceil(n / 2); i++) {
+        var x = -2 * Math.PI * (i / n);
+        real[i] = Math.cos(x);
+        imag[i] = Math.sin(x);
+    }
+    return { real: real, imag: imag };
+}
+exports.exponents = exponents;
+function exponent(k, n) {
+    var x = -2 * Math.PI * (k / n);
+    var real = Math.cos(x);
+    var imag = Math.sin(x);
+    return { real: real, imag: imag };
+}
+exports.exponent = exponent;
 
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15807,7 +16493,33 @@ function intersectionOverUnion(boxes, i, j) {
     return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 
-},{"../ops/tensor_ops":171}],85:[function(require,module,exports){
+},{"../ops/tensor_ops":191}],86:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function getChannels(name) {
+    return ['x', 'y', 'z', 'w'].map(function (d) { return name + "." + d; });
+}
+exports.getChannels = getChannels;
+function getInnerDims(rank, dims) {
+    return dims.slice(0, rank).slice(-2);
+}
+exports.getInnerDims = getInnerDims;
+function getSourceCoords(rank, dims) {
+    if (rank === 1) {
+        return 'rc';
+    }
+    var coords = '';
+    for (var i = 0; i < rank; i++) {
+        coords += dims[i];
+        if (i < rank - 1) {
+            coords += ',';
+        }
+    }
+    return coords;
+}
+exports.getSourceCoords = getSourceCoords;
+
+},{}],87:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function split(x, sizeSplits, axis) {
@@ -15822,7 +16534,7 @@ function split(x, sizeSplits, axis) {
 }
 exports.split = split;
 
-},{}],86:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15857,7 +16569,7 @@ function topkImpl(x, xShape, xDtype, k, sorted) {
 }
 exports.topkImpl = topkImpl;
 
-},{"../ops/tensor_ops":171,"../util":194}],87:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214}],89:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ArgMinMaxProgram = (function () {
@@ -15875,13 +16587,13 @@ var ArgMinMaxProgram = (function () {
         var indexSnippet = firstPass ?
             'inOffset + i;' :
             'round(getBestIndicesA(batch, inOffset + i));';
-        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = 0;\n        float bestValue = getA(batch, inOffset);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
+        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = inOffset;\n        float bestValue = getA(batch, bestIndex);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
     }
     return ArgMinMaxProgram;
 }());
 exports.ArgMinMaxProgram = ArgMinMaxProgram;
 
-},{}],88:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var AvgPool2DBackpropProgram = (function () {
@@ -15892,16 +16604,20 @@ var AvgPool2DBackpropProgram = (function () {
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
         var avgMultiplier = 1 / (filterHeight * filterWidth);
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + ";\n            wC+= " + dilationWidth + ") {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return AvgPool2DBackpropProgram;
 }());
 exports.AvgPool2DBackpropProgram = AvgPool2DBackpropProgram;
 
-},{}],89:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15925,13 +16641,52 @@ var BatchNormProgram = (function () {
             scaleSnippet = 'getScaleAtOutCoords()';
         }
         this.outputShape = xShape;
-        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput(dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));\n      }\n    ";
     }
     return BatchNormProgram;
 }());
 exports.BatchNormProgram = BatchNormProgram;
 
-},{"../../ops/broadcast_util":139}],90:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],92:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var broadcast_util = require("../../ops/broadcast_util");
+var BatchNormPackedProgram = (function () {
+    function BatchNormPackedProgram(xShape, meanShape, varianceShape, offsetShape, scaleShape, varianceEpsilon) {
+        this.supportsBroadcasting = true;
+        this.usesPackedTextures = true;
+        this.variableNames = ['x', 'mean', 'variance'];
+        broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+        broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+        var meanSnippet = broadcastSample('mean', meanShape.length);
+        var varianceSnippet = broadcastSample('variance', varianceShape.length);
+        var offsetSnippet = 'vec4 offset = vec4(0.0)';
+        if (offsetShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+            this.variableNames.push('offset');
+            offsetSnippet = broadcastSample('offset', offsetShape.length);
+        }
+        var scaleSnippet = 'vec4 scale = vec4(1.0)';
+        if (scaleShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+            this.variableNames.push('scale');
+            scaleSnippet = broadcastSample('scale', scaleShape.length);
+        }
+        this.outputShape = xShape;
+        this.userCode = "\n      void main() {\n        ivec4 rc = getOutputCoords();\n\n        " + offsetSnippet + ";\n        " + scaleSnippet + ";\n\n        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);\n        " + meanSnippet + ";\n        " + varianceSnippet + ";\n\n        vec4 inv = scale * inversesqrt(variance + vec4(" + varianceEpsilon + "));\n\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+    }
+    return BatchNormPackedProgram;
+}());
+exports.BatchNormPackedProgram = BatchNormPackedProgram;
+function broadcastSample(texName, rank) {
+    var texSampler = "get" + texName.charAt(0).toUpperCase() + texName.slice(1);
+    if (rank === 1) {
+        return "\n      vec4 " + texName + "Sample = " + texSampler + "(rc.w);\n      vec4 " + texName + " = vec4(" + texName + "Sample.xy, " + texName + "Sample.xy);\n    ";
+    }
+    return "vec4 " + texName + " = " + texSampler + "(rc.x, rc.y, rc.z, rc.w)";
+}
+
+},{"../../ops/broadcast_util":151}],93:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15951,7 +16706,7 @@ var BinaryOpComplexProgram = (function () {
 }());
 exports.BinaryOpComplexProgram = BinaryOpComplexProgram;
 
-},{"../../ops/broadcast_util":139}],91:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],94:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -16000,7 +16755,7 @@ var BinaryOpProgram = (function () {
 }());
 exports.BinaryOpProgram = BinaryOpProgram;
 
-},{"../../ops/broadcast_util":139}],92:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],95:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ClipProgram = (function () {
@@ -16013,7 +16768,20 @@ var ClipProgram = (function () {
 }());
 exports.ClipProgram = ClipProgram;
 
-},{}],93:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var ComplexAbsProgram = (function () {
+    function ComplexAbsProgram(shape) {
+        this.variableNames = ['real', 'imag'];
+        this.outputShape = shape;
+        this.userCode = "\n      void main() {\n        float real = getRealAtOutCoords();\n        float imag = getImagAtOutCoords();\n        vec2 v = vec2(real, imag);\n\n        setOutput(sqrt(dot(v, v)));\n      }\n    ";
+    }
+    return ComplexAbsProgram;
+}());
+exports.ComplexAbsProgram = ComplexAbsProgram;
+
+},{}],97:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var concat_util = require("../../ops/concat_util");
@@ -16029,7 +16797,7 @@ var ConcatProgram = (function () {
 }());
 exports.ConcatProgram = ConcatProgram;
 
-},{"../../ops/concat_util":143}],94:[function(require,module,exports){
+},{"../../ops/concat_util":155}],98:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DDerFilterProgram = (function () {
@@ -16061,7 +16829,7 @@ var Conv2DDerInputProgram = (function () {
 }());
 exports.Conv2DDerInputProgram = Conv2DDerInputProgram;
 
-},{}],95:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DDerFilterProgram = (function () {
@@ -16095,7 +16863,7 @@ var DepthwiseConv2DDerInputProgram = (function () {
 }());
 exports.DepthwiseConv2DDerInputProgram = DepthwiseConv2DDerInputProgram;
 
-},{}],96:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DProgram = (function () {
@@ -16118,7 +16886,7 @@ var Conv2DProgram = (function () {
 }());
 exports.Conv2DProgram = Conv2DProgram;
 
-},{}],97:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DProgram = (function () {
@@ -16142,7 +16910,7 @@ var DepthwiseConv2DProgram = (function () {
 }());
 exports.DepthwiseConv2DProgram = DepthwiseConv2DProgram;
 
-},{}],98:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var CropAndResizeProgram = (function () {
@@ -16183,7 +16951,7 @@ var CropAndResizeProgram = (function () {
 }());
 exports.CropAndResizeProgram = CropAndResizeProgram;
 
-},{}],99:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16234,7 +17002,7 @@ function getFinalCoord(rank, name) {
     }
 }
 
-},{"./shader_compiler":123}],100:[function(require,module,exports){
+},{"./shader_compiler":133}],104:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthToSpaceProgram = (function () {
@@ -16290,7 +17058,7 @@ var DepthToSpaceProgram = (function () {
 }());
 exports.DepthToSpaceProgram = DepthToSpaceProgram;
 
-},{}],101:[function(require,module,exports){
+},{}],105:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var EncodeFloatProgram = (function () {
@@ -16303,7 +17071,25 @@ var EncodeFloatProgram = (function () {
 }());
 exports.EncodeFloatProgram = EncodeFloatProgram;
 
-},{}],102:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COMPLEX_FFT = {
+    REAL: 'return real * expR - imag * expI;',
+    IMAG: 'return real * expI + imag * expR;'
+};
+var FFTProgram = (function () {
+    function FFTProgram(op, inputShape) {
+        this.variableNames = ['real', 'imag'];
+        var innerDim = inputShape[1];
+        this.outputShape = inputShape;
+        this.userCode = "\n      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;\n\n      float unaryOpComplex(float real, float expR, float imag, float expI) {\n        " + op + "\n      }\n\n      float mulMatDFT(int batch, int index) {\n        float indexRatio = float(index) / float(" + innerDim + ");\n        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;\n\n        float result = 0.0;\n\n        for (int i = 0; i < " + innerDim + "; i++) {\n          // x = (-2 * PI / N) * index * i;\n          float x = negativeTwoPiTimesIndexRatio * float(i);\n          float expR = cos(x);\n          float expI = sin(x);\n          float real = getReal(batch, i);\n          float imag = getImag(batch, i);\n\n          result += unaryOpComplex(real, expR, imag, expI);\n        }\n\n        return result;\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        setOutput(mulMatDFT(coords[0], coords[1]));\n      }\n    ";
+    }
+    return FFTProgram;
+}());
+exports.FFTProgram = FFTProgram;
+
+},{}],107:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var FromPixelsProgram = (function () {
@@ -16317,7 +17103,7 @@ var FromPixelsProgram = (function () {
 }());
 exports.FromPixelsProgram = FromPixelsProgram;
 
-},{}],103:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16356,7 +17142,26 @@ function getSourceCoords(aShape, axis) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],104:[function(require,module,exports){
+},{"./shader_compiler":133}],109:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var GatherNDProgram = (function () {
+    function GatherNDProgram(sliceDim, strides, shape) {
+        this.sliceDim = sliceDim;
+        this.strides = strides;
+        this.variableNames = ['x', 'indices'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + this.strides + ");\n         void main() {\n          " + dtype + " coords = getOutputCoords();\n          int flattenIndex = 0;\n          for (int j = 0; j < " + this.sliceDim + "; j++) {\n            int index = round(getIndices(coords[0], j));\n            flattenIndex += index * " + strideString + ";\n          }\n          setOutput(getX(flattenIndex, coords[1]));\n        }\n      ";
+    }
+    return GatherNDProgram;
+}());
+exports.GatherNDProgram = GatherNDProgram;
+
+},{"./shader_compiler":133}],110:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16484,6 +17289,10 @@ var GPGPUContext = (function () {
         this.throwIfDisposed();
         gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
     };
+    GPGPUContext.prototype.createFloat16PackedMatrixTexture = function (rows, columns) {
+        this.throwIfDisposed();
+        return gpgpu_util.createFloat16PackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
+    };
     GPGPUContext.prototype.createPackedMatrixTexture = function (rows, columns) {
         this.throwIfDisposed();
         return gpgpu_util.createPackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
@@ -16502,9 +17311,9 @@ var GPGPUContext = (function () {
         var numChannels = webgl_util.getNumChannels();
         return gpgpu_util.uploadMatrixToTexture(this.gl, texture, rows, columns, matrix, numChannels, this.textureConfig);
     };
-    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, rows, columns, matrix) {
+    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, batch, rows, columns, matrix) {
         this.throwIfDisposed();
-        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, rows, columns, matrix, this.textureConfig);
+        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, batch, rows, columns, matrix, this.textureConfig);
     };
     GPGPUContext.prototype.downloadFloat32MatrixFromOutputTexture = function (texture, rows, columns) {
         var _this = this;
@@ -16552,9 +17361,9 @@ var GPGPUContext = (function () {
         }
         return { query: query, isFencePassed: isFencePassed };
     };
-    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, rows, columns) {
+    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, batch, rows, columns, physicalRows, physicalCols) {
         var _this = this;
-        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, rows, columns, _this.textureConfig); });
+        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, batch, rows, columns, physicalRows, physicalCols, _this.textureConfig); });
     };
     GPGPUContext.prototype.createProgram = function (fragmentShaderSource) {
         this.throwIfDisposed();
@@ -16836,7 +17645,7 @@ function binSearchLastTrue(arr) {
 }
 exports.binSearchLastTrue = binSearchLastTrue;
 
-},{"../../environment":64,"../../util":194,"./gpgpu_util":106,"./tex_util":126,"./webgl_util":131}],105:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./gpgpu_util":112,"./tex_util":136,"./webgl_util":142}],111:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../../util");
@@ -16847,7 +17656,8 @@ function compileProgram(gpgpu, program, inputs, output) {
         var shapeInfo = {
             logicalShape: input.shape,
             texShape: input.isUniform ? null : input.texData.texShape,
-            isUniform: input.isUniform
+            isUniform: input.isUniform,
+            isPacked: input.isUniform ? false : input.texData.isPacked
         };
         return { name: program.variableNames[i], shapeInfo: shapeInfo };
     });
@@ -16855,7 +17665,8 @@ function compileProgram(gpgpu, program, inputs, output) {
     var outShapeInfo = {
         logicalShape: output.shape,
         texShape: output.texData.texShape,
-        isUniform: false
+        isUniform: false,
+        isPacked: output.texData.isPacked
     };
     var source = shader_compiler.makeShader(inputInfos, outShapeInfo, userCode, program.supportsBroadcasting === true);
     var webGLProgram = gpgpu.createProgram(source);
@@ -16907,7 +17718,12 @@ function runProgram(binary, inputs, output, customSetup) {
     var outTex = output.texData.texture;
     var outTexShape = output.texData.texShape;
     var gpgpu = binary.gpgpu;
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    if (output.texData.isPacked) {
+        gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
+    else {
+        gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
     gpgpu.setProgram(binary.webGLProgram);
     inputs.forEach(function (input, i) {
         var variableName = binary.program.variableNames[i];
@@ -16949,10 +17765,11 @@ function makeShaderKey(program, inputs, output) {
 }
 exports.makeShaderKey = makeShaderKey;
 
-},{"../../util":194,"./shader_compiler":123}],106:[function(require,module,exports){
+},{"../../util":214,"./shader_compiler":133}],112:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 var tex_util = require("./tex_util");
 var webgl_util = require("./webgl_util");
 function getWebGLContextAttributes() {
@@ -17047,7 +17864,7 @@ function getTextureConfig(gl, textureHalfFloatExtension) {
 }
 exports.getTextureConfig = getTextureConfig;
 function createAndConfigureTexture(gl, width, height, internalFormat, textureFormat, textureType) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     var texture = webgl_util.createTexture(gl);
     var tex2d = gl.TEXTURE_2D;
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(tex2d, texture); });
@@ -17079,6 +17896,11 @@ function createPackedMatrixTexture(gl, rows, columns, textureConfig) {
     return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatPackedFloat, gl.RGBA, gl.FLOAT);
 }
 exports.createPackedMatrixTexture = createPackedMatrixTexture;
+function createFloat16PackedMatrixTexture(gl, rows, columns, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), width = _a[0], height = _a[1];
+    return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA, textureConfig.textureTypeHalfFloat);
+}
+exports.createFloat16PackedMatrixTexture = createFloat16PackedMatrixTexture;
 function bindVertexProgramAttributeStreams(gl, program, vertexBuffer) {
     var posOffset = 0;
     var uvOffset = 3 * 4;
@@ -17096,7 +17918,7 @@ function uploadPixelDataToTexture(gl, texture, pixels) {
 }
 exports.uploadPixelDataToTexture = uploadPixelDataToTexture;
 function uploadDataToTexture(gl, texture, width, height, data, textureFormat) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, texture); });
     webgl_util.callAndCheck(gl, function () { return gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, textureFormat, gl.FLOAT, data); });
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, null); });
@@ -17115,10 +17937,10 @@ function uploadMatrixToTexture(gl, texture, rows, columns, matrix, numChannels, 
     uploadDataToTexture(gl, texture, w, h, unpackedArray, textureConfig.textureFormatFloat);
 }
 exports.uploadMatrixToTexture = uploadMatrixToTexture;
-function uploadMatrixToPackedTexture(gl, texture, rows, columns, matrix, textureConfig) {
+function uploadMatrixToPackedTexture(gl, texture, batch, rows, columns, matrix, textureConfig) {
     var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
     var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
-    tex_util.encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA);
+    tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
     uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }
 exports.uploadMatrixToPackedTexture = uploadMatrixToPackedTexture;
@@ -17167,16 +17989,32 @@ function downloadByteEncodedFloatMatrixFromOutputTexture(gl, rows, columns, text
     return new Float32Array(downloadTarget.buffer);
 }
 exports.downloadByteEncodedFloatMatrixFromOutputTexture = downloadByteEncodedFloatMatrixFromOutputTexture;
-function downloadMatrixFromPackedOutputTexture(gl, rows, columns, textureConfig) {
-    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
-    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+function downloadMatrixFromPackedOutputTexture(gl, batch, rows, cols, physicalRows, physicalCols, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(physicalRows, physicalCols), w = _a[0], h = _a[1];
+    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
     webgl_util.callAndCheck(gl, function () { return gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, packedRGBA); });
-    var matrix = new Float32Array(rows * columns);
-    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix);
+    var matrix = new Float32Array(util.sizeFromShape([batch, rows, cols]));
+    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, batch, rows, cols, matrix);
 }
 exports.downloadMatrixFromPackedOutputTexture = downloadMatrixFromPackedOutputTexture;
 
-},{"../../environment":64,"./tex_util":126,"./webgl_util":131}],107:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./tex_util":136,"./webgl_util":142}],113:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Im2ColProgram = (function () {
+    function Im2ColProgram(outputShape, inputShape, convInfo) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var filterWidth = convInfo.filterWidth, inChannels = convInfo.inChannels, strideWidth = convInfo.strideWidth, strideHeight = convInfo.strideHeight, padInfo = convInfo.padInfo, outWidth = convInfo.outWidth, dilationWidth = convInfo.dilationWidth, dilationHeight = convInfo.dilationHeight;
+        var left = padInfo.left, top = padInfo.top;
+        var itemsPerBlockRow = inChannels * filterWidth;
+        this.userCode = "\n      void main() {\n        ivec2 rc = getOutputCoords();\n\n        vec4 result = vec4(0);\n\n        for(int row=0; row<=1; row++) {\n          for(int col=0; col<=1; col++) {\n            int blockIndex = rc.y + col;\n            int pos = rc.x + row;\n\n            if(blockIndex >= " + outputShape[1] + " || pos >= " + outputShape[0] + ") continue;\n\n            int offsetY = int(blockIndex / (" + outWidth + ")) * " + strideHeight + " - " + top + ";\n            int d0 = offsetY + " + dilationHeight + " * (pos / " + itemsPerBlockRow + ");\n\n            if(d0 >= " + inputShape[0] + " || d0 < 0) continue;\n\n            int offsetX = int(mod(float(blockIndex), " + outWidth + ".) * " + strideWidth + ". - " + left + ".);\n            int d1 = offsetX + " + dilationWidth + " * (int(mod(float(pos), " + itemsPerBlockRow + ".) / " + inChannels + ".));\n\n            if(d1 >= " + inputShape[1] + " || d1 < 0) continue;\n\n            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), " + inChannels + ".)));\n          }\n        }\n\n        gl_FragColor = result;\n      }\n    ";
+    }
+    return Im2ColProgram;
+}());
+exports.Im2ColProgram = Im2ColProgram;
+
+},{}],114:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNProgram = (function () {
@@ -17203,7 +18041,7 @@ var LRNProgram = (function () {
 }());
 exports.LRNProgram = LRNProgram;
 
-},{}],108:[function(require,module,exports){
+},{}],115:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNGradProgram = (function () {
@@ -17222,27 +18060,28 @@ var LRNGradProgram = (function () {
 }());
 exports.LRNGradProgram = LRNGradProgram;
 
-},{}],109:[function(require,module,exports){
+},{}],116:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MaxPool2DBackpropProgram = (function () {
     function MaxPool2DBackpropProgram(convInfo) {
         this.variableNames = ['dy', 'maxPos'];
         this.outputShape = convInfo.inShape;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var lastIndex = filterHeight * filterWidth - 1;
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + filterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        var dilationHeight = convInfo.dilationHeight;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var lastIndex = effectiveFilterHeight * effectiveFilterWidth - 1;
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n          wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + effectiveFilterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return MaxPool2DBackpropProgram;
 }());
 exports.MaxPool2DBackpropProgram = MaxPool2DBackpropProgram;
 
-},{}],110:[function(require,module,exports){
+},{}],117:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MatMulProgram = (function () {
@@ -17271,7 +18110,29 @@ var MatMulProgram = (function () {
 }());
 exports.MatMulProgram = MatMulProgram;
 
-},{}],111:[function(require,module,exports){
+},{}],118:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var MatMulPackedProgram = (function () {
+    function MatMulPackedProgram(aShape, bShape, outputShape, transposeA, transposeB) {
+        if (transposeA === void 0) { transposeA = false; }
+        if (transposeB === void 0) { transposeB = false; }
+        this.variableNames = ['matrixA', 'matrixB'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var sharedDim = transposeA ? aShape[0] : aShape[1];
+        var sharedDimensionPacked = Math.ceil(sharedDim / 2);
+        var aSample = transposeA ? 'i * 2, rc.x' : 'rc.x, i * 2';
+        var bSample = transposeB ? 'rc.y, i * 2' : 'i * 2, rc.y';
+        var aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
+        var bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
+        this.userCode = "\n      const float sharedDimension = " + sharedDimensionPacked + ".0;\n\n      vec4 dot2x2ARowBCol(ivec2 rc) {\n        vec4 result = vec4(0);\n        for (int i = 0; i < " + sharedDimensionPacked + "; i++) {\n          vec4 a = getMatrixA(" + aSample + ");\n          vec4 b = getMatrixB(" + bSample + ");\n\n          result += (" + aSwizzle[0] + " * " + bSwizzle[0] + ") + (" + aSwizzle[1] + " * " + bSwizzle[1] + ");\n        }\n        return result;\n      }\n\n      void main() {\n        ivec2 rc = getOutputCoords();\n        setOutput(dot2x2ARowBCol(rc));\n      }\n    ";
+    }
+    return MatMulPackedProgram;
+}());
+exports.MatMulPackedProgram = MatMulPackedProgram;
+
+},{}],119:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MultinomialProgram = (function () {
@@ -17293,7 +18154,7 @@ var MultinomialProgram = (function () {
 }());
 exports.MultinomialProgram = MultinomialProgram;
 
-},{}],112:[function(require,module,exports){
+},{}],120:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var OneHotProgram = (function () {
@@ -17306,7 +18167,69 @@ var OneHotProgram = (function () {
 }());
 exports.OneHotProgram = OneHotProgram;
 
-},{}],113:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var PackProgram = (function () {
+    function PackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var outOfBoundsCondition = getOutOfBoundsCondition(rank, outputShape, channels);
+        var setup = getSetup(rank, outputShape[outputShape.length - 1], outputShape[outputShape.length - 2], channels);
+        var output = getOutput(outputShape, channels);
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n\n        if(" + outOfBoundsCondition + ") {\n          gl_FragColor = vec4(0);\n        } else {\n          " + setup + "\n\n          setOutput(vec4(" + output + "));\n        }\n      }\n    ";
+    }
+    return PackProgram;
+}());
+exports.PackProgram = PackProgram;
+function getSourceCoordsArr(rank, dims) {
+    var coords = [];
+    for (var row = 0; row <= 1; row++) {
+        for (var col = 0; col <= 1; col++) {
+            var coord = (row === 0 ? 'r' : 'rp1') + ", " + (col === 0 ? 'c' : 'cp1');
+            for (var d = 2; d < rank; d++) {
+                coord = dims[dims.length - 1 - d] + "," + coord;
+            }
+            coords.push(coord);
+        }
+    }
+    return coords;
+}
+function getOutOfBoundsCondition(rank, shape, dims) {
+    if (rank === 1) {
+        return "rc > " + shape[0];
+    }
+    var cond = '';
+    for (var i = 0; i < rank; i++) {
+        cond += dims[i] + " >= " + shape[i];
+        if (i < rank - 1) {
+            cond += '||';
+        }
+    }
+    return cond;
+}
+function getSetup(rank, cols, rows, dims) {
+    if (rank === 1) {
+        return '';
+    }
+    var innerDims = packing_util_1.getInnerDims(rank, dims);
+    return "\n    int r = " + innerDims[0] + ";\n    int c = " + innerDims[1] + ";\n    int rp1 = r + 1;\n    int cp1 = c + 1;\n\n    bool cEdge = cp1 >= " + cols + ";\n    bool rEdge = rp1 >= " + rows + ";\n  ";
+}
+function getOutput(shape, dims) {
+    var rank = shape.length;
+    var sourceCoords = getSourceCoordsArr(rank, dims);
+    if (rank === 1) {
+        return "getA(rc),\n            rc + 1 >= " + shape[0] + " ? 0. : getA(rc + 1),\n            0, 0";
+    }
+    return "getA(" + sourceCoords[0] + "),\n          cEdge ? 0. : getA(" + sourceCoords[1] + "),\n          rEdge ? 0. : getA(" + sourceCoords[2] + "),\n          rEdge || cEdge ? 0. : getA(" + sourceCoords[3] + ")";
+}
+
+},{"../packing_util":86,"./shader_compiler":133}],122:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17329,7 +18252,7 @@ var PadProgram = (function () {
 }());
 exports.PadProgram = PadProgram;
 
-},{"./shader_compiler":123}],114:[function(require,module,exports){
+},{"./shader_compiler":133}],123:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Pool2DProgram = (function () {
@@ -17338,10 +18261,13 @@ var Pool2DProgram = (function () {
         if (poolType === 'avg' && computePositions) {
             throw new Error('Cannot compute positions for average pool.');
         }
-        var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         this.outputShape = convInfo.outShape;
@@ -17352,7 +18278,7 @@ var Pool2DProgram = (function () {
         }
         if (computePositions) {
             var compareOp_1 = '>=';
-            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + filterHeight + "; wR++) {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + filterWidth + "; wC++) {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + filterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
+            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + effectiveFilterHeight + ";\n              wR += " + dilationHeight + ") {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + effectiveFilterWidth + ";\n                wC += " + dilationWidth + ") {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + effectiveFilterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
             return;
         }
         var compareOp = 'max';
@@ -17364,13 +18290,13 @@ var Pool2DProgram = (function () {
         var filterWidthNearestVec4 = Math.floor(filterWidth / 4) * 4;
         var filterWidthVec4Remainder = filterWidth % 4;
         var updateSnippet = "\n      if (" + isAvgPool + ") {\n        avgValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
-        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC;\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              getValue(batch, xR, xC + 3, d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC * " + dilationWidth + ";\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 3 * " + dilationWidth + ", d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return Pool2DProgram;
 }());
 exports.Pool2DProgram = Pool2DProgram;
 
-},{}],115:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ReduceProgram = (function () {
@@ -17383,7 +18309,10 @@ var ReduceProgram = (function () {
         this.outputShape = [batchSize, outSize];
         var initializationValue = '0.0';
         var compareOp = "";
-        if (reduceType === 'min') {
+        if (reduceType === 'prod') {
+            initializationValue = '1.0';
+        }
+        else if (reduceType === 'min') {
             initializationValue = '1.0 / 0.0';
             compareOp = "min";
         }
@@ -17396,6 +18325,9 @@ var ReduceProgram = (function () {
         if (reduceType === 'sum') {
             returnValue = "sumValue";
         }
+        else if (reduceType === 'prod') {
+            returnValue = "prodValue";
+        }
         else if (reduceType === 'all') {
             returnValue = "allValue";
         }
@@ -17404,7 +18336,7 @@ var ReduceProgram = (function () {
         }
         var windowSizeNearestVec4 = Math.floor(windowSize / 4) * 4;
         var windowSizeVec4Remainder = windowSize % 4;
-        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
+        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else if (" + (reduceType === 'prod') + ") {\n        vec2 tmp = vec2(values[0], values[1]) * vec2(values[2], values[3]);\n        prodValue *= tmp[0] * tmp[1];\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
         var vecType = "vec4";
         if (reduceType === 'all') {
             initializationValue = '1.0';
@@ -17420,13 +18352,13 @@ var ReduceProgram = (function () {
         if (inSize % windowSize > 0) {
             checkOutOfBounds = "\n        if (inIdx < 0 || inIdx >= " + inSize + ") {\n          return initializationValue;\n        }\n      ";
         }
-        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float prodValue = 1.0;\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return ReduceProgram;
 }());
 exports.ReduceProgram = ReduceProgram;
 
-},{}],116:[function(require,module,exports){
+},{}],125:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearBackpropProgram = (function () {
@@ -17456,7 +18388,7 @@ var ResizeBilinearBackpropProgram = (function () {
 }());
 exports.ResizeBilinearBackpropProgram = ResizeBilinearBackpropProgram;
 
-},{}],117:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearProgram = (function () {
@@ -17479,7 +18411,7 @@ var ResizeBilinearProgram = (function () {
 }());
 exports.ResizeBilinearProgram = ResizeBilinearProgram;
 
-},{}],118:[function(require,module,exports){
+},{}],127:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeigborBackpropProgram = (function () {
@@ -17509,7 +18441,7 @@ var ResizeNearestNeigborBackpropProgram = (function () {
 }());
 exports.ResizeNearestNeigborBackpropProgram = ResizeNearestNeigborBackpropProgram;
 
-},{}],119:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeighborProgram = (function () {
@@ -17533,7 +18465,7 @@ var ResizeNearestNeighborProgram = (function () {
 }());
 exports.ResizeNearestNeighborProgram = ResizeNearestNeighborProgram;
 
-},{}],120:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17563,7 +18495,41 @@ var ReverseProgram = (function () {
 }());
 exports.ReverseProgram = ReverseProgram;
 
-},{"./shader_compiler":123}],121:[function(require,module,exports){
+},{"./shader_compiler":133}],130:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var ScatterProgram = (function () {
+    function ScatterProgram(updateSize, sliceDim, indicesRank, updatesRank, strides, shape, summingDupeIndex) {
+        if (summingDupeIndex === void 0) { summingDupeIndex = true; }
+        this.variableNames = ['updates', 'indices', 'defaultValue'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var indicesString = '';
+        if (indicesRank === 1) {
+            indicesString = 'i';
+        }
+        else if (indicesRank === 2) {
+            indicesString = 'i, j';
+        }
+        var indicesSnippet = "getIndices(" + indicesString + ")";
+        var updatesString = '';
+        if (updatesRank === 1) {
+            updatesString = 'i';
+        }
+        else if (updatesRank === 2) {
+            updatesString = 'i, coords[1]';
+        }
+        var updatesSnippet = "getUpdates(" + updatesString + ")";
+        var strideString = sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + strides + ");\n\n        void main() {\n          " + dtype + " coords = getOutputCoords();\n          float sum = 0.0;\n          bool found = false;\n          for (int i = 0; i < " + updateSize + "; i++) {\n            int flattenedIndex = 0;\n            for (int j = 0; j < " + sliceDim + "; j++) {\n              int index = round(" + indicesSnippet + ");\n              flattenedIndex += index * " + strideString + ";\n            }\n            if (flattenedIndex == coords[0]) {\n              sum += " + updatesSnippet + ";\n              found = true;\n            }\n          }\n          setOutput(mix(getDefaultValue(), sum, float(found)));\n        }\n      ";
+    }
+    return ScatterProgram;
+}());
+exports.ScatterProgram = ScatterProgram;
+
+},{"./shader_compiler":133}],131:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var SegmentOpProgram = (function () {
@@ -17594,7 +18560,7 @@ var SegmentOpProgram = (function () {
 }());
 exports.SegmentOpProgram = SegmentOpProgram;
 
-},{}],122:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17631,7 +18597,7 @@ var SelectProgram = (function () {
 }());
 exports.SelectProgram = SelectProgram;
 
-},{"./shader_compiler":123}],123:[function(require,module,exports){
+},{"./shader_compiler":133}],133:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -17648,11 +18614,21 @@ function makeShader(inputsInfo, outputShape, userCode, broadcast) {
     var inputSamplingSnippet = inputsInfo.map(function (x) { return getInputSamplingSnippet(x, outputShape, broadcast); })
         .join('\n');
     var outTexShape = outputShape.texShape;
-    var outputSamplingSnippet = getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    var outputSamplingSnippet;
+    var floatTextureSetOutputSnippet;
+    if (outputShape.isPacked) {
+        outputSamplingSnippet =
+            getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    }
+    else {
+        outputSamplingSnippet =
+            getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    }
     var source = [
-        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-        FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-        inputSamplingSnippet, userCode
+        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+        inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
     ].join('\n');
     return source;
 }
@@ -17679,14 +18655,47 @@ function getSamplerFromInInfo(inInfo) {
                 " is not yet supported");
     }
 }
+function getPackedSamplerFromInInfo(inInfo) {
+    var shape = inInfo.shapeInfo.logicalShape;
+    switch (shape.length) {
+        case 1:
+            return getPackedSampler1D(inInfo);
+        case 2:
+            return getPackedSampler2D(inInfo);
+        case 4:
+            return getPackedSampler4D(inInfo);
+        default:
+            throw new Error("Packed " + shape.length + "-D input sampling" +
+                " is not yet supported");
+    }
+}
 function getInputSamplingSnippet(inInfo, outShapeInfo, broadcast) {
     var res = getSamplerFlat(inInfo);
-    res += getSamplerFromInInfo(inInfo);
+    if (inInfo.shapeInfo.isPacked) {
+        res += getPackedSamplerFromInInfo(inInfo);
+    }
+    else {
+        res += getSamplerFromInInfo(inInfo);
+    }
     if (broadcast ||
         util.arraysEqual(inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
         res += getSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     }
     return res;
+}
+function getPackedOutputSamplingSnippet(outShape, outTexShape) {
+    switch (outShape.length) {
+        case 0:
+            return getOutputScalarCoords();
+        case 1:
+            return getOutputPacked1DCoords(outShape, outTexShape);
+        case 2:
+            return getOutputPacked2DCoords(outShape, outTexShape);
+        case 4:
+            return getOutputPacked4DCoords(outShape, outTexShape);
+        default:
+            throw new Error(outShape.length + "-D output packed sampling is not yet supported");
+    }
 }
 function getOutputSamplingSnippet(outShape, outTexShape) {
     switch (outShape.length) {
@@ -17708,17 +18717,28 @@ function getOutputSamplingSnippet(outShape, outTexShape) {
             throw new Error(outShape.length + "-D output sampling is not yet supported");
     }
 }
-var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom1D(int texNumR, int texNumC, int index) {\n  int texelIndex = index / 2;\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom2D(int texelsInLogicalRow, int texNumR,\n  int texNumC, int row, int col) {\n  int texelIndex = (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_3D_SNIPPET = "\nvec2 UVfrom3D(int texNumR, int texNumC, int stride0,\n    int stride1, int row, int col, int depth) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,\n    int texelsInBatch, int texelsInLogicalRow, int b2, int b,\n    int row, int col) {\n  int index = b2 * texelsInBatch2 + b * texelsInBatch +\n    (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_5D_SNIPPET = "\nvec2 UVfrom5D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int row, int col, int depth,\n    int depth2, int depth3) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 +\n              depth * stride2 + depth2 * stride3 + depth3;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_6D_SNIPPET = "\nvec2 UVfrom6D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int stride4,\n    int row, int col, int depth, int depth2, int depth3, int depth4) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2 *\n    stride3 + depth3 * stride4 + depth4;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var FLOAT_TEXTURE_SAMPLE_SNIPPET = "\n  float sampleTexture(sampler2D textureSampler, vec2 uv) {\n    return texture2D(textureSampler, uv).r;\n  }\n";
-var FLOAT_TEXTURE_SETOUTPUT_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
-var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
+var FLOAT_TEXTURE_SET_R_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
+var FLOAT_TEXTURE_SET_RGBA_SNIPPET = "\n  void setOutput(vec4 val) {\n    gl_FragColor = val;\n  }\n";
+var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
 function getOutputScalarCoords() {
     return "\n    int getOutputCoords() {\n      return 0;\n    }\n  ";
+}
+function getOutputPacked1DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (texShape[0] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.x * " + packedTexShape[1] + ".0);\n      }\n    ";
+    }
+    if (texShape[1] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.y * " + packedTexShape[0] + ".0);\n      }\n    ";
+    }
+    return "\n    int getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      return resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n    }\n  ";
 }
 function getOutput1DCoords(shape, texShape) {
     if (texShape[0] === 1) {
@@ -17733,6 +18753,13 @@ function getOutput3DCoords(shape, texShape) {
     var stride0 = shape[1] * shape[2];
     var stride1 = shape[2];
     return "\n    ivec3 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n      int c = index / " + stride1 + ";\n      int d = index - c * " + stride1 + ";\n      return ivec3(r, c, d);\n    }\n  ";
+}
+function getOutputPacked4DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texelsInLogicalRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    ivec4 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n\n      int b2 = index / " + texelsInBatch2 + ";\n      index -= b2 * " + texelsInBatch2 + ";\n\n      int b = index / " + texelsInBatch + ";\n      index -= b * " + texelsInBatch + ";\n\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = int(mod(float(index), " + texelsInLogicalRow + ".)) * 2;\n\n      return ivec4(b2, b, r, c);\n    }\n  ";
 }
 function getOutput4DCoords(shape, texShape) {
     var stride2 = shape[3];
@@ -17755,6 +18782,14 @@ function getOutput6DCoords(shape, texShape) {
     var stride0 = shape[1] * stride1;
     return "\n    ivec6 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n        vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n\n      int c = index / " + stride1 + ";\n      index -= c * " + stride1 + ";\n\n      int d = index / " + stride2 + ";\n      index -= d * " + stride2 + ";\n\n      int d2 = index / " + stride3 + ";\n      index -= d2 * " + stride3 + ";\n\n      int d3 = index / " + stride4 + ";\n      int d4 = index - d3 * " + stride4 + ";\n\n      ivec6 result = ivec6(r, c, d, d2, d3, d4);\n      return result;\n    }\n  ";
 }
+function getOutputPacked2DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (util.arraysEqual(shape, texShape)) {
+        return "\n      ivec2 getOutputCoords() {\n        return 2 * ivec2(resultUV.yx * vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      }\n    ";
+    }
+    var texelsInLogicalRow = Math.ceil(shape[1] / 2);
+    return "\n    ivec2 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = imod(index, " + texelsInLogicalRow + ") * 2;\n\n      return ivec2(r, c);\n    }\n  ";
+}
 function getOutput2DCoords(shape, texShape) {
     if (util.arraysEqual(shape, texShape)) {
         return "\n      ivec2 getOutputCoords() {\n        return ivec2(resultUV.yx * vec2(" + texShape[0] + ", " + texShape[1] + "));\n      }\n    ";
@@ -17775,10 +18810,31 @@ function getSamplerScalar(inputInfo) {
     }
     return "\n    float " + funcName + "() {\n      return sampleTexture(" + texName + ", halfCR);\n    }\n  ";
 }
+function getPackedSampler1D(inputInfo) {
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    return "\n    vec4 " + funcName + "(int index) {\n      vec2 uv = packedUVfrom1D(\n        " + packedTexShape[0] + ", " + packedTexShape[1] + ", index);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
+}
 function getSampler1D(inputInfo) {
     var texName = inputInfo.name;
     var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
     return "\n    float " + funcName + "(int index) {\n      return " + funcName + "Flat(index);\n    }\n  ";
+}
+function getPackedSampler2D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var texNumR = texShape[0];
+    var texNumC = texShape[1];
+    if (texShape != null && util.arraysEqual(shape, texShape)) {
+        return "\n      vec4 " + funcName + "(int row, int col) {\n        vec2 uv = (vec2(col, row) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n\n        return texture2D(" + texName + ", uv);\n      }\n    ";
+    }
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var valuesPerRow = Math.ceil(shape[1] / 2);
+    return "\n    vec4 " + funcName + "(int row, int col) {\n      vec2 uv = packedUVfrom2D(" + valuesPerRow + ", " + packedTexShape[0] + ", " + packedTexShape[1] + ", row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler2D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17798,15 +18854,15 @@ function getSampler2D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col) {\n        int index = row * " + shape[1] + " + col;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col) {\n        float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2(0.5, (float(index) + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2(0.5, (index + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     if (texNumR === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2((float(index) + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2((index + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n  float " + funcName + "(int row, int col) {\n    vec2 uv = UVfrom2D(" + texNumR + ", " + texNumC + ", " + shape[1] + ", row, col);\n    return sampleTexture(" + texName + ", uv);\n  }\n";
 }
@@ -17824,18 +18880,31 @@ function getSampler3D(inputInfo) {
         return "\n        " + getSamplerFromInInfo(newInputInfo) + "\n        float " + funcName + "(int row, int col, int depth) {\n          return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n        }\n      ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth) {\n        int index = row * " + stride0 + " + col * " + stride1 + " + depth;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth) {\n        float index = dot(vec3(row, col, depth),\n                          vec3(" + stride0 + ", " + stride1 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n        float " + funcName + "(int row, int col, int depth) {\n          int texR = row;\n          int texC = col * " + stride1 + " + depth;\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
+        return "\n        float " + funcName + "(int row, int col, int depth) {\n          float texR = float(row);\n          float texC = dot(vec2(col, depth), vec2(" + stride1 + ", 1));\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
     }
     if (texNumC === stride1) {
-        return "\n    float " + funcName + "(int row, int col, int depth) {\n      int texR = row * " + shape[1] + " + col;\n      int texC = depth;\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col, int depth) {\n      float texR = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      float texC = float(depth);\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n      float " + funcName + "(int row, int col, int depth) {\n        vec2 uv = UVfrom3D(\n            " + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ", row, col, depth);\n        return sampleTexture(" + texName + ", uv);\n      }\n  ";
+}
+function getPackedSampler4D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texNumR = packedTexShape[0];
+    var texNumC = packedTexShape[1];
+    var valuesPerRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    vec4 " + funcName + "(int b2, int b, int row, int col) {\n      vec2 uv = packedUVfrom4D(\n        " + texNumR + ", " + texNumC + ", " + texelsInBatch2 + ",\n        " + texelsInBatch + ", " + valuesPerRow + ", b2, b, row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler4D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17851,16 +18920,16 @@ function getSampler4D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float index = dot(vec4(row, col, depth, depth2),\n                          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = float(row);\n        float texC =\n            dot(vec3(col, depth, depth2), vec3(" + stride1 + ", " + stride2 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride2) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = dot(vec3(row, col, depth),\n                         vec3(" + shape[1] * shape[2] + ", " + shape[2] + ", 1));\n        float texC = float(depth2);\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2) {\n      vec2 uv = UVfrom4D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", row, col, depth, depth2);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17879,16 +18948,16 @@ function getSampler5D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " +\n                   depth2 * " + stride3 + " + depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride3) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " +\n                   depth * " + shape[3] + " + depth2;\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] + ", " + shape[2] * shape[3] + ",\n            " + shape[3] + ", 1));\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n      vec2 uv = UVfrom5D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", row, col, depth, depth2, depth3);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17908,16 +18977,16 @@ function getSampler6D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3 * " + stride3 + "\n            + depth4\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          dot(\n            vec2(depth3, depth4),\n            vec2(" + stride4 + ", 1));\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", " + stride4 + ")) + depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride4) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] * shape[4] + ",\n               " + shape[2] * shape[3] * shape[4] + ",\n               " + shape[3] * shape[4] + ",\n               " + shape[4] + ")) + depth3;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n      vec2 uv = UVfrom6D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", " + stride4 + "\n          ,row, col, depth, depth2, depth3, depth4);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -18046,7 +19115,7 @@ function getSqueezedParams(params, keptDims) {
     return keptDims.map(function (d) { return params[d]; }).join(', ');
 }
 
-},{"../../ops/broadcast_util":139,"../../util":194}],124:[function(require,module,exports){
+},{"../../ops/broadcast_util":151,"../../util":214}],134:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18110,7 +19179,7 @@ function getCoords(rank) {
     }
 }
 
-},{"./shader_compiler":123}],125:[function(require,module,exports){
+},{"./shader_compiler":133}],135:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18148,9 +19217,10 @@ var StridedSliceProgram = (function () {
 }());
 exports.StridedSliceProgram = StridedSliceProgram;
 
-},{"./shader_compiler":123}],126:[function(require,module,exports){
+},{"./shader_compiler":133}],136:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var util = require("../../util");
 var TextureUsage;
 (function (TextureUsage) {
     TextureUsage[TextureUsage["RENDER"] = 0] = "RENDER";
@@ -18160,9 +19230,11 @@ var TextureUsage;
 })(TextureUsage = exports.TextureUsage || (exports.TextureUsage = {}));
 var PhysicalTextureType;
 (function (PhysicalTextureType) {
-    PhysicalTextureType[PhysicalTextureType["FLOAT16"] = 0] = "FLOAT16";
-    PhysicalTextureType[PhysicalTextureType["FLOAT32"] = 1] = "FLOAT32";
-    PhysicalTextureType[PhysicalTextureType["UNSIGNED_BYTE"] = 2] = "UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT16"] = 0] = "UNPACKED_FLOAT16";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT32"] = 1] = "UNPACKED_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_4X1_UNSIGNED_BYTE"] = 2] = "PACKED_4X1_UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT32"] = 3] = "PACKED_2X2_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT16"] = 4] = "PACKED_2X2_FLOAT16";
 })(PhysicalTextureType = exports.PhysicalTextureType || (exports.PhysicalTextureType = {}));
 function getUnpackedMatrixTextureShapeWidthHeight(rows, columns) {
     return [columns, rows];
@@ -18230,118 +19302,130 @@ function getPackedRGBAArraySizeFromMatrixShape(rows, columns) {
     return w * h * 4;
 }
 exports.getPackedRGBAArraySizeFromMatrixShape = getPackedRGBAArraySizeFromMatrixShape;
-function encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA) {
+function encodeMatrixToPackedRGBA(matrix, batches, rows, columns, packedRGBA) {
     var requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
     if (packedRGBA.length < requiredSize) {
-        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >= " + requiredSize);
+        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >=\n        " + requiredSize);
     }
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    {
-        var dstStride = (oddWidth ? 4 : 0);
-        var oneRow = columns;
-        var dst = 0;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            var matrixSrcRow = (blockY * 2 * columns);
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                var matrixSrcCol = blockX * 2;
-                var src = matrixSrcRow + matrixSrcCol;
-                packedRGBA[dst] = matrix[src];
-                packedRGBA[dst + 1] = matrix[src + 1];
-                packedRGBA[dst + 2] = matrix[src + oneRow];
-                packedRGBA[dst + 3] = matrix[src + oneRow + 1];
-                dst += 4;
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var sourceOffset = batch * rows * columns;
+        var batchOffset = batch * flattenedMatrixSize;
+        {
+            var dstStride = (oddWidth ? 4 : 0);
+            var oneRow = columns;
+            var dst = batchOffset;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                var matrixSrcRow = (blockY * 2 * columns);
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    var matrixSrcCol = blockX * 2;
+                    var src = sourceOffset + matrixSrcRow + matrixSrcCol;
+                    packedRGBA[dst] = matrix[src];
+                    packedRGBA[dst + 1] = matrix[src + 1];
+                    packedRGBA[dst + 2] = matrix[src + oneRow];
+                    packedRGBA[dst + 3] = matrix[src + oneRow + 1];
+                    dst += 4;
+                }
+                dst += dstStride;
             }
-            dst += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = columns - 1;
-        var dst = (textureWidth - 1) * 4;
-        var srcStride = 2 * columns;
-        var dstStride = textureWidth * 4;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            packedRGBA[dst] = matrix[src];
-            packedRGBA[dst + 2] = matrix[src + columns];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + columns - 1;
+            var dst = batchOffset + (texelsPerRow - 1) * 4;
+            var srcStride = 2 * columns;
+            var dstStride = texelsPerRow * 4;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                packedRGBA[dst] = matrix[src];
+                packedRGBA[dst + 2] = matrix[src + columns];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (rows - 1) * columns;
-        var dst = (textureHeight - 1) * textureWidth * 4;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            packedRGBA[dst++] = matrix[src++];
-            packedRGBA[dst++] = matrix[src++];
-            dst += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (rows - 1) * columns;
+            var dst = batchOffset + (texelsPerBatch - texelsPerRow) * 4;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                packedRGBA[dst++] = matrix[src++];
+                packedRGBA[dst++] = matrix[src++];
+                dst += 2;
+            }
+            if (oddWidth && oddHeight) {
+                packedRGBA[batchOffset + flattenedMatrixSize - 4] = matrix[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        packedRGBA[packedRGBA.length - 4] = matrix[matrix.length - 1];
     }
     return packedRGBA;
 }
 exports.encodeMatrixToPackedRGBA = encodeMatrixToPackedRGBA;
-function decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix) {
+function decodeMatrixFromPackedRGBA(packedRGBA, batches, rows, columns, matrix) {
     var requiredSize = rows * columns;
-    if (requiredSize < matrix.length) {
+    if (matrix.length < requiredSize) {
         throw new Error("matrix length (" + matrix.length + ") must be >= " + requiredSize);
     }
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
-    {
-        var srcStride = oddWidth ? 4 : 0;
-        var dstStride = columns + (oddWidth ? 1 : 0);
-        var src = 0;
-        var dstRow1 = 0;
-        var dstRow2 = columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var batchOffset = batch * rows * columns;
+        var sourceOffset = batch * flattenedMatrixSize;
+        {
+            var srcStride = oddWidth ? 4 : 0;
+            var dstStride = columns + (oddWidth ? 1 : 0);
+            var src = sourceOffset;
+            var dstRow1 = batchOffset;
+            var dstRow2 = batchOffset + columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                }
+                src += srcStride;
+                dstRow1 += dstStride;
+                dstRow2 += dstStride;
             }
-            src += srcStride;
-            dstRow1 += dstStride;
-            dstRow2 += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = (textureWidth - 1) * 4;
-        var dst = columns - 1;
-        var srcStride = textureWidth * 4;
-        var dstStride = 2 * columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            matrix[dst] = packedRGBA[src];
-            matrix[dst + columns] = packedRGBA[src + 2];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + (texelsPerRow - 1) * 4;
+            var dst = batchOffset + columns - 1;
+            var srcStride = texelsPerRow * 4;
+            var dstStride = 2 * columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                matrix[dst] = packedRGBA[src];
+                matrix[dst + columns] = packedRGBA[src + 2];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (textureHeight - 1) * textureWidth * 4;
-        var dst = (rows - 1) * columns;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            matrix[dst++] = packedRGBA[src++];
-            matrix[dst++] = packedRGBA[src++];
-            src += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (texelsPerBatch - texelsPerRow) * 4;
+            var dst = batchOffset + (rows - 1) * columns;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                matrix[dst++] = packedRGBA[src++];
+                matrix[dst++] = packedRGBA[src++];
+                src += 2;
+            }
+            if (oddWidth) {
+                matrix[batchOffset + (rows * columns) - 1] = packedRGBA[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        matrix[matrix.length - 1] = packedRGBA[packedRGBA.length - 4];
     }
     return matrix;
 }
 exports.decodeMatrixFromPackedRGBA = decodeMatrixFromPackedRGBA;
 
-},{}],127:[function(require,module,exports){
+},{"../../util":214}],137:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
@@ -18355,9 +19439,9 @@ var TextureManager = (function () {
         this.logEnabled = false;
         this.usedTextures = {};
     }
-    TextureManager.prototype.acquireTexture = function (shapeRC, usage) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(usage);
-        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType);
+    TextureManager.prototype.acquireTexture = function (shapeRC, usage, isPacked) {
+        var physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
+        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18375,24 +19459,34 @@ var TextureManager = (function () {
         this.numUsedTextures++;
         this.log();
         var newTexture;
-        if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT32) {
+        if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32) {
+            newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16) {
+            newTexture =
+                this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32) {
             newTexture =
                 this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT16) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16) {
             newTexture =
                 this.gpgpu.createFloat16MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNSIGNED_BYTE) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE) {
             newTexture =
                 this.gpgpu.createUnsignedBytesMatrixTexture(shapeRC[0], shapeRC[1]);
         }
         this.usedTextures[shapeKey].push(newTexture);
         return newTexture;
     };
-    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType);
-        var shapeKey = getKeyFromTextureShape(shape, physicalTexType);
+    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType, isPacked) {
+        if (this.freeTextures == null) {
+            return;
+        }
+        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+        var shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18444,26 +19538,31 @@ var TextureManager = (function () {
     return TextureManager;
 }());
 exports.TextureManager = TextureManager;
-function getPhysicalFromLogicalTextureType(logicalTexType) {
-    if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
+function getPhysicalFromLogicalTextureType(logicalTexType, isPacked) {
+    if (isPacked) {
+        return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32 :
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    else if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
         logicalTexType === tex_util_1.TextureUsage.PIXELS) {
-        return tex_util_1.PhysicalTextureType.UNSIGNED_BYTE;
+        return tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.UPLOAD) {
-        return tex_util_1.PhysicalTextureType.FLOAT32;
+        return tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.RENDER) {
         return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-            tex_util_1.PhysicalTextureType.FLOAT32 :
-            tex_util_1.PhysicalTextureType.FLOAT16;
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32 :
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16;
     }
     throw new Error("Unknown logical texture type " + logicalTexType);
 }
-function getKeyFromTextureShape(shapeRowsCol, physicalTexType) {
-    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType;
+function getKeyFromTextureShape(shapeRowsCol, physicalTexType, isPacked) {
+    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType + "_" + isPacked;
 }
 
-},{"../../environment":64,"./tex_util":126}],128:[function(require,module,exports){
+},{"../../environment":64,"./tex_util":136}],138:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18499,7 +19598,7 @@ function getSourceCoords(aShape) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],129:[function(require,module,exports){
+},{"./shader_compiler":133}],139:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18532,7 +19631,7 @@ function getSwitchedCoords(newDim) {
     return switchedCoords.join();
 }
 
-},{"./shader_compiler":123}],130:[function(require,module,exports){
+},{"./shader_compiler":133}],140:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var erf_util = require("../../ops/erf_util");
@@ -18599,12 +19698,33 @@ exports.RECIPROCAL = "return 1.0 / x;";
 exports.LOGICAL_NOT = "return float(!(x >= 1.0));";
 exports.TO_INT = "return float(int(x));";
 
-},{"../../ops/erf_util":146,"../../ops/selu_util":166}],131:[function(require,module,exports){
+},{"../../ops/erf_util":159,"../../ops/selu_util":183}],141:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var MAX_TEXTURE_SIZE = null;
-var util = require("../../util");
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var UnpackProgram = (function () {
+    function UnpackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var sourceCoords = packing_util_1.getSourceCoords(rank, channels);
+        var innerDims = packing_util_1.getInnerDims(rank, channels);
+        var coords = rank === 1 ? 'rc' : innerDims.join(',');
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n        vec2 modCoord = mod(vec2(" + coords + "), 2.);\n        vec4 packedInput = getA(" + sourceCoords + ");\n\n        setOutput(\n          modCoord.x == 0. ?\n            (modCoord.y == 0. ? packedInput.r : packedInput.g) :\n            (modCoord.y == 0. ? packedInput.b : packedInput.a)\n        );\n      }\n    ";
+    }
+    return UnpackProgram;
+}());
+exports.UnpackProgram = UnpackProgram;
+
+},{"../packing_util":86,"./shader_compiler":133}],142:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 function createWebGLRenderingContext(attributes) {
     var canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -18755,15 +19875,6 @@ function createStaticIndexBuffer(gl, data) {
     return buffer;
 }
 exports.createStaticIndexBuffer = createStaticIndexBuffer;
-function queryMaxTextureSize(gl) {
-    if (MAX_TEXTURE_SIZE != null) {
-        return MAX_TEXTURE_SIZE;
-    }
-    MAX_TEXTURE_SIZE =
-        callAndCheck(gl, function () { return gl.getParameter(gl.MAX_TEXTURE_SIZE); });
-    return MAX_TEXTURE_SIZE;
-}
-exports.queryMaxTextureSize = queryMaxTextureSize;
 function getNumChannels() {
     if (environment_1.ENV.get('WEBGL_VERSION') === 2) {
         return 1;
@@ -18775,8 +19886,8 @@ function createTexture(gl) {
     return throwIfNull(gl, function () { return gl.createTexture(); }, 'Unable to create WebGLTexture.');
 }
 exports.createTexture = createTexture;
-function validateTextureSize(gl, width, height) {
-    var maxTextureSize = queryMaxTextureSize(gl);
+function validateTextureSize(width, height) {
+    var maxTextureSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
     if ((width <= 0) || (height <= 0)) {
         var requested = "[" + width + "x" + height + "]";
         throw new Error('Requested texture size ' + requested + ' is invalid.');
@@ -18882,12 +19993,19 @@ function validateTextureUnit(gl, textureUnit) {
         throw new Error("textureUnit must be in " + textureUnitRange + ".");
     }
 }
-function getTextureShapeFromLogicalShape(gl, logShape) {
+function getTextureShapeFromLogicalShape(logShape, isPacked) {
+    if (isPacked === void 0) { isPacked = false; }
+    var maxTexSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    if (isPacked) {
+        maxTexSize = maxTexSize * 2;
+        logShape = logShape.map(function (d, i) { return i >= logShape.length - 2 ?
+            util.nearestLargerEven(logShape[i]) :
+            logShape[i]; });
+    }
     if (logShape.length !== 2) {
         var squeezeResult = util.squeezeShape(logShape);
         logShape = squeezeResult.newShape;
     }
-    var maxTexSize = queryMaxTextureSize(gl);
     var size = util.sizeFromShape(logShape);
     if (logShape.length <= 1 && size <= maxTexSize) {
         return [size, 1];
@@ -18896,9 +20014,18 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
         logShape[1] <= maxTexSize) {
         return logShape;
     }
+    else if (logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+        logShape[2] <= maxTexSize) {
+        return [logShape[0] * logShape[1], logShape[2]];
+    }
     else if (logShape.length === 3 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] <= maxTexSize) {
         return [logShape[0], logShape[1] * logShape[2]];
+    }
+    else if (logShape.length === 4 &&
+        logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+        logShape[3] <= maxTexSize) {
+        return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
     }
     else if (logShape.length === 4 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
@@ -18910,7 +20037,7 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
 }
 exports.getTextureShapeFromLogicalShape = getTextureShapeFromLogicalShape;
 
-},{"../../environment":64,"../../util":194}],132:[function(require,module,exports){
+},{"../../environment":64,"../../util":214}],143:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var array_ops_1 = require("../ops/array_ops");
@@ -18932,7 +20059,7 @@ function whereImpl(condShape, condVals) {
 }
 exports.whereImpl = whereImpl;
 
-},{"../ops/array_ops":134}],133:[function(require,module,exports){
+},{"../ops/array_ops":146}],144:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -18957,7 +20084,13 @@ function log() {
 }
 exports.log = log;
 
-},{"./environment":64}],134:[function(require,module,exports){
+},{"./environment":64}],145:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var confusion_matrix_1 = require("./ops/confusion_matrix");
+exports.confusionMatrix = confusion_matrix_1.confusionMatrix;
+
+},{"./ops/confusion_matrix":156}],146:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -19356,9 +20489,10 @@ function stack_(tensors, axis) {
 function batchToSpaceND_(x, blockShape, crops) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'batchToSpaceND');
     var prod = blockShape.reduce(function (a, b) { return a * b; });
-    util.assert($x.rank >= 1 + blockShape.length, "input rank should be > than [blockShape] but got " + $x.rank);
-    util.assert(crops.length === blockShape.length, "crops.shape[0] must be equal to [blockShape] but got " + crops.length);
-    util.assert($x.shape[0] % prod === 0, "input tensor batch must be divisible by prod( blockShape )");
+    util.assert($x.rank >= 1 + blockShape.length, "input rank is " + $x.rank + " but should be > than blockShape.length " + blockShape.length);
+    util.assert(crops.length === blockShape.length, "crops.length is " + crops.length + " but should be equal to blockShape.length  " + blockShape.length);
+    util.assert($x.shape[0] % prod === 0, "input tensor batch is " + $x.shape[0] + " but is not divisible by the product of " +
+        ("the elements of blockShape " + blockShape.join(' * ') + " === " + prod));
     var grad = function (dy) {
         return { $x: function () { return dy.spaceToBatchND(blockShape, crops); } };
     };
@@ -19485,7 +20619,7 @@ exports.tile = operation_1.op({ tile_: tile_ });
 exports.truncatedNormal = operation_1.op({ truncatedNormal_: truncatedNormal_ });
 exports.unstack = operation_1.op({ unstack_: unstack_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_split":142,"./operation":156,"./rand":159,"./tensor_ops":171}],135:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_split":154,"./operation":171,"./rand":174,"./tensor_ops":191}],147:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getReshaped(inputShape, blockShape, prod, batchToSpace) {
@@ -19583,7 +20717,7 @@ function getSliceSize(uncroppedShape, crops, blockShape) {
 }
 exports.getSliceSize = getSliceSize;
 
-},{}],136:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -19673,7 +20807,7 @@ function getInnerMostAxes(numAxes, rank) {
 }
 exports.getInnerMostAxes = getInnerMostAxes;
 
-},{"../util":194}],137:[function(require,module,exports){
+},{"../util":214}],149:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19893,7 +21027,7 @@ exports.batchNormalization3d = operation_1.op({ batchNormalization3d_: batchNorm
 exports.batchNormalization4d = operation_1.op({ batchNormalization4d_: batchNormalization4d_ });
 exports.batchNormalization = operation_1.op({ batchNormalization_: batchNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],138:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],150:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20259,7 +21393,7 @@ exports.squaredDifferenceStrict = operation_1.op({ squaredDifferenceStrict_: squ
 exports.sub = operation_1.op({ sub_: sub_ });
 exports.subStrict = operation_1.op({ subStrict_: subStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../types":193,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],139:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../types":213,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],151:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getBroadcastDims(inShape, outShape) {
@@ -20329,7 +21463,7 @@ function assertAndGetBroadcastShape(shapeA, shapeB) {
 }
 exports.assertAndGetBroadcastShape = assertAndGetBroadcastShape;
 
-},{}],140:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20433,7 +21567,7 @@ exports.lessStrict = operation_1.op({ lessStrict_: lessStrict_ });
 exports.notEqual = operation_1.op({ notEqual_: notEqual_ });
 exports.notEqualStrict = operation_1.op({ notEqualStrict_: notEqualStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],141:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],153:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20459,7 +21593,7 @@ exports.complex = operation_1.op({ complex_: complex_ });
 exports.real = operation_1.op({ real_: real_ });
 exports.imag = operation_1.op({ imag_: imag_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],142:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],154:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20485,6 +21619,7 @@ function concat_(tensors, axis) {
     if (axis === void 0) { axis = 0; }
     util_1.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     var $tensors = tensor_util_env_1.convertToTensorArray(tensors, 'tensors', 'concat');
+    axis = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var outShape = concat_util_1.computeOutShape($tensors.map(function (t) { return t.shape; }), axis);
     if (util_1.sizeFromShape(outShape) === 0) {
         return tensor_ops_1.tensor([], outShape);
@@ -20493,16 +21628,15 @@ function concat_(tensors, axis) {
     if ($tensors.length === 1) {
         return $tensors[0];
     }
-    var axes = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var shapes = $tensors.map(function (t) { return t.shape; });
-    concat_util_1.assertParamsConsistent(shapes, axes);
+    concat_util_1.assertParamsConsistent(shapes, axis);
     var der = function (dy) {
         var sizeSplits = shapes.map(function (s) { return s[axis]; });
         var derTensors = exports.split(dy, sizeSplits, axis);
         return derTensors.map(function (t) { return function () { return t; }; });
     };
     var inputs = $tensors;
-    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axes); }, inputs, der);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axis); }, inputs, der);
 }
 function split_(x, numOrSizeSplits, axis) {
     if (axis === void 0) { axis = 0; }
@@ -20527,7 +21661,7 @@ exports.concat3d = operation_1.op({ concat3d_: concat3d_ });
 exports.concat4d = operation_1.op({ concat4d_: concat4d_ });
 exports.split = operation_1.op({ split_: split_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_util":143,"./operation":156,"./tensor_ops":171}],143:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_util":155,"./operation":171,"./tensor_ops":191}],155:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -20557,13 +21691,40 @@ function computeOutShape(shapes, axis) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194}],144:[function(require,module,exports){
+},{"../util":214}],156:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tensor_util_env_1 = require("../tensor_util_env");
+var util = require("../util");
+var array_ops_1 = require("./array_ops");
+var operation_1 = require("./operation");
+function confusionMatrix_(labels, predictions, numClasses) {
+    var $labels = tensor_util_env_1.convertToTensor(labels, 'label', 'confusionMatrix', 'int32');
+    var $predictions = tensor_util_env_1.convertToTensor(predictions, 'label', 'confusionMatrix', 'int32');
+    util.assert(numClasses == null || numClasses > 0 && Number.isInteger(numClasses), "If provided, numClasses must be a positive integer, " +
+        ("but got " + numClasses));
+    util.assert($labels.rank === 1, "Expected the rank of labels to be 1, but got " + $labels.rank);
+    util.assert($predictions.rank === 1, "Expected the rank of predictions to be 1, " +
+        ("but got " + $predictions.rank));
+    util.assert($labels.shape[0] === $predictions.shape[0], "Mismatch in the number of examples: " +
+        ($labels.shape[0] + " vs. " + $predictions.shape[0] + ". ") +
+        "Labels and predictions should have the same number of elements.");
+    util.assert(numClasses > 0 && Number.isInteger(numClasses), "numClasses is required to be a positive integer, but got " + numClasses);
+    var oneHotLabels = array_ops_1.oneHot($labels, numClasses);
+    var oneHotPredictions = array_ops_1.oneHot($predictions, numClasses);
+    return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+exports.confusionMatrix_ = confusionMatrix_;
+exports.confusionMatrix = operation_1.op({ confusionMatrix_: confusionMatrix_ });
+
+},{"../tensor_util_env":210,"../util":214,"./array_ops":146,"./operation":171}],157:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
+var matmul_1 = require("./matmul");
 var operation_1 = require("./operation");
 function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) {
     if (dataFormat === void 0) { dataFormat = 'NWC'; }
@@ -20585,7 +21746,7 @@ function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) 
     }
     util.assert(x3D.shape[2] === $filter.shape[1], "Error in conv1d: depth of input (" + x3D.shape[2] + ") must match " +
         ("input depth for filter " + $filter.shape[1] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
         ("Got stride " + stride + " and dilation '" + dilation + "'"));
     util.assert(dataFormat === 'NWC', "Error in conv1d: got dataFormat of " + dataFormat + " but only NWC is currently supported.");
     var filter4D = $filter.as4D(1, $filter.shape[0], $filter.shape[1], $filter.shape[2]);
@@ -20619,19 +21780,30 @@ function conv2d_(x, filter, strides, pad, dataFormat, dilations, dimRoundingMode
     }
     util.assert(x4D.shape[3] === $filter.shape[2], "Error in conv2d: depth of input (" + x4D.shape[3] + ") must match " +
         ("input depth for filter " + $filter.shape[2] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert(dataFormat === 'NHWC', "Error in conv2d: got dataFormat of " + dataFormat + " but only NHWC is currently supported.");
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
-    var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
-            ("yet supported in gradients. Got dilations '" + dilations + "'"));
-        return {
-            x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
-            $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+    var res;
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' || convInfo.padInfo.type === 'VALID')) {
+        var x2d = x4D.reshape([-1, convInfo.inChannels]);
+        var w2d = $filter.reshape([convInfo.inChannels, convInfo.outChannels]);
+        res = matmul_1.matMul(x2d, w2d).reshape(convInfo.outShape);
+    }
+    else {
+        var grad = function (dy) {
+            util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+                ("yet supported in gradients. Got dilations '" + dilations + "'"));
+            return {
+                x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
+                $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+            };
         };
-    };
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+        res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+    }
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20665,8 +21837,15 @@ function conv2dDerInput_(xShape, dy, filter, strides, pad, dimRoundingMode) {
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
     var dilations = 1;
+    var grad = function (ddx) {
+        var dataFormat = 'NHWC';
+        return {
+            dy4D: function () { return exports.conv2d(ddx, filter, strides, pad, dataFormat, dilations, dimRoundingMode); },
+            filter: function () { return exports.conv2dDerFilter(ddx, dy4D, filter.shape, strides, pad, dimRoundingMode); }
+        };
+    };
     var convInfo = conv_util.computeConv2DInfo(xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D });
+    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D, filter: filter }, grad);
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20725,7 +21904,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     if (dilations == null) {
         dilations = [1, 1];
     }
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in depthwiseConv2d: pad must be an integer when using, " +
@@ -20733,7 +21912,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     }
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode, true);
     var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+        util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
             ("1 are not yet supported. Got dilations '" + dilations + "'"));
         return {
             x: function () { return depthwiseConv2dDerInput(x4D.shape, dy, $filter, convInfo); },
@@ -20785,16 +21964,6 @@ function separableConv2d_(x, depthwiseFilter, pointwiseFilter, strides, pad, dil
     }
     return res;
 }
-function parseTupleParam(param) {
-    return typeof param === 'number' ? [param, param] : param;
-}
-function tupleValuesAreOne(param) {
-    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
-    return dimA === 1 && dimB === 1;
-}
-function eitherStridesOrDilationsAreOne(strides, dilations) {
-    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
-}
 function depthwiseConv2dDerInput(xShape, dy, filter, convInfo) {
     var dy4D = dy;
     var reshapedTo4D = false;
@@ -20821,15 +21990,16 @@ function depthwiseConv2dDerFilter(x, dy, filterShape, convInfo) {
 }
 exports.conv1d = operation_1.op({ conv1d_: conv1d_ });
 exports.conv2d = operation_1.op({ conv2d_: conv2d_ });
+exports.conv2dDerFilter = operation_1.op({ conv2dDerFilter_: conv2dDerFilter_ });
 exports.depthwiseConv2d = operation_1.op({ depthwiseConv2d_: depthwiseConv2d_ });
 exports.separableConv2d = operation_1.op({ separableConv2d_: separableConv2d_ });
 exports.conv2dTranspose = operation_1.op({ conv2dTranspose_: conv2dTranspose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],145:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./matmul":168,"./operation":171}],158:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
-function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, dataFormat) {
+function computePool2DInfo(inShape, filterSize, strides, dilations, pad, roundingMode, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var _a = parseTupleParam(filterSize), filterHeight = _a[0], filterWidth = _a[1];
     var filterShape;
@@ -20842,7 +22012,6 @@ function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, data
     else {
         throw new Error("Unknown dataFormat " + dataFormat);
     }
-    var dilations = 1;
     return computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundingMode, false, dataFormat);
 }
 exports.computePool2DInfo = computePool2DInfo;
@@ -20887,6 +22056,8 @@ function computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundi
         strideWidth: strideWidth,
         filterHeight: filterHeight,
         filterWidth: filterWidth,
+        effectiveFilterHeight: effectiveFilterHeight,
+        effectiveFilterWidth: effectiveFilterWidth,
         dilationHeight: dilationHeight,
         dilationWidth: dilationWidth,
         inShape: inShape,
@@ -20971,8 +22142,17 @@ function conditionalRound(value, roundingMode) {
             throw new Error("Unknown roundingMode " + roundingMode);
     }
 }
+function tupleValuesAreOne(param) {
+    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
+    return dimA === 1 && dimB === 1;
+}
+exports.tupleValuesAreOne = tupleValuesAreOne;
+function eitherStridesOrDilationsAreOne(strides, dilations) {
+    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+exports.eitherStridesOrDilationsAreOne = eitherStridesOrDilationsAreOne;
 
-},{"../util":194}],146:[function(require,module,exports){
+},{"../util":214}],159:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ERF_P = 0.3275911;
@@ -20982,7 +22162,64 @@ exports.ERF_A3 = 1.421413741;
 exports.ERF_A4 = -1.453152027;
 exports.ERF_A5 = 1.061405429;
 
-},{}],147:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function gatherND_(x, indices) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'gatherND', 'int32');
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'gatherND');
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.gatherND($x, $indices); }, { $x: $x, $indices: $indices });
+}
+exports.gatherND = operation_1.op({ gatherND_: gatherND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],161:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function prepareAndValidate(tensor, indices) {
+    if (tensor.rank < 1) {
+        throw new Error('tf.gatherND() expects the input to be rank 1 or higher,' +
+            (" but the rank was " + tensor.rank + "."));
+    }
+    if (indices.rank < 1) {
+        throw new Error('tf.gatherND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error('tf.gatherND() expects the indices to be int32 type,' +
+            (" but the dtype was " + indices.dtype + "."));
+    }
+    if (indices.shape[indices.rank - 1] > tensor.rank) {
+        throw new Error('index innermost dimension length must be <= tensor rank; saw: ' +
+            (indices.shape[indices.rank - 1] + " vs. " + tensor.rank));
+    }
+    if (tensor.size === 0) {
+        throw new Error('Requested more than 0 entries, but input is empty.' +
+            (" Input shape: " + tensor.shape + "."));
+    }
+    var indicesShape = indices.shape;
+    var sliceRank = indicesShape[indicesShape.length - 1];
+    var nResult = 1;
+    for (var i = 0; i < indicesShape.length - 1; ++i) {
+        nResult *= indicesShape[i];
+    }
+    var inputShape = tensor.shape;
+    var resultShape = indicesShape.slice();
+    resultShape.pop();
+    var sliceSize = 1;
+    for (var i = sliceRank; i < tensor.rank; ++i) {
+        sliceSize *= inputShape[i];
+        resultShape.push(inputShape[i]);
+    }
+    var strides = util_1.computeStrides(tensor.shape).map(function (stride) { return stride / sliceSize; }).concat([1]).slice(0, sliceRank);
+    return [resultShape, nResult, sliceSize, strides];
+}
+exports.prepareAndValidate = prepareAndValidate;
+
+},{"../util":214}],162:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21177,7 +22414,7 @@ exports.nonMaxSuppression = operation_1.op({ nonMaxSuppression_: nonMaxSuppressi
 exports.nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
 exports.cropAndResize = cropAndResize_;
 
-},{"../environment":64,"../kernels/non_max_suppression_impl":84,"../tensor_util_env":190,"../util":194,"./operation":156}],148:[function(require,module,exports){
+},{"../environment":64,"../kernels/non_max_suppression_impl":85,"../tensor_util_env":210,"../util":214,"./operation":171}],163:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21323,7 +22560,7 @@ function qr2d(x, fullMatrices) {
 exports.gramSchmidt = operation_1.op({ gramSchmidt_: gramSchmidt_ });
 exports.qr = operation_1.op({ qr_: qr_ });
 
-},{"../environment":64,"../globals":66,"../util":194,"./array_ops":134,"./concat_split":142,"./norm":155,"./operation":156,"./reduction_ops":161,"./tensor_ops":171}],149:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../util":214,"./array_ops":146,"./concat_split":154,"./norm":170,"./operation":171,"./reduction_ops":176,"./tensor_ops":191}],164:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21440,7 +22677,7 @@ exports.logicalXor = operation_1.op({ logicalXor_: logicalXor_ });
 exports.where = operation_1.op({ where_: where_ });
 exports.whereAsync = whereAsync_;
 
-},{"../environment":64,"../kernels/where_impl":132,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],150:[function(require,module,exports){
+},{"../environment":64,"../kernels/where_impl":143,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],165:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var globals_1 = require("../globals");
@@ -21665,7 +22902,7 @@ exports.meanSquaredError = operation_1.op({ meanSquaredError_: meanSquaredError_
 exports.sigmoidCrossEntropy = operation_1.op({ sigmoidCrossEntropy_: sigmoidCrossEntropy_ });
 exports.softmaxCrossEntropy = operation_1.op({ softmaxCrossEntropy_: softmaxCrossEntropy_ });
 
-},{"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],151:[function(require,module,exports){
+},{"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],166:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21702,7 +22939,7 @@ function localResponseNormalization_(x, depthRadius, bias, alpha, beta) {
 }
 exports.localResponseNormalization = operation_1.op({ localResponseNormalization_: localResponseNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],152:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],167:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21751,7 +22988,7 @@ function basicLSTMCell_(forgetBias, lstmKernel, lstmBias, data, c, h) {
 exports.basicLSTMCell = operation_1.op({ basicLSTMCell_: basicLSTMCell_ });
 exports.multiRNNCell = operation_1.op({ multiRNNCell_: multiRNNCell_ });
 
-},{"../tensor_util_env":190,"./operation":156}],153:[function(require,module,exports){
+},{"../tensor_util_env":210,"./operation":171}],168:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21847,7 +23084,7 @@ exports.matMul = operation_1.op({ matMul_: matMul_ });
 exports.dot = operation_1.op({ dot_: dot_ });
 exports.outerProduct = operation_1.op({ outerProduct_: outerProduct_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],154:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],169:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_1 = require("../tensor_util");
@@ -21875,7 +23112,7 @@ function movingAverage_(v, x, decay, step, zeroDebias) {
 }
 exports.movingAverage = operation_1.op({ movingAverage_: movingAverage_ });
 
-},{"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],155:[function(require,module,exports){
+},{"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],170:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21938,7 +23175,7 @@ function normImpl(x, p, axis) {
 }
 exports.norm = operation_1.op({ norm_: norm_ });
 
-},{"../tensor_util_env":190,"./axis_util":136,"./operation":156,"./tensor_ops":171}],156:[function(require,module,exports){
+},{"../tensor_util_env":210,"./axis_util":148,"./operation":171,"./tensor_ops":191}],171:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21978,7 +23215,7 @@ function op(f) {
 }
 exports.op = op;
 
-},{"../environment":64}],157:[function(require,module,exports){
+},{"../environment":64}],172:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -22009,6 +23246,10 @@ __export(require("./lstm"));
 __export(require("./moving_average"));
 __export(require("./strided_slice"));
 __export(require("./topk"));
+__export(require("./scatter_nd"));
+__export(require("./spectral_ops"));
+__export(require("./sparse_to_dense"));
+__export(require("./gather_nd"));
 var operation_1 = require("./operation");
 exports.op = operation_1.op;
 var losses = require("./loss_ops");
@@ -22017,8 +23258,10 @@ var linalg = require("./linalg_ops");
 exports.linalg = linalg;
 var image = require("./image_ops");
 exports.image = image;
+var spectral = require("./spectral_ops");
+exports.spectral = spectral;
 
-},{"./array_ops":134,"./batchnorm":137,"./binary_ops":138,"./compare":140,"./complex_ops":141,"./concat_split":142,"./conv":144,"./image_ops":147,"./linalg_ops":148,"./logical_ops":149,"./loss_ops":150,"./lrn":151,"./lstm":152,"./matmul":153,"./moving_average":154,"./norm":155,"./operation":156,"./pool":158,"./reduction_ops":161,"./relu_ops":162,"./reverse":163,"./segment_ops":164,"./slice":167,"./softmax":169,"./strided_slice":170,"./tensor_ops":171,"./topk":172,"./transpose":173,"./unary_ops":174}],158:[function(require,module,exports){
+},{"./array_ops":146,"./batchnorm":149,"./binary_ops":150,"./compare":152,"./complex_ops":153,"./concat_split":154,"./conv":157,"./gather_nd":160,"./image_ops":162,"./linalg_ops":163,"./logical_ops":164,"./loss_ops":165,"./lrn":166,"./lstm":167,"./matmul":168,"./moving_average":169,"./norm":170,"./operation":171,"./pool":173,"./reduction_ops":176,"./relu_ops":177,"./reverse":178,"./scatter_nd":179,"./segment_ops":181,"./slice":184,"./softmax":186,"./sparse_to_dense":187,"./spectral_ops":189,"./strided_slice":190,"./tensor_ops":191,"./topk":192,"./transpose":193,"./unary_ops":194}],173:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22026,7 +23269,7 @@ var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
 var operation_1 = require("./operation");
-function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'maxPool');
     var x4D = $x;
     var reshapedTo4D = false;
@@ -22034,18 +23277,21 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
         reshapedTo4D = true;
         x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
     }
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
     util.assert(x4D.rank === 4, "Error in maxPool: input must be rank 4 but got rank " + x4D.rank + ".");
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in maxPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var grad = function (dy, saved) {
         var y4D = saved[0];
         return {
-            x: function () {
-                return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, pad);
-            }
+            x: function () { return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, dilations, pad); }
         };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.maxPool(x4D, convInfo)); }, { x: x4D }, grad);
@@ -22054,9 +23300,17 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return maxPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function avgPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'avgPool');
     util.assert($x.dtype === 'float32', 'The input dtype to avgPool must be float32');
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var x4D = $x;
     var reshapedTo4D = false;
     if ($x.rank === 3) {
@@ -22068,9 +23322,11 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
         util.assert(util.isInt(pad), "Error in avgPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad);
     var grad = function (dy) {
-        return { x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, pad); } };
+        return {
+            x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, dilations, pad); }
+        };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPool(x4D, convInfo); }, { x: x4D }, grad);
     res = res.cast($x.dtype);
@@ -22079,11 +23335,33 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundingMode) {
+function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return avgPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function pool_(input, windowShape, poolingType, padding, dilationRate, strides) {
+    if (dilationRate == null) {
+        dilationRate = 1;
+    }
+    if (strides == null) {
+        strides = 1;
+    }
+    if (poolingType === 'avg') {
+        return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+    else {
+        return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+}
+function maxPoolBackprop(dy, input, output, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'maxPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'maxPoolBackprop');
     var $output = tensor_util_env_1.convertToTensor(output, 'output', 'maxPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPoolBackProp: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert($dy.rank === 4, "Error in maxPoolBackprop: dy must be rank 4 but got rank " +
         ($dy.rank + "."));
     util.assert($input.rank === 4, "Error in maxPoolBackprop: input must be rank 4 but got rank " +
@@ -22092,14 +23370,19 @@ function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundin
         util.assert(util.isInt(pad), "Error in maxPoolBackprop: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.maxPoolBackprop($dy, $input, $output, convInfo); }, { $dy: $dy, $input: $input });
     return res;
 }
-function avgPoolBackprop(dy, input, filterSize, strides, pad) {
+function avgPoolBackprop(dy, input, filterSize, strides, dilations, pad) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'avgPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'avgPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPoolBackprop: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var input4D = $input;
     var dy4D = $dy;
     var reshapedTo4D = false;
@@ -22112,7 +23395,7 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
         (dy4D.rank + "."));
     util.assert(input4D.rank === 4, "Error in avgPoolBackprop: input must be rank 4 but got rank " +
         (input4D.rank + "."));
-    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, dilations, pad);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPoolBackprop(dy4D, input4D, convInfo); }, { dy4D: dy4D, input4D: input4D });
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
@@ -22121,8 +23404,9 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
 }
 exports.maxPool = operation_1.op({ maxPool_: maxPool_ });
 exports.avgPool = operation_1.op({ avgPool_: avgPool_ });
+exports.pool = operation_1.op({ pool_: pool_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],159:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./operation":171}],174:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var seedrandom = require("seedrandom");
@@ -22180,7 +23464,7 @@ var MPRandGauss = (function () {
 }());
 exports.MPRandGauss = MPRandGauss;
 
-},{"seedrandom":282}],160:[function(require,module,exports){
+},{"seedrandom":306}],175:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22193,7 +23477,7 @@ function computeOptimalWindowSize(inSize) {
 }
 exports.computeOptimalWindowSize = computeOptimalWindowSize;
 
-},{"../util":194}],161:[function(require,module,exports){
+},{"../util":214}],176:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22254,6 +23538,28 @@ function sum_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function prod_(x, axis, keepDims) {
+    if (axis === void 0) { axis = null; }
+    if (keepDims === void 0) { keepDims = false; }
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'prod');
+    if ($x.dtype === 'bool') {
+        $x = $x.toInt();
+    }
+    var axes = axis_util.parseAxisParam(axis, $x.shape);
+    var permutation = axis_util.getAxesPermutation(axes, $x.rank);
+    var reductionAxes = axes;
+    var permutedX = $x;
+    if (permutation != null) {
+        permutedX = $x.transpose(permutation);
+        reductionAxes = axis_util.getInnerMostAxes(reductionAxes.length, $x.rank);
+    }
+    var value = environment_1.ENV.engine.runKernel(function (backend) { return backend.prod(permutedX, reductionAxes); }, { permutedX: permutedX });
+    if (keepDims) {
+        var newShape = axis_util.expandShapeToKeepDim(value.shape, axes);
+        value = value.reshape(newShape);
+    }
+    return value;
+}
 function mean_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
@@ -22280,10 +23586,26 @@ function mean_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes) {
+    var y = saved[0];
+    if (y.rank < xOrig.rank) {
+        y = y.reshape(axis_util.expandShapeToKeepDim(y.shape, origAxes));
+    }
+    if (dy.rank < xOrig.rank) {
+        dy = dy.reshape(axis_util.expandShapeToKeepDim(dy.shape, origAxes));
+    }
+    return {
+        $x: function () {
+            var dx = dy.mul(xOrig.equal(y).cast(dy.dtype));
+            return permutedAxes == null ? dx : dx.transpose(permutedAxes);
+        }
+    };
+}
 function min_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'min');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22291,10 +23613,13 @@ function min_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.min($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.min($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22302,6 +23627,7 @@ function max_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'max');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22309,10 +23635,13 @@ function max_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.max($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.max($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22412,8 +23741,9 @@ exports.mean = operation_1.op({ mean_: mean_ });
 exports.min = operation_1.op({ min_: min_ });
 exports.moments = operation_1.op({ moments_: moments_ });
 exports.sum = operation_1.op({ sum_: sum_ });
+exports.prod = operation_1.op({ prod_: prod_ });
 
-},{"../environment":64,"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156,"./tensor_ops":171}],162:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171,"./tensor_ops":191}],177:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22479,7 +23809,7 @@ exports.prelu = operation_1.op({ prelu_: prelu_ });
 exports.relu = operation_1.op({ relu_: relu_ });
 exports.selu = operation_1.op({ selu_: selu_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./binary_ops":138,"./logical_ops":149,"./operation":156,"./selu_util":166,"./tensor_ops":171}],163:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./binary_ops":150,"./logical_ops":164,"./operation":171,"./selu_util":183,"./tensor_ops":191}],178:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22525,7 +23855,99 @@ exports.reverse2d = operation_1.op({ reverse2d_: reverse2d_ });
 exports.reverse3d = operation_1.op({ reverse3d_: reverse3d_ });
 exports.reverse4d = operation_1.op({ reverse4d_: reverse4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],164:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],179:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+var scatter_nd_util = require("./scatter_nd_util");
+function scatterND_(indices, updates, shape) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'scatterND', 'int32');
+    var $updates = tensor_util_env_1.convertToTensor(updates, 'updates', 'scatterND');
+    scatter_nd_util.validateInput($updates, $indices, shape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.scatterND($indices, $updates, shape); }, { $indices: $indices, $updates: $updates });
+}
+exports.scatterND = operation_1.op({ scatterND_: scatterND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171,"./scatter_nd_util":180}],180:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function validateUpdateShape(shape, indices, updates) {
+    var sliceDim = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var batchDim = (indices.rank > 1) ? indices.rank - 1 : 1;
+    var shapeError = 'Must have updates.shape = indices.shape[:batchDim] + ' +
+        ("shape[sliceDim:], got updates.shape: " + updates.shape) +
+        (", indices.shape: " + indices.shape + ", shape: " + shape) +
+        (", sliceDim: " + sliceDim + ", and batchDim: " + batchDim + ".");
+    if (updates.rank < batchDim) {
+        throw new Error(shapeError + (" update.rank < " + batchDim + ". "));
+    }
+    if (shape.length < sliceDim + (updates.rank - batchDim)) {
+        throw new Error(shapeError +
+            (" Output shape length < " + (sliceDim + (updates.rank - batchDim))));
+    }
+    if (updates.rank !== batchDim + shape.length - sliceDim) {
+        throw new Error(shapeError + (" update.rank != " + (batchDim + shape.length - sliceDim)));
+    }
+    for (var d = 0; d < batchDim; ++d) {
+        if (updates.shape[d] !== indices.shape[d]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + d + "] (" + updates.shape[d] + ") != indices.shape[" + d + "] (" + indices.shape[d] + ")."));
+        }
+    }
+    for (var d = 0; d < updates.rank - batchDim; ++d) {
+        if (updates.shape[d + batchDim] !== shape[d + sliceDim]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + (d + batchDim) + "] (" + updates.shape[d + batchDim] + ") != shape[" + (d + batchDim) + "] (" + shape[d + batchDim] + ")"));
+        }
+    }
+}
+exports.validateUpdateShape = validateUpdateShape;
+function validateInput(updates, indices, shape) {
+    if (indices.rank < 1) {
+        throw new Error('tf.scatterND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (updates.rank < 1) {
+        throw new Error('tf.scatterND() expects the updates to be rank 1 or higher,' +
+            (" but the rank was " + updates.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error("The dtype of 'indices' should be int32, but got dtype: " + indices.dtype);
+    }
+    if (shape.length < 1) {
+        throw new Error("Output rank must be greater or equal to 1, but got shape: " + shape);
+    }
+    if (shape.length === 0) {
+        if (indices.size === 0) {
+            throw new Error("Indices specified for empty output. indices shape: " + indices.shape);
+        }
+        if (updates.size === 0) {
+            throw new Error("Updates specified for empty output. updates shape: " + updates.shape);
+        }
+    }
+    validateUpdateShape(shape, indices, updates);
+}
+exports.validateInput = validateInput;
+function calculateShapes(updates, indices, shape) {
+    var sliceRank = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var totalNd = shape.length;
+    var sliceSize = 1;
+    for (var i = sliceRank; i < totalNd; ++i) {
+        sliceSize *= shape[i];
+    }
+    var safeSliceDim = (sliceRank < 1) ? 1 : sliceRank;
+    var numUpdates = indices.size / safeSliceDim;
+    var outputStrides = util_1.computeStrides(shape).concat([1]);
+    var strides = outputStrides.slice(outputStrides.length - sliceRank, outputStrides.length);
+    var outputSize = util_1.sizeFromShape(shape);
+    return { sliceRank: sliceRank, numUpdates: numUpdates, sliceSize: sliceSize, strides: strides, outputSize: outputSize };
+}
+exports.calculateShapes = calculateShapes;
+
+},{"../util":214}],181:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22617,7 +24039,7 @@ function gatherDropNegatives(x, indices) {
 exports.gather = operation_1.op({ gather_: gather_ });
 exports.unsortedSegmentSum = operation_1.op({ unsortedSegmentSum_: unsortedSegmentSum_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./axis_util":136,"./binary_ops":138,"./compare":140,"./logical_ops":149,"./operation":156,"./tensor_ops":171}],165:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./axis_util":148,"./binary_ops":150,"./compare":152,"./logical_ops":164,"./operation":171,"./tensor_ops":191}],182:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22659,13 +24081,13 @@ function computeOutShape(aShape, axis, numSegments) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194,"./reduce_util":160}],166:[function(require,module,exports){
+},{"../util":214,"./reduce_util":175}],183:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SELU_SCALEALPHA = 1.7580993408473768599402175208123;
 exports.SELU_SCALE = 1.0507009873554804934193349852946;
 
-},{}],167:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22680,17 +24102,17 @@ function slice1d_(x, begin, size) {
 }
 function slice2d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice2d');
-    util.assert($x.rank === 2, "slice1d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 2, "slice2d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice3d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice3d');
-    util.assert($x.rank === 3, "slice1d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 3, "slice3d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice4d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice4d');
-    util.assert($x.rank === 4, "slice1d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 4, "slice4d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice_(x, begin, size) {
@@ -22747,7 +24169,7 @@ exports.slice2d = operation_1.op({ slice2d_: slice2d_ });
 exports.slice3d = operation_1.op({ slice3d_: slice3d_ });
 exports.slice4d = operation_1.op({ slice4d_: slice4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./slice_util":168}],168:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./slice_util":185}],185:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -22838,7 +24260,7 @@ function stopForAxis(endMask, stopIndices, strides, inputShape, axis) {
 }
 exports.stopForAxis = stopForAxis;
 
-},{"../util":194}],169:[function(require,module,exports){
+},{"../util":214}],186:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gradients_1 = require("../gradients");
@@ -22870,7 +24292,67 @@ function softmax_(logits, dim) {
 }
 exports.softmax = operation_1.op({ softmax_: softmax_ });
 
-},{"../gradients":67,"../tensor_util_env":190,"./operation":156}],170:[function(require,module,exports){
+},{"../gradients":67,"../tensor_util_env":210,"./operation":171}],187:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var sparse_to_dense = require("../ops/sparse_to_dense_util");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function sparseToDense_(sparseIndices, sparseValues, outputShape, defaultValue) {
+    var $sparseIndices = tensor_util_env_1.convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
+    var $sparseValues = tensor_util_env_1.convertToTensor(sparseValues, 'sparseValues', 'sparseToDense');
+    var $defaultValue = tensor_util_env_1.convertToTensor(defaultValue, 'defaultValue', 'sparseToDense');
+    sparse_to_dense.validateInput($sparseIndices, $sparseValues, outputShape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.sparseToDense($sparseIndices, $sparseValues, outputShape, $defaultValue); }, { $sparseIndices: $sparseIndices, $sparseValues: $sparseValues, $defaultValue: $defaultValue });
+}
+exports.sparseToDense = operation_1.op({ sparseToDense_: sparseToDense_ });
+
+},{"../environment":64,"../ops/sparse_to_dense_util":188,"../tensor_util_env":210,"./operation":171}],188:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateInput(sparseIndices, sparseValues, outputShape) {
+    if (sparseIndices.dtype !== 'int32') {
+        throw new Error('tf.sparseToDense() expects the indices to be int32 type,' +
+            (" but the dtype was " + sparseIndices.dtype + "."));
+    }
+    if (sparseIndices.rank > 2) {
+        throw new Error('sparseIndices should be a scalar, vector, or matrix,' +
+            (" but got shape " + sparseIndices.shape + "."));
+    }
+    var numElems = sparseIndices.rank > 0 ? sparseIndices.shape[0] : 1;
+    var numDims = sparseIndices.rank > 1 ? sparseIndices.shape[1] : 1;
+    if (outputShape.length !== numDims) {
+        throw new Error('outputShape has incorrect number of elements:,' +
+            (" " + outputShape.length + ", should be: " + numDims + "."));
+    }
+    var numValues = sparseValues.size;
+    if (!(sparseValues.rank === 0 ||
+        sparseValues.rank === 1 && numValues === numElems)) {
+        throw new Error('sparseValues has incorrect shape ' +
+            (sparseValues.shape + ", should be [] or [" + numElems + "]"));
+    }
+}
+exports.validateInput = validateInput;
+
+},{}],189:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var operation_1 = require("../ops/operation");
+var util_1 = require("../util");
+function fft_(input) {
+    util_1.assert(input.dtype === 'complex64', "The dtype for tf.spectral.fft() must be complex64 " +
+        ("but got " + input.dtype + "."));
+    var innerDimensionSize = input.shape[input.shape.length - 1];
+    var batch = input.size / innerDimensionSize;
+    var input2D = input.as2D(batch, innerDimensionSize);
+    var ret = environment_1.ENV.engine.runKernel(function (backend) { return backend.fft(input2D); }, { input: input });
+    return ret.reshape(input.shape);
+}
+exports.fft = operation_1.op({ fft_: fft_ });
+
+},{"../environment":64,"../ops/operation":171,"../util":214}],190:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22893,12 +24375,13 @@ function stridedSlice_(x, begin, end, strides, beginMask, endMask, ellipsisMask,
 }
 exports.stridedSlice = operation_1.op({ stridedSlice_: stridedSlice_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],171:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],191:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_1 = require("../tensor");
 var tensor_util_env_1 = require("../tensor_util_env");
+var tensor_util_env_2 = require("../tensor_util_env");
 var util_1 = require("../util");
 var complex_ops_1 = require("./complex_ops");
 var operation_1 = require("./operation");
@@ -22913,7 +24396,7 @@ function tensor(values, shape, dtype) {
         throw new Error('values passed to tensor(values) must be an ' +
             'array of numbers or booleans, or a TypedArray');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (shape != null && inferredShape.length !== 1) {
         util_1.assertShapesMatch(shape, inferredShape, "Error creating a new Tensor. " +
             ("Inferred shape (" + inferredShape + ") does not match the ") +
@@ -22940,7 +24423,7 @@ exports.scalar = scalar;
 function tensor1d(values, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     util_1.assertNonNull(values);
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 1) {
         throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
@@ -22953,7 +24436,7 @@ function tensor2d(values, shape, dtype) {
     if (shape != null && shape.length !== 2) {
         throw new Error('tensor2d() requires shape to have two numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
         throw new Error('tensor2d() requires values to be number[][] or flat/TypedArray');
     }
@@ -22971,7 +24454,7 @@ function tensor3d(values, shape, dtype) {
     if (shape != null && shape.length !== 3) {
         throw new Error('tensor3d() requires shape to have three numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
         throw new Error('tensor3d() requires values to be number[][][] or flat/TypedArray');
     }
@@ -22989,7 +24472,7 @@ function tensor4d(values, shape, dtype) {
     if (shape != null && shape.length !== 4) {
         throw new Error('tensor4d() requires shape to have four numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
         throw new Error('tensor4d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -23007,7 +24490,7 @@ function tensor5d(values, shape, dtype) {
     if (shape != null && shape.length !== 5) {
         throw new Error('tensor5d() requires shape to have five numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 5 && inferredShape.length !== 1) {
         throw new Error('tensor5d() requires values to be ' +
             'number[][][][][] or flat/TypedArray');
@@ -23026,7 +24509,7 @@ function tensor6d(values, shape, dtype) {
     if (shape != null && shape.length !== 6) {
         throw new Error('tensor6d() requires shape to have six numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 6 && inferredShape.length !== 1) {
         throw new Error('tensor6d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -23117,7 +24600,7 @@ exports.range = range;
 exports.onesLike = operation_1.op({ onesLike_: onesLike_ });
 exports.zerosLike = operation_1.op({ zerosLike_: zerosLike_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./complex_ops":141,"./operation":156}],172:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./complex_ops":153,"./operation":171}],192:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23140,7 +24623,7 @@ function topk_(x, k, sorted) {
 }
 exports.topk = operation_1.op({ topk_: topk_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],173:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],193:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23170,7 +24653,7 @@ function transpose_(x, perm) {
 }
 exports.transpose = operation_1.op({ transpose_: transpose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],174:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],194:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23460,7 +24943,7 @@ exports.step = operation_1.op({ step_: step_ });
 exports.tan = operation_1.op({ tan_: tan_ });
 exports.tanh = operation_1.op({ tanh_: tanh_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./tensor_ops":171}],175:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./tensor_ops":191}],195:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23567,7 +25050,7 @@ var AdadeltaOptimizer = (function (_super) {
 exports.AdadeltaOptimizer = AdadeltaOptimizer;
 serialization_1.registerClass(AdadeltaOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],176:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],196:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23649,7 +25132,7 @@ var AdagradOptimizer = (function (_super) {
 exports.AdagradOptimizer = AdagradOptimizer;
 serialization_1.registerClass(AdagradOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],177:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],197:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23768,7 +25251,7 @@ var AdamOptimizer = (function (_super) {
 exports.AdamOptimizer = AdamOptimizer;
 serialization_1.registerClass(AdamOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],178:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],198:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23889,7 +25372,7 @@ var AdamaxOptimizer = (function (_super) {
 exports.AdamaxOptimizer = AdamaxOptimizer;
 serialization_1.registerClass(AdamaxOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],179:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],199:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23979,7 +25462,7 @@ var MomentumOptimizer = (function (_super) {
 exports.MomentumOptimizer = MomentumOptimizer;
 serialization_1.registerClass(MomentumOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./sgd_optimizer":183}],180:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./sgd_optimizer":203}],200:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24020,7 +25503,7 @@ var Optimizer = (function (_super) {
 }(serialization_1.Serializable));
 exports.Optimizer = Optimizer;
 
-},{"../globals":66,"../serialization":185}],181:[function(require,module,exports){
+},{"../globals":66,"../serialization":205}],201:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./adadelta_optimizer");
@@ -24076,7 +25559,7 @@ var OptimizerConstructors = (function () {
 }());
 exports.OptimizerConstructors = OptimizerConstructors;
 
-},{"./adadelta_optimizer":175,"./adagrad_optimizer":176,"./adam_optimizer":177,"./adamax_optimizer":178,"./momentum_optimizer":179,"./rmsprop_optimizer":182,"./sgd_optimizer":183}],182:[function(require,module,exports){
+},{"./adadelta_optimizer":195,"./adagrad_optimizer":196,"./adam_optimizer":197,"./adamax_optimizer":198,"./momentum_optimizer":199,"./rmsprop_optimizer":202,"./sgd_optimizer":203}],202:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24220,7 +25703,7 @@ var RMSPropOptimizer = (function (_super) {
 exports.RMSPropOptimizer = RMSPropOptimizer;
 serialization_1.registerClass(RMSPropOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],183:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],203:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24280,7 +25763,7 @@ var SGDOptimizer = (function (_super) {
 exports.SGDOptimizer = SGDOptimizer;
 serialization_1.registerClass(SGDOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],184:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],204:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("./util");
@@ -24304,7 +25787,11 @@ var Profiler = (function () {
             var vals = r.dataSync();
             util.checkComputationForNaN(vals, r.dtype, name);
             timer.then(function (timing) {
-                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+                var extraInfo = '';
+                if (timing.getExtraProfileInfo != null) {
+                    extraInfo = timing.getExtraProfileInfo();
+                }
+                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
             });
         });
         return result;
@@ -24315,19 +25802,19 @@ exports.Profiler = Profiler;
 var Logger = (function () {
     function Logger() {
     }
-    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs) {
+    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs, extraInfo) {
         var time = util.rightPad(timeMs + "ms", 9);
         var paddedName = util.rightPad(name, 25);
         var rank = result.rank;
         var size = result.size;
         var shape = util.rightPad(result.shape.toString(), 14);
-        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size + "\t%c" + extraInfo, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange', 'color: green');
     };
     return Logger;
 }());
 exports.Logger = Logger;
 
-},{"./util":194}],185:[function(require,module,exports){
+},{"./util":214}],205:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -24372,7 +25859,7 @@ function registerClass(cls) {
 }
 exports.registerClass = registerClass;
 
-},{"./util":194}],186:[function(require,module,exports){
+},{"./util":214}],206:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -24485,7 +25972,7 @@ function backpropagateGradients(tensorAccumulatedGradientMap, filteredTape) {
 }
 exports.backpropagateGradients = backpropagateGradients;
 
-},{"./tensor":187,"./util":194}],187:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],207:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24871,6 +26358,12 @@ var Tensor = (function () {
         if (keepDims === void 0) { keepDims = false; }
         this.throwIfDisposed();
         return opHandler.sum(this, axis, keepDims);
+    };
+    Tensor.prototype.prod = function (axis, keepDims) {
+        if (axis === void 0) { axis = null; }
+        if (keepDims === void 0) { keepDims = false; }
+        this.throwIfDisposed();
+        return opHandler.prod(this, axis, keepDims);
     };
     Tensor.prototype.mean = function (axis, keepDims) {
         if (axis === void 0) { axis = null; }
@@ -25272,6 +26765,10 @@ var Tensor = (function () {
         if (beta === void 0) { beta = 0.5; }
         return opHandler.localResponseNormalization(this, radius, bias, alpha, beta);
     };
+    Tensor.prototype.pool = function (windowShape, poolingType, padding, dilationRate, strides) {
+        this.throwIfDisposed();
+        return opHandler.pool(this, windowShape, poolingType, padding, dilationRate, strides);
+    };
     Tensor.prototype.variable = function (trainable, name, dtype) {
         if (trainable === void 0) { trainable = true; }
         this.throwIfDisposed();
@@ -25304,6 +26801,10 @@ var Tensor = (function () {
     Tensor.prototype.depthToSpace = function (blockSize, dataFormat) {
         this.throwIfDisposed();
         return opHandler.depthToSpace(this, blockSize, dataFormat);
+    };
+    Tensor.prototype.fft = function () {
+        this.throwIfDisposed();
+        return opHandler.spectral.fft(this);
     };
     Tensor.nextId = 0;
     return Tensor;
@@ -25367,7 +26868,7 @@ Object.defineProperty(Variable, Symbol.hasInstance, {
 var variable = Variable.variable;
 exports.variable = variable;
 
-},{"./tensor_format":188,"./util":194}],188:[function(require,module,exports){
+},{"./tensor_format":208,"./util":214}],208:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -25498,7 +26999,7 @@ function createComplexTuples(vals) {
     return complexTuples;
 }
 
-},{"./util":194}],189:[function(require,module,exports){
+},{"./util":214}],209:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -25573,12 +27074,47 @@ function isIterable(obj) {
     return Array.isArray(obj) || typeof obj === 'object';
 }
 
-},{"./tensor":187,"./util":194}],190:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],210:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
 var tensor_1 = require("./tensor");
 var util_1 = require("./util");
+function inferShape(val) {
+    var firstElem = val;
+    if (util_1.isTypedArray(val)) {
+        return [val.length];
+    }
+    if (!Array.isArray(val)) {
+        return [];
+    }
+    var shape = [];
+    while (firstElem instanceof Array) {
+        shape.push(firstElem.length);
+        firstElem = firstElem[0];
+    }
+    if (val instanceof Array && environment_1.ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+        deepAssertShapeConsistency(val, shape, []);
+    }
+    return shape;
+}
+exports.inferShape = inferShape;
+function deepAssertShapeConsistency(val, shape, indices) {
+    indices = indices || [];
+    if (!(val instanceof Array)) {
+        util_1.assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
+            ("but should be an array of " + shape[0] + " elements"); });
+        return;
+    }
+    util_1.assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
+        ("but is an array of " + val.length + " elements"); });
+    util_1.assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
+        ("elements, but has " + val.length + " elements"); });
+    var subShape = shape.slice(1);
+    for (var i = 0; i < val.length; ++i) {
+        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
+    }
+}
 function convertToTensor(x, argName, functionName, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     dtype = dtype || 'float32';
@@ -25590,7 +27126,7 @@ function convertToTensor(x, argName, functionName, dtype) {
         throw new Error("Argument '" + argName + "' passed to '" + functionName + "' must be a " +
             ("Tensor or TensorLike, but got " + x.constructor.name));
     }
-    var inferredShape = util_1.inferShape(x);
+    var inferredShape = inferShape(x);
     if (!util_1.isTypedArray(x) && !Array.isArray(x)) {
         x = [x];
     }
@@ -25607,7 +27143,7 @@ function convertToTensorArray(arg, argName, functionName) {
 }
 exports.convertToTensorArray = convertToTensorArray;
 
-},{"./environment":64,"./tensor":187,"./util":194}],191:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],211:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -25627,6 +27163,9 @@ exports.BROWSER_ENVS = {
 };
 exports.CPU_ENVS = {
     'HAS_WEBGL': false
+};
+exports.BROWSER_CPU_ENVS = {
+    'BACKEND': 'test-cpu'
 };
 exports.ALL_ENVS = {};
 function expectArraysClose(actual, expected, epsilon) {
@@ -25728,7 +27267,7 @@ function expectArrayBuffersEqual(actual, expected) {
 }
 exports.expectArrayBuffersEqual = expectArrayBuffersEqual;
 
-},{"./environment":64,"./tensor":187,"./util":194}],192:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],212:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./optimizers/adadelta_optimizer");
@@ -25751,7 +27290,7 @@ exports.train = {
     adam: optimizer_constructors_1.OptimizerConstructors.adam
 };
 
-},{"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer_constructors":181,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183}],193:[function(require,module,exports){
+},{"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer_constructors":201,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203}],213:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DType;
@@ -25813,7 +27352,7 @@ function sumOutType(type) {
 }
 exports.sumOutType = sumOutType;
 
-},{}],194:[function(require,module,exports){
+},{}],214:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -25834,6 +27373,18 @@ function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 exports.clamp = clamp;
+function nearestLargerEven(val) {
+    return val % 2 === 0 ? val : val + 1;
+}
+exports.nearestLargerEven = nearestLargerEven;
+function sum(arr) {
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) {
+        sum += arr[i];
+    }
+    return sum;
+}
+exports.sum = sum;
 function randUniform(a, b) {
     var r = Math.random();
     return (b * r) + (1 - r) * a;
@@ -25876,41 +27427,6 @@ function flatten(arr, ret) {
     return ret;
 }
 exports.flatten = flatten;
-function inferShape(val) {
-    var firstElem = val;
-    if (isTypedArray(val)) {
-        return [val.length];
-    }
-    if (!Array.isArray(val)) {
-        return [];
-    }
-    var shape = [];
-    while (firstElem instanceof Array) {
-        shape.push(firstElem.length);
-        firstElem = firstElem[0];
-    }
-    if (val instanceof Array) {
-        deepAssertShapeConsistency(val, shape, []);
-    }
-    return shape;
-}
-exports.inferShape = inferShape;
-function deepAssertShapeConsistency(val, shape, indices) {
-    indices = indices || [];
-    if (!(val instanceof Array)) {
-        assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
-            ("but should be an array of " + shape[0] + " elements"); });
-        return;
-    }
-    assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
-        ("but is an array of " + val.length + " elements"); });
-    assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
-        ("elements, but has " + val.length + " elements"); });
-    var subShape = shape.slice(1);
-    for (var i = 0; i < val.length; ++i) {
-        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
-    }
-}
 function sizeFromShape(shape) {
     if (shape.length === 0) {
         return 1;
@@ -25927,6 +27443,12 @@ function isScalarShape(shape) {
 }
 exports.isScalarShape = isScalarShape;
 function arraysEqual(n1, n2) {
+    if (n1 === n2) {
+        return true;
+    }
+    if (n1 == null || n2 == null) {
+        return false;
+    }
     if (n1.length !== n2.length) {
         return false;
     }
@@ -26244,13 +27766,13 @@ function now() {
 exports.now = now;
 
 }).call(this,require('_process'))
-},{"_process":270}],195:[function(require,module,exports){
+},{"_process":294}],215:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.17';
+var version = '0.13.8';
 exports.version = version;
 
-},{}],196:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gpgpu_util = require("./kernels/webgl/gpgpu_util");
@@ -26262,7 +27784,7 @@ exports.MathBackendWebGL = backend_webgl_1.MathBackendWebGL;
 var gpgpu_context_1 = require("./kernels/webgl/gpgpu_context");
 exports.GPGPUContext = gpgpu_context_1.GPGPUContext;
 
-},{"./kernels/backend_webgl":82,"./kernels/webgl/gpgpu_context":104,"./kernels/webgl/gpgpu_util":106,"./kernels/webgl/webgl_util":131}],197:[function(require,module,exports){
+},{"./kernels/backend_webgl":83,"./kernels/webgl/gpgpu_context":110,"./kernels/webgl/gpgpu_util":112,"./kernels/webgl/webgl_util":142}],217:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26304,7 +27826,7 @@ var Elu = (function (_super) {
     return Elu;
 }(Activation));
 exports.Elu = Elu;
-tfjs_core_1.serialization.SerializationMap.register(Elu);
+tfjs_core_1.serialization.registerClass(Elu);
 var Selu = (function (_super) {
     __extends(Selu, _super);
     function Selu() {
@@ -26317,7 +27839,7 @@ var Selu = (function (_super) {
     return Selu;
 }(Activation));
 exports.Selu = Selu;
-tfjs_core_1.serialization.SerializationMap.register(Selu);
+tfjs_core_1.serialization.registerClass(Selu);
 var Relu = (function (_super) {
     __extends(Relu, _super);
     function Relu() {
@@ -26330,7 +27852,7 @@ var Relu = (function (_super) {
     return Relu;
 }(Activation));
 exports.Relu = Relu;
-tfjs_core_1.serialization.SerializationMap.register(Relu);
+tfjs_core_1.serialization.registerClass(Relu);
 var Relu6 = (function (_super) {
     __extends(Relu6, _super);
     function Relu6() {
@@ -26343,7 +27865,7 @@ var Relu6 = (function (_super) {
     return Relu6;
 }(Activation));
 exports.Relu6 = Relu6;
-tfjs_core_1.serialization.SerializationMap.register(Relu6);
+tfjs_core_1.serialization.registerClass(Relu6);
 var Linear = (function (_super) {
     __extends(Linear, _super);
     function Linear() {
@@ -26356,7 +27878,7 @@ var Linear = (function (_super) {
     return Linear;
 }(Activation));
 exports.Linear = Linear;
-tfjs_core_1.serialization.SerializationMap.register(Linear);
+tfjs_core_1.serialization.registerClass(Linear);
 var Sigmoid = (function (_super) {
     __extends(Sigmoid, _super);
     function Sigmoid() {
@@ -26369,7 +27891,7 @@ var Sigmoid = (function (_super) {
     return Sigmoid;
 }(Activation));
 exports.Sigmoid = Sigmoid;
-tfjs_core_1.serialization.SerializationMap.register(Sigmoid);
+tfjs_core_1.serialization.registerClass(Sigmoid);
 var HardSigmoid = (function (_super) {
     __extends(HardSigmoid, _super);
     function HardSigmoid() {
@@ -26382,7 +27904,7 @@ var HardSigmoid = (function (_super) {
     return HardSigmoid;
 }(Activation));
 exports.HardSigmoid = HardSigmoid;
-tfjs_core_1.serialization.SerializationMap.register(HardSigmoid);
+tfjs_core_1.serialization.registerClass(HardSigmoid);
 var Softplus = (function (_super) {
     __extends(Softplus, _super);
     function Softplus() {
@@ -26395,7 +27917,7 @@ var Softplus = (function (_super) {
     return Softplus;
 }(Activation));
 exports.Softplus = Softplus;
-tfjs_core_1.serialization.SerializationMap.register(Softplus);
+tfjs_core_1.serialization.registerClass(Softplus);
 var Softsign = (function (_super) {
     __extends(Softsign, _super);
     function Softsign() {
@@ -26408,7 +27930,7 @@ var Softsign = (function (_super) {
     return Softsign;
 }(Activation));
 exports.Softsign = Softsign;
-tfjs_core_1.serialization.SerializationMap.register(Softsign);
+tfjs_core_1.serialization.registerClass(Softsign);
 var Tanh = (function (_super) {
     __extends(Tanh, _super);
     function Tanh() {
@@ -26421,7 +27943,7 @@ var Tanh = (function (_super) {
     return Tanh;
 }(Activation));
 exports.Tanh = Tanh;
-tfjs_core_1.serialization.SerializationMap.register(Tanh);
+tfjs_core_1.serialization.registerClass(Tanh);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax() {
@@ -26435,7 +27957,7 @@ var Softmax = (function (_super) {
     return Softmax;
 }(Activation));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 function serializeActivation(activation) {
     return activation.getClassName();
 }
@@ -26463,7 +27985,7 @@ function getActivation(identifier) {
 }
 exports.getActivation = getActivation;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],198:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],218:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26481,7 +28003,7 @@ function imageDataFormat() {
 }
 exports.imageDataFormat = imageDataFormat;
 
-},{"@tensorflow/tfjs-core":68}],199:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26526,7 +28048,7 @@ function disposeScalarCache() {
 }
 exports.disposeScalarCache = disposeScalarCache;
 
-},{"@tensorflow/tfjs-core":68}],200:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -26735,27 +28257,42 @@ function randomNormal(shape, mean, stddev, dtype, seed) {
 }
 exports.randomNormal = randomNormal;
 function dot(x, y) {
-    if (y.rank !== 2) {
-        throw new errors_1.NotImplementedError("dot support for y other than rank 2 is not yet implemented: " +
-            ("y shape = " + y.shape));
+    if ((x.rank < 2) || (y.rank < 2)) {
+        throw new errors_1.NotImplementedError("dot requires both inputs to be rank >= 2" +
+            (" but got x shape = " + x.shape + " and y shape = " + y.shape));
+    }
+    if (y.rank >= 3) {
+        var xLastDim = x.shape.slice(-1)[0];
+        var ySecondLastDim = y.shape.slice(-2)[0];
+        if (xLastDim !== ySecondLastDim) {
+            throw new errors_1.NotImplementedError("If rank y >= 3, then the second last dim" +
+                (" of y must equal the last dim of x but got x shape = " + x.shape + " and ") +
+                (" y shape = " + y.shape));
+        }
+    }
+    if ((x.rank === 2) && (y.rank === 2)) {
+        return tfc.matMul(x, y);
     }
     else {
-        if (x.rank === 2) {
-            return tfc.matMul(x, y);
-        }
-        else if (x.rank === 3) {
-            var xShape0 = x.shape[0];
-            var xShape1 = x.shape[1];
-            var xShape2 = x.shape[2];
-            x = x.reshape([xShape0 * xShape1, xShape2]);
-            return tfc.matMul(x, y).reshape([
-                xShape0, xShape1, y.shape[1]
-            ]);
-        }
-        else {
-            throw new errors_1.NotImplementedError("dot support for x of rank " + x.rank + " is not yet implemented: " +
-                ("x shape = " + x.shape));
-        }
+        var xFirstDims = x.shape.slice();
+        var xLastDim = xFirstDims.pop();
+        x = x.reshape([-1, xLastDim]);
+        var yShape = y.shape.slice();
+        var yLastDim = yShape.pop();
+        var ySecondLastDim = yShape.pop();
+        var yOtherDims = yShape.concat([yLastDim]);
+        var perm = Array.from({ length: y.rank }, function (_, i) {
+            if (i === 0) {
+                return y.rank - 2;
+            }
+            else if (i <= y.rank - 2) {
+                return i - 1;
+            }
+            return i;
+        });
+        y = y.transpose(perm).reshape([ySecondLastDim, -1]);
+        var outputShape = xFirstDims.concat(yOtherDims);
+        return tfc.matMul(x, y).reshape(outputShape);
     }
 }
 exports.dot = dot;
@@ -26923,7 +28460,7 @@ function inTrainPhase(x, alt, training) {
 }
 exports.inTrainPhase = inTrainPhase;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/math_utils":240,"./common":198,"@tensorflow/tfjs-core":68}],201:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/math_utils":264,"./common":218,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26973,8 +28510,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("./backend/state");
+var errors_1 = require("./errors");
 var logs_1 = require("./logs");
 var generic_utils = require("./utils/generic_utils");
+var ModelLoggingVerbosity;
+(function (ModelLoggingVerbosity) {
+    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
+    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
+})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
 var BaseCallback = (function () {
     function BaseCallback() {
         this.validationData = null;
@@ -27128,19 +28671,22 @@ var CallbackList = (function () {
                         if (logs == null) {
                             logs = {};
                         }
-                        _i = 0, _a = this.callbacks;
-                        _b.label = 1;
+                        return [4, logs_1.resolveScalarsInLogs(logs)];
                     case 1:
-                        if (!(_i < _a.length)) return [3, 4];
+                        _b.sent();
+                        _i = 0, _a = this.callbacks;
+                        _b.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3, 5];
                         callback = _a[_i];
                         return [4, callback.onBatchEnd(batch, logs)];
-                    case 2:
-                        _b.sent();
-                        _b.label = 3;
                     case 3:
+                        _b.sent();
+                        _b.label = 4;
+                    case 4:
                         _i++;
-                        return [3, 1];
-                    case 4: return [2];
+                        return [3, 2];
+                    case 5: return [2];
                 }
             });
         });
@@ -27624,8 +29170,70 @@ function standardizeCallbacks(callbacks) {
     return callbackConfigs.map(function (callbackConfig) { return new CustomCallback(callbackConfig); });
 }
 exports.standardizeCallbacks = standardizeCallbacks;
+var CallbackConstructorRegistry = (function () {
+    function CallbackConstructorRegistry() {
+    }
+    CallbackConstructorRegistry.registerCallbackConstructor = function (verbosityLevel, callbackConstructor) {
+        tfjs_core_1.util.assert(verbosityLevel >= 0 && Number.isInteger(verbosityLevel), "Verbosity level is expected to be an integer >= 0, " +
+            ("but got " + verbosityLevel));
+        CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
+        if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {
+            CallbackConstructorRegistry.constructors[verbosityLevel] = [];
+        }
+        CallbackConstructorRegistry.constructors[verbosityLevel].push(callbackConstructor);
+    };
+    CallbackConstructorRegistry.checkForDuplicate = function (callbackConstructor) {
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var constructors = CallbackConstructorRegistry.constructors[+levelName];
+            constructors.forEach(function (ctor) {
+                if (ctor === callbackConstructor) {
+                    throw new errors_1.ValueError('Duplicate callback constructor.');
+                }
+            });
+        }
+    };
+    CallbackConstructorRegistry.clear = function () {
+        CallbackConstructorRegistry.constructors = {};
+    };
+    CallbackConstructorRegistry.createCallbacks = function (verbosityLevel) {
+        var constructors = [];
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var level = +levelName;
+            if (verbosityLevel >= level) {
+                constructors.push.apply(constructors, CallbackConstructorRegistry.constructors[level]);
+            }
+        }
+        return constructors.map(function (ctor) { return new ctor(); });
+    };
+    CallbackConstructorRegistry.constructors = {};
+    return CallbackConstructorRegistry;
+}());
+exports.CallbackConstructorRegistry = CallbackConstructorRegistry;
+function configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics) {
+    var history = new History();
+    var actualCallbacks = [
+        new BaseLogger(yieldEvery)
+    ].concat(CallbackConstructorRegistry.createCallbacks(verbose));
+    if (callbacks != null) {
+        actualCallbacks.push.apply(actualCallbacks, callbacks);
+    }
+    actualCallbacks.push(history);
+    var callbackList = new CallbackList(actualCallbacks);
+    callbackList.setParams({
+        epochs: epochs,
+        initialEpoch: initialEpoch,
+        samples: numTrainSamples,
+        steps: stepsPerEpoch,
+        batchSize: batchSize,
+        verbose: verbose,
+        doValidation: doValidation,
+        metrics: callbackMetrics,
+    });
+    return { callbackList: callbackList, history: history };
+}
+exports.configureCallbacks = configureCallbacks;
 
-},{"./backend/state":199,"./logs":231,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],202:[function(require,module,exports){
+},{"./backend/state":219,"./errors":233,"./logs":255,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27657,7 +29265,7 @@ var Callback = (function (_super) {
 }(base_callbacks_1.BaseCallback));
 exports.Callback = Callback;
 
-},{"./base_callbacks":201,"./engine/training":209}],203:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/training":230}],223:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils_1 = require("./utils/generic_utils");
@@ -27726,13 +29334,13 @@ function getUniqueTensorName(scopedName) {
     }
 }
 exports.getUniqueTensorName = getUniqueTensorName;
-var tensorNameRegex = new RegExp(/^[A-Za-z][A-Za-z0-9\._\/]*$/);
+var tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
 function isValidTensorName(name) {
     return name.match(tensorNameRegex) ? true : false;
 }
 exports.isValidTensorName = isValidTensorName;
 
-},{"./utils/generic_utils":238}],204:[function(require,module,exports){
+},{"./utils/generic_utils":262}],224:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27790,7 +29398,7 @@ var MaxNorm = (function (_super) {
     return MaxNorm;
 }(Constraint));
 exports.MaxNorm = MaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MaxNorm);
+tfjs_core_1.serialization.registerClass(MaxNorm);
 var UnitNorm = (function (_super) {
     __extends(UnitNorm, _super);
     function UnitNorm(config) {
@@ -27810,7 +29418,7 @@ var UnitNorm = (function (_super) {
     return UnitNorm;
 }(Constraint));
 exports.UnitNorm = UnitNorm;
-tfjs_core_1.serialization.SerializationMap.register(UnitNorm);
+tfjs_core_1.serialization.registerClass(UnitNorm);
 var NonNeg = (function (_super) {
     __extends(NonNeg, _super);
     function NonNeg() {
@@ -27823,7 +29431,7 @@ var NonNeg = (function (_super) {
     return NonNeg;
 }(Constraint));
 exports.NonNeg = NonNeg;
-tfjs_core_1.serialization.SerializationMap.register(NonNeg);
+tfjs_core_1.serialization.registerClass(NonNeg);
 var MinMaxNorm = (function (_super) {
     __extends(MinMaxNorm, _super);
     function MinMaxNorm(config) {
@@ -27860,7 +29468,7 @@ var MinMaxNorm = (function (_super) {
     return MinMaxNorm;
 }(Constraint));
 exports.MinMaxNorm = MinMaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MinMaxNorm);
+tfjs_core_1.serialization.registerClass(MinMaxNorm);
 exports.CONSTRAINT_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'maxNorm': 'MaxNorm',
     'minMaxNorm': 'MinMaxNorm',
@@ -27896,7 +29504,7 @@ function getConstraint(identifier) {
 }
 exports.getConstraint = getConstraint;
 
-},{"./backend/common":198,"./backend/state":199,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],205:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28559,7 +30167,7 @@ var Container = (function (_super) {
             keptNodes = layer instanceof Container ? 1 : 0;
             for (var originalNodeIndex = 0; originalNodeIndex < layer.inboundNodes.length; originalNodeIndex++) {
                 var nodeKey = Container.nodeKey(layer, originalNodeIndex);
-                if (nodeKey in this.containerNodes) {
+                if (this.containerNodes.has(nodeKey)) {
                     nodeConversionMap[nodeKey] = keptNodes;
                     keptNodes += 1;
                 }
@@ -28642,7 +30250,7 @@ var Container = (function (_super) {
                             var tensorIndex = node.tensorIndices[i];
                             var nodeKey_1 = Container.nodeKey(inboundLayer, nodeIndex);
                             var newNodeIndex = nodeConversionMap[nodeKey_1];
-                            if (newNodeIndex === null || newNodeIndex === undefined) {
+                            if (newNodeIndex == null) {
                                 newNodeIndex = 0;
                             }
                             nodeData.push([inboundLayer.name, newNodeIndex, tensorIndex, kwargs]);
@@ -28763,19 +30371,20 @@ var Container = (function (_super) {
                 var layerData = layersFromConfig_2[_a];
                 var layer = createdLayers[layerData.name];
                 if (layer.name in unprocessedNodes) {
-                    for (var _b = 0, _c = unprocessedNodes[layer.name]; _b < _c.length; _b++) {
-                        var nodeData = _c[_b];
+                    var currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
+                    delete unprocessedNodes[layer.name];
+                    for (var _b = 0, currentUnprocessedNodesForLayer_1 = currentUnprocessedNodesForLayer; _b < currentUnprocessedNodesForLayer_1.length; _b++) {
+                        var nodeData = currentUnprocessedNodesForLayer_1[_b];
                         processNode(layer, nodeData);
                     }
-                    delete unprocessedNodes[layer.name];
                 }
             }
         }
         var inputTensors = [];
         var outputTensors = [];
         var inputLayersFromConfig = config.inputLayers;
-        for (var _d = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _d < inputLayersFromConfig_1.length; _d++) {
-            var layerData = inputLayersFromConfig_1[_d];
+        for (var _c = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _c < inputLayersFromConfig_1.length; _c++) {
+            var layerData = inputLayersFromConfig_1[_c];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28785,8 +30394,8 @@ var Container = (function (_super) {
             inputTensors.push(layerOutputTensors[tensorIndex]);
         }
         var outputLayersFromConfig = config.outputLayers;
-        for (var _e = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _e < outputLayersFromConfig_1.length; _e++) {
-            var layerData = outputLayersFromConfig_1[_e];
+        for (var _d = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _d < outputLayersFromConfig_1.length; _d++) {
+            var layerData = outputLayersFromConfig_1[_d];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28829,7 +30438,23 @@ var Container = (function (_super) {
 }(topology_1.Layer));
 exports.Container = Container;
 
-},{"../backend/state":199,"../errors":210,"../layers/serialization":229,"../utils/generic_utils":238,"../utils/serialization_utils":241,"../utils/types_utils":242,"../variables":244,"../version":245,"./input_layer":207,"./topology":208,"@tensorflow/tfjs-core":68}],206:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"../layers/serialization":253,"../utils/generic_utils":262,"../utils/serialization_utils":265,"../utils/types_utils":266,"../variables":268,"../version":269,"./input_layer":228,"./topology":229,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyIterator = (function () {
+    function LazyIterator() {
+    }
+    return LazyIterator;
+}());
+exports.LazyIterator = LazyIterator;
+var Dataset = (function () {
+    function Dataset() {
+    }
+    return Dataset;
+}());
+exports.Dataset = Dataset;
+
+},{}],227:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -28963,7 +30588,7 @@ function getNodeOutputs(fetch) {
     return layerOutputs;
 }
 
-},{"../errors":210,"./input_layer":207,"@tensorflow/tfjs-core":68}],207:[function(require,module,exports){
+},{"../errors":233,"./input_layer":228,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29042,10 +30667,7 @@ var InputLayer = (function (_super) {
             ("InputLayer's apply() method. InputLayer name: " + this.name));
     };
     InputLayer.prototype.dispose = function () {
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: 0
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: 0 };
     };
     InputLayer.prototype.getConfig = function () {
         return {
@@ -29059,7 +30681,7 @@ var InputLayer = (function (_super) {
     return InputLayer;
 }(topology_1.Layer));
 exports.InputLayer = InputLayer;
-tfjs_core_1.serialization.SerializationMap.register(InputLayer);
+tfjs_core_1.serialization.registerClass(InputLayer);
 function Input(config) {
     if (config.batchShape == null && config.shape == null) {
         throw new Error('Please provide to Input either a `shape`' +
@@ -29090,7 +30712,7 @@ function Input(config) {
 }
 exports.Input = Input;
 
-},{"../backend/state":199,"../errors":210,"./topology":208,"@tensorflow/tfjs-core":68}],208:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"./topology":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29778,10 +31400,7 @@ var Layer = (function (_super) {
         if (--this._refCount === 0) {
             numDisposedVariables = this.disposeWeights();
         }
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: numDisposedVariables
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: numDisposedVariables };
     };
     return Layer;
 }(tfjs_core_1.serialization.Serializable));
@@ -29832,7 +31451,7 @@ function getSourceInputs(tensor, layer, nodeIndex) {
 }
 exports.getSourceInputs = getSourceInputs;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"../utils/variable_utils":243,"../variables":244,"@tensorflow/tfjs-core":68}],209:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"../utils/variable_utils":267,"../variables":268,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29884,10 +31503,8 @@ var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
-var base_callbacks_1 = require("../base_callbacks");
 var common_1 = require("../common");
 var errors_1 = require("../errors");
-var logs_1 = require("../logs");
 var losses = require("../losses");
 var Metrics = require("../metrics");
 var optimizers = require("../optimizers");
@@ -29896,6 +31513,8 @@ var layer_utils_1 = require("../utils/layer_utils");
 var math_utils_1 = require("../utils/math_utils");
 var container_1 = require("./container");
 var executor_1 = require("./executor");
+var training_dataset_1 = require("./training_dataset");
+var training_tensors_1 = require("./training_tensors");
 function isDataTensor(x) {
     return x instanceof tfjs_core_1.Tensor;
 }
@@ -30060,46 +31679,6 @@ function checkLossAndTargetCompatibility(targets, lossFns, outputShapes) {
         }
     }
 }
-function makeBatches(size, batchSize) {
-    var output = [];
-    var batchStart = 0;
-    var batchEnd = null;
-    while (batchStart < size) {
-        batchEnd = batchStart + batchSize;
-        if (batchEnd >= size) {
-            batchEnd = size;
-        }
-        output.push([batchStart, batchEnd]);
-        batchStart = batchEnd;
-    }
-    return output;
-}
-exports.makeBatches = makeBatches;
-function sliceArrays(arrays, start, stop) {
-    if (arrays == null) {
-        return [null];
-    }
-    else if (Array.isArray(arrays)) {
-        return arrays.map(function (array) { return K.sliceAlongFirstAxis(array, start, stop - start); });
-    }
-    else {
-        return K.sliceAlongFirstAxis(arrays, start, stop - start);
-    }
-}
-function sliceArraysByIndices(arrays, indices) {
-    return tfc.tidy(function () {
-        if (arrays == null) {
-            return null;
-        }
-        else if (Array.isArray(arrays)) {
-            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
-        }
-        else {
-            return K.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
-        }
-    });
-}
-exports.sliceArraysByIndices = sliceArraysByIndices;
 function checkInputData(data, names, shapes, checkBatchAxis, exceptionPrefix) {
     if (checkBatchAxis === void 0) { checkBatchAxis = true; }
     if (exceptionPrefix === void 0) { exceptionPrefix = ''; }
@@ -30172,14 +31751,6 @@ function collectMetrics(metrics, outputNames) {
         throw new TypeError('Type of metrics argument not understood. Expected an Array or ' +
             'Object, found: ' + metrics);
     }
-}
-var ModelLoggingVerbosity;
-(function (ModelLoggingVerbosity) {
-    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
-    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
-})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
-function checkBatchSize(batchSize) {
-    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
 }
 var Model = (function (_super) {
     __extends(Model, _super);
@@ -30370,13 +31941,21 @@ var Model = (function (_super) {
     Model.prototype.evaluate = function (x, y, config) {
         if (config === void 0) { config = {}; }
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         var standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
         var ins = standardizedOuts[0].concat(standardizedOuts[1]);
         this.makeTestFunction();
         var f = this.testFunction;
         var testOuts = this.testLoop(f, ins, batchSize, config.verbose, config.steps);
         return generic_utils_1.singletonOrArray(testOuts);
+    };
+    Model.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                this.makeTestFunction();
+                return [2, training_dataset_1.evaluateDataset(this, dataset, config)];
+            });
+        });
     };
     Model.prototype.checkNumSamples = function (ins, batchSize, steps, stepsName) {
         if (stepsName === void 0) { stepsName = 'steps'; }
@@ -30481,13 +32060,13 @@ var Model = (function (_super) {
             if (verbose) {
                 throw new errors_1.NotImplementedError('Verbose predictLoop() is not implemented yet.');
             }
-            var batches = makeBatches(numSamples, batchSize);
+            var batches = training_tensors_1.makeBatches(numSamples, batchSize);
             var outs = [];
             var _loop_3 = function (batchIndex) {
                 var batchOuts = tfc.tidy(function () {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
-                    var insBatch = sliceArrays(ins, batchStart, batchEnd);
+                    var insBatch = training_tensors_1.sliceArrays(ins, batchStart, batchEnd);
                     var feeds = [];
                     if (Array.isArray(insBatch)) {
                         for (var i = 0; i < insBatch.length; ++i) {
@@ -30522,7 +32101,7 @@ var Model = (function (_super) {
         if (config === void 0) { config = {}; }
         checkInputData(x, this.inputNames, this.feedInputShapes, false);
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         return this.predictLoop(x, batchSize);
     };
     Model.prototype.predictOnBatch = function (x) {
@@ -30559,204 +32138,26 @@ var Model = (function (_super) {
         }
         return [x, y, null];
     };
-    Model.prototype.fitLoop = function (f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var doValidation, numTrainSamples, indexArray, baseLogger, callbackList, _loop_4, this_1, epoch, state_2;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (batchSize == null) {
-                            batchSize = 32;
-                        }
-                        if (epochs == null) {
-                            epochs = 1;
-                        }
-                        if (shuffle == null) {
-                            shuffle = true;
-                        }
-                        if (initialEpoch == null) {
-                            initialEpoch = 0;
-                        }
-                        doValidation = false;
-                        if (valF != null && valIns != null) {
-                            doValidation = true;
-                        }
-                        if (validationSteps != null) {
-                            doValidation = true;
-                            if (stepsPerEpoch == null) {
-                                throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
-                                    'i.e., `stepsPerEpoch` must be set.');
-                            }
-                        }
-                        numTrainSamples = this.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
-                        if (numTrainSamples != null) {
-                            indexArray = math_utils_1.range(0, numTrainSamples);
-                        }
-                        this.history = new base_callbacks_1.History();
-                        baseLogger = new base_callbacks_1.BaseLogger(yieldEvery);
-                        if (callbacks == null) {
-                            callbacks = [baseLogger];
-                        }
-                        else {
-                            callbacks = [baseLogger].concat(callbacks);
-                        }
-                        callbacks = callbacks.concat([this.history]);
-                        if (verbose > 0) {
-                            throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
-                        }
-                        callbackList = new base_callbacks_1.CallbackList(callbacks);
-                        callbackList.setModel(this);
-                        callbackList.setParams({
-                            epochs: epochs,
-                            initialEpoch: initialEpoch,
-                            samples: numTrainSamples,
-                            steps: stepsPerEpoch,
-                            batchSize: batchSize,
-                            verbose: verbose,
-                            doValidation: doValidation,
-                            metrics: callbackMetrics,
-                        });
-                        return [4, callbackList.onTrainBegin()];
-                    case 1:
-                        _a.sent();
-                        this.stopTraining_ = false;
-                        _loop_4 = function (epoch) {
-                            var epochLogs, epochIndexArray1D_1, batches_1, _loop_5, batchIndex, state_3;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4, callbackList.onEpochBegin(epoch)];
-                                    case 1:
-                                        _a.sent();
-                                        epochLogs = {};
-                                        if (!(stepsPerEpoch != null)) return [3, 2];
-                                        throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
-                                    case 2:
-                                        if (shuffle === 'batch') {
-                                            throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
-                                        }
-                                        else if (shuffle) {
-                                            tfjs_core_1.util.shuffle(indexArray);
-                                        }
-                                        epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
-                                        batches_1 = makeBatches(numTrainSamples, batchSize);
-                                        _loop_5 = function (batchIndex) {
-                                            var batchLogs;
-                                            return __generator(this, function (_a) {
-                                                switch (_a.label) {
-                                                    case 0:
-                                                        batchLogs = {};
-                                                        return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
-                                                    case 1:
-                                                        _a.sent();
-                                                        tfc.tidy(function () {
-                                                            var batchStart = batches_1[batchIndex][0];
-                                                            var batchEnd = batches_1[batchIndex][1];
-                                                            var batchIds = K.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
-                                                            batchLogs['batch'] = batchIndex;
-                                                            batchLogs['size'] = batchEnd - batchStart;
-                                                            var insBatch = sliceArraysByIndices(ins, batchIds);
-                                                            var outs = f(insBatch);
-                                                            for (var i = 0; i < outLabels.length; ++i) {
-                                                                var label = outLabels[i];
-                                                                var out = outs[i];
-                                                                batchLogs[label] = out;
-                                                                tfc.keep(out);
-                                                            }
-                                                            if (batchIndex === batches_1.length - 1) {
-                                                                if (doValidation) {
-                                                                    var valOuts = _this.testLoop(valF, valIns, batchSize);
-                                                                    for (var i = 0; i < outLabels.length; ++i) {
-                                                                        var label = outLabels[i];
-                                                                        var out = valOuts[i];
-                                                                        tfc.keep(out);
-                                                                        epochLogs['val_' + label] = out;
-                                                                    }
-                                                                }
-                                                            }
-                                                        });
-                                                        return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
-                                                    case 2:
-                                                        _a.sent();
-                                                        logs_1.disposeTensorsInLogs(batchLogs);
-                                                        if (this_1.stopTraining_) {
-                                                            return [2, "break"];
-                                                        }
-                                                        return [2];
-                                                }
-                                            });
-                                        };
-                                        batchIndex = 0;
-                                        _a.label = 3;
-                                    case 3:
-                                        if (!(batchIndex < batches_1.length)) return [3, 6];
-                                        return [5, _loop_5(batchIndex)];
-                                    case 4:
-                                        state_3 = _a.sent();
-                                        if (state_3 === "break")
-                                            return [3, 6];
-                                        _a.label = 5;
-                                    case 5:
-                                        ++batchIndex;
-                                        return [3, 3];
-                                    case 6:
-                                        epochIndexArray1D_1.dispose();
-                                        _a.label = 7;
-                                    case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
-                                    case 8:
-                                        _a.sent();
-                                        if (this_1.stopTraining_) {
-                                            return [2, "break"];
-                                        }
-                                        return [2];
-                                }
-                            });
-                        };
-                        this_1 = this;
-                        epoch = initialEpoch;
-                        _a.label = 2;
-                    case 2:
-                        if (!(epoch < epochs)) return [3, 5];
-                        return [5, _loop_4(epoch)];
-                    case 3:
-                        state_2 = _a.sent();
-                        if (state_2 === "break")
-                            return [3, 5];
-                        _a.label = 4;
-                    case 4:
-                        ++epoch;
-                        return [3, 2];
-                    case 5: return [4, callbackList.onTrainEnd()];
-                    case 6:
-                        _a.sent();
-                        return [4, this.history.syncData()];
-                    case 7:
-                        _a.sent();
-                        return [2, this.history];
-                }
-            });
-        });
-    };
     Model.prototype.testLoop = function (f, ins, batchSize, verbose, steps) {
         var _this = this;
         if (verbose === void 0) { verbose = 0; }
         return tfc.tidy(function () {
             var numSamples = _this.checkNumSamples(ins, batchSize, steps, 'steps');
             var outs = [];
-            if (verbose === 1) {
+            if (verbose > 0) {
                 throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
             }
             if (steps != null) {
                 throw new errors_1.NotImplementedError('steps mode in testLoop() is not implemented yet');
             }
             else {
-                var batches = makeBatches(numSamples, batchSize);
+                var batches = training_tensors_1.makeBatches(numSamples, batchSize);
                 var indexArray = tfjs_core_1.tensor1d(math_utils_1.range(0, numSamples));
                 for (var batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
                     var batchIds = K.sliceAlongFirstAxis(indexArray, batchStart, batchEnd - batchStart);
-                    var insBatch = sliceArraysByIndices(ins, batchIds);
+                    var insBatch = training_tensors_1.sliceArraysByIndices(ins, batchIds);
                     var batchOuts = f(insBatch);
                     if (batchIndex === 0) {
                         for (var i = 0; i < batchOuts.length; ++i) {
@@ -30789,6 +32190,54 @@ var Model = (function (_super) {
             dedupedOutLabels.push(newLabel);
         }
         return dedupedOutLabels;
+    };
+    Model.prototype.makeTrainFunction = function () {
+        var _this = this;
+        return function (data) {
+            var losses = [];
+            var lossValues = [];
+            var inputs = data.slice(0, _this.inputs.length);
+            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
+            var metricsValues = [];
+            var totalLossFunction = function () {
+                var feeds = [];
+                for (var i = 0; i < _this.inputs.length; ++i) {
+                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
+                }
+                var feedDict = new executor_1.FeedDict(feeds);
+                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
+                var totalLoss;
+                for (var i = 0; i < _this.lossFunctions.length; ++i) {
+                    var lossFunction = _this.lossFunctions[i];
+                    var loss = lossFunction(targets[i], outputs[i]);
+                    losses.push(loss);
+                    var meanLoss = tfc.mean(loss);
+                    lossValues.push(meanLoss);
+                    if (i === 0) {
+                        totalLoss = loss;
+                    }
+                    else {
+                        totalLoss = tfc.add(totalLoss, loss);
+                    }
+                }
+                for (var i = 0; i < _this.metricsTensors.length; ++i) {
+                    var metric = _this.metricsTensors[i][0];
+                    var outputIndex = _this.metricsTensors[i][1];
+                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
+                    tfc.keep(meanMetric);
+                    metricsValues.push(meanMetric);
+                }
+                totalLoss = tfc.mean(totalLoss);
+                _this.calculateLosses().forEach(function (regularizerLoss) {
+                    totalLoss = tfc.add(totalLoss, regularizerLoss);
+                });
+                return totalLoss;
+            };
+            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
+            var returnCost = true;
+            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
+            return [totalLossValue].concat(metricsValues);
+        };
     };
     Model.prototype.makeTestFunction = function () {
         var _this = this;
@@ -30828,139 +32277,15 @@ var Model = (function (_super) {
     Model.prototype.fit = function (x, y, config) {
         if (config === void 0) { config = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (this.isTraining) {
-                            throw new Error('Cannot start training because another fit() call is ongoing.');
-                        }
-                        this.isTraining = true;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, , 3, 4]);
-                        batchSize = config.batchSize == null ? 32 : config.batchSize;
-                        checkBatchSize(batchSize);
-                        standardizedOuts = this.standardizeUserData(x, y, false, batchSize);
-                        inputs = standardizedOuts[0];
-                        targets = standardizedOuts[1];
-                        doValidation = false;
-                        valX = void 0;
-                        valY = void 0;
-                        valIns = void 0;
-                        needValidationDisposal = false;
-                        if (config.validationData != null && config.validationData.length > 0) {
-                            doValidation = true;
-                            if (config.validationData.length === 2) {
-                                valX = config.validationData[0];
-                                valY = config.validationData[1];
-                            }
-                            else if (config.validationData.length === 3) {
-                                throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
-                            }
-                            else {
-                                throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
-                                    "or 3 (valX, valY, valSampleWeight) items; " +
-                                    (config.validationData + " is invalid."));
-                            }
-                            valStandardized = this.standardizeUserData(valX, valY, true, batchSize);
-                            valX = valStandardized[0];
-                            valY = valStandardized[1];
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSplit != null && config.validationSplit > 0 &&
-                            config.validationSplit < 1) {
-                            doValidation = true;
-                            splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
-                            originalBatchSize = inputs[0].shape[0];
-                            valX = sliceArrays(inputs, splitAt, originalBatchSize);
-                            inputs = sliceArrays(inputs, 0, splitAt);
-                            valY = sliceArrays(targets, splitAt, originalBatchSize);
-                            targets = sliceArrays(targets, 0, splitAt);
-                            needValidationDisposal = true;
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSteps != null) {
-                            doValidation = true;
-                        }
-                        ins = inputs.concat(targets);
-                        this.checkTrainableWeightsConsistency();
-                        trainFunction = function (data) {
-                            var losses = [];
-                            var lossValues = [];
-                            var inputs = data.slice(0, _this.inputs.length);
-                            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
-                            var metricsValues = [];
-                            var totalLossFunction = function () {
-                                var feeds = [];
-                                for (var i = 0; i < _this.inputs.length; ++i) {
-                                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
-                                }
-                                var feedDict = new executor_1.FeedDict(feeds);
-                                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
-                                var totalLoss;
-                                for (var i = 0; i < _this.lossFunctions.length; ++i) {
-                                    var lossFunction = _this.lossFunctions[i];
-                                    var loss = lossFunction(targets[i], outputs[i]);
-                                    losses.push(loss);
-                                    var meanLoss = tfc.mean(loss);
-                                    lossValues.push(meanLoss);
-                                    if (i === 0) {
-                                        totalLoss = loss;
-                                    }
-                                    else {
-                                        totalLoss = tfc.add(totalLoss, loss);
-                                    }
-                                }
-                                for (var i = 0; i < _this.metricsTensors.length; ++i) {
-                                    var metric = _this.metricsTensors[i][0];
-                                    var outputIndex = _this.metricsTensors[i][1];
-                                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
-                                    tfc.keep(meanMetric);
-                                    metricsValues.push(meanMetric);
-                                }
-                                totalLoss = tfc.mean(totalLoss);
-                                _this.calculateLosses().forEach(function (regularizerLoss) {
-                                    totalLoss = tfc.add(totalLoss, regularizerLoss);
-                                });
-                                return totalLoss;
-                            };
-                            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
-                            var returnCost = true;
-                            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
-                            return [totalLossValue].concat(metricsValues);
-                        };
-                        outLabels = this.getDedupedMetricsNames();
-                        valFunction = void 0;
-                        callbackMetrics = void 0;
-                        if (doValidation) {
-                            this.makeTestFunction();
-                            valFunction = this.testFunction;
-                            callbackMetrics =
-                                outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
-                        }
-                        else {
-                            valFunction = null;
-                            valIns = [];
-                            callbackMetrics = outLabels.slice();
-                        }
-                        callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
-                        return [4, this.fitLoop(trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
-                    case 2:
-                        out = _a.sent();
-                        if (needValidationDisposal) {
-                            valIns.forEach(function (tensor) { return tensor.dispose(); });
-                            inputs.forEach(function (tensor) { return tensor.dispose(); });
-                            targets.forEach(function (tensor) { return tensor.dispose(); });
-                        }
-                        this.isTraining = false;
-                        return [2, out];
-                    case 3:
-                        this.isTraining = false;
-                        return [7];
-                    case 4: return [2];
-                }
+                return [2, training_tensors_1.fitTensors(this, x, y, config)];
+            });
+        });
+    };
+    Model.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, training_dataset_1.fitDataset(this, dataset, config)];
             });
         });
     };
@@ -31024,9 +32349,699 @@ var Model = (function (_super) {
     return Model;
 }(container_1.Container));
 exports.Model = Model;
-tfjs_core_1.serialization.SerializationMap.register(Model);
+tfjs_core_1.serialization.registerClass(Model);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../base_callbacks":201,"../common":203,"../errors":210,"../logs":231,"../losses":232,"../metrics":233,"../optimizers":235,"../utils/generic_utils":238,"../utils/layer_utils":239,"../utils/math_utils":240,"./container":205,"./executor":206,"@tensorflow/tfjs-core":68}],210:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../errors":233,"../losses":256,"../metrics":257,"../optimizers":259,"../utils/generic_utils":262,"../utils/layer_utils":263,"../utils/math_utils":264,"./container":225,"./executor":227,"./training_dataset":231,"./training_tensors":232,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var state_1 = require("../backend/state");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var generic_utils_1 = require("../utils/generic_utils");
+var dataset_stub_1 = require("./dataset_stub");
+var DEFAULT_VALIDATION_BATCH_SIZE = 32;
+function standardizeDataIteratorOutput(model, iteratorOut) {
+    if (model.outputs.length > 1) {
+        throw new errors_1.NotImplementedError("Support for training a model with multiple output tensors with " +
+            "a dataset object is not implemented yet.");
+    }
+    tfc.util.assert(Array.isArray(iteratorOut) && iteratorOut.length === 2, 'Dataset iterator for fitDataset() is expected to generate ' +
+        'an Array of length 2: `[xs, ys]`, but instead generates ' +
+        iteratorOut);
+    iteratorOut = iteratorOut;
+    var ys = iteratorOut[1];
+    var xs = iteratorOut[0];
+    if (xs instanceof tfc.Tensor) {
+        tfc.util.assert(model.inputs.length === 1, "Model has multiple " + model.inputs.length + " inputs, hence it " +
+            "expects the input dataset to generate a dictionary of tensors " +
+            (" (with keys " + JSON.stringify(model.inputNames) + ", ") +
+            "but received a single tensor.");
+        tfc.util.assert(xs.shape[0] === ys.shape[0], "Mismatch in batch size between x and y tensors (" + xs.shape[0] + " vs. " +
+            (ys.shape[0] + ")"));
+        return [xs, ys];
+    }
+    else {
+        var batchSize = void 0;
+        xs = xs;
+        var flattendXs = [];
+        for (var _i = 0, _a = model.inputNames; _i < _a.length; _i++) {
+            var inputName = _a[_i];
+            if (xs[inputName] == null) {
+                throw new errors_1.ValueError("The feature data generated by the dataset lacks the required " +
+                    ("input key '" + inputName + "'."));
+            }
+            flattendXs.push(xs[inputName]);
+            if (batchSize == null) {
+                batchSize = xs[inputName].shape[0];
+            }
+            else {
+                tfc.util.assert(xs[inputName].shape[0] === batchSize, "Mismatch in batch size between x and y tensors " +
+                    ("(" + xs[inputName].shape[0] + " vs. " + ys.shape[0] + ")"));
+            }
+        }
+        return flattendXs.concat(ys);
+    }
+}
+function standardizeTensorValidationData(data) {
+    if (data.length === 3) {
+        throw new errors_1.NotImplementedError('Validation with sample weights is not implemented yet.');
+    }
+    return { xs: data[0], ys: data[1] };
+}
+function fitDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, validationDataIterator, valXs, valYs, validationData, trainFunction, outLabels, callbackMetrics, callbacks, _a, callbackList, history_1, epoch, epochLogs, dataIterator, stepsDone, batchIndex, iteratorOut, xsAndYs, batchLogs, outs, i, label, out, valOuts, _b, i;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    tfc.util.assert(model.optimizer != null, 'You must compile a model before training/testing. Use ' +
+                        'Model.compile(modelCompileConfig).');
+                    tfc.util.assert(config != null, "For fitDataset(), the 2nd argument (config) is required, " +
+                        "but it is not provided in this call.");
+                    tfc.util.assert(config.epochs != null && config.epochs > 0 &&
+                        Number.isInteger(config.epochs), "For fitDataset(), config.epochs is expected to be a positive " +
+                        ("integer, but got " + config.epochs));
+                    tfc.util.assert(config.batchesPerEpoch != null && config.batchesPerEpoch > 0 &&
+                        Number.isInteger(config.batchesPerEpoch), "For fitDataset(), config.batchesPerEpoch is expected to be a " +
+                        ("positive integer, but got " + config.batchesPerEpoch));
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _c.label = 1;
+                case 1:
+                    _c.trys.push([1, , 21, 22]);
+                    doValidation = config.validationData != null;
+                    validationDataIterator = void 0;
+                    valXs = void 0;
+                    valYs = void 0;
+                    if (!doValidation) return [3, 4];
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 3];
+                    tfc.util.assert(config.validationBatches > 0 &&
+                        Number.isInteger(config.validationBatches), "For fitDataset() with dataset-based validation, " +
+                        "config.validationBatches is expected to be a " +
+                        ("positive integer, but got " + config.validationBatches));
+                    return [4, config.validationData.iterator()];
+                case 2:
+                    validationDataIterator = _c.sent();
+                    return [3, 4];
+                case 3:
+                    validationData = standardizeTensorValidationData(config.validationData);
+                    valXs = validationData.xs;
+                    valYs = validationData.ys;
+                    _c.label = 4;
+                case 4:
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    _a = base_callbacks_1.configureCallbacks(callbacks, config.yieldEvery, config.verbose, config.epochs, null, null, config.batchesPerEpoch, null, doValidation, callbackMetrics), callbackList = _a.callbackList, history_1 = _a.history;
+                    model.history = history_1;
+                    return [4, callbackList.onTrainBegin()];
+                case 5:
+                    _c.sent();
+                    epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
+                    epochLogs = {};
+                    return [4, dataset.iterator()];
+                case 6:
+                    dataIterator = _c.sent();
+                    _c.label = 7;
+                case 7:
+                    if (!(epoch < config.epochs)) return [3, 18];
+                    return [4, callbackList.onEpochBegin(epoch)];
+                case 8:
+                    _c.sent();
+                    stepsDone = 0;
+                    batchIndex = 0;
+                    _c.label = 9;
+                case 9:
+                    if (!(stepsDone < config.batchesPerEpoch)) return [3, 16];
+                    return [4, dataIterator.next()];
+                case 10:
+                    iteratorOut = _c.sent();
+                    if (iteratorOut.done) {
+                        console.warn('Your dataset iterator ran out of data; ' +
+                            'interrupting training. Make sure that your ' +
+                            'dataset can generate at least `batchesPerEpoch * epochs` ' +
+                            'batches (in this case, ' +
+                            (config.batchesPerEpoch * config.epochs + " batches). ") +
+                            'You may need to use the repeat() function when building ' +
+                            'your dataset.');
+                        return [3, 16];
+                    }
+                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                    batchLogs = {};
+                    batchLogs['batch'] = batchIndex;
+                    batchLogs['size'] = xsAndYs[0].shape[0];
+                    callbackList.onBatchBegin(batchIndex, batchLogs);
+                    outs = trainFunction(xsAndYs);
+                    tfc.dispose(xsAndYs);
+                    for (i = 0; i < outLabels.length; ++i) {
+                        label = outLabels[i];
+                        out = outs[i];
+                        batchLogs[label] = out;
+                        tfc.keep(out);
+                    }
+                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                case 11:
+                    _c.sent();
+                    logs_1.disposeTensorsInLogs(batchLogs);
+                    batchIndex++;
+                    stepsDone++;
+                    if (!(stepsDone >= config.batchesPerEpoch && doValidation)) return [3, 15];
+                    valOuts = void 0;
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 13];
+                    _b = generic_utils_1.toList;
+                    return [4, model.evaluateDataset(validationDataIterator, { batches: config.validationBatches })];
+                case 12:
+                    valOuts = _b.apply(void 0, [_c.sent()]);
+                    return [3, 14];
+                case 13:
+                    valOuts = generic_utils_1.toList(model.evaluate(valXs, valYs, {
+                        batchSize: config.validationBatchSize == null ?
+                            DEFAULT_VALIDATION_BATCH_SIZE :
+                            config.validationBatchSize,
+                        verbose: 0
+                    }));
+                    _c.label = 14;
+                case 14:
+                    for (i = 0; i < model.metricsNames.length; ++i) {
+                        epochLogs["val_" + model.metricsNames[i]] = valOuts[i];
+                    }
+                    _c.label = 15;
+                case 15:
+                    if (model.stopTraining_) {
+                        return [3, 16];
+                    }
+                    return [3, 9];
+                case 16: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                case 17:
+                    _c.sent();
+                    epoch++;
+                    if (model.stopTraining_) {
+                        return [3, 18];
+                    }
+                    return [3, 7];
+                case 18: return [4, callbackList.onTrainEnd()];
+                case 19:
+                    _c.sent();
+                    return [4, model.history.syncData()];
+                case 20:
+                    _c.sent();
+                    return [2, model.history];
+                case 21:
+                    model.isTraining = false;
+                    return [7];
+                case 22: return [2];
+            }
+        });
+    });
+}
+exports.fitDataset = fitDataset;
+function evaluateDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var f, outs, dataIterator, _a, numExamples, _loop_1, batch, state_2, _loop_2, i;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    f = model.testFunction;
+                    outs = [];
+                    if (config.verbose > 0) {
+                        throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
+                    }
+                    tfc.util.assert(config.batches > 0 && Number.isInteger(config.batches), 'Test loop expects `batches` to be a positive integer, but ' +
+                        ("received " + JSON.stringify(config.batches)));
+                    if (!(dataset instanceof dataset_stub_1.LazyIterator)) return [3, 1];
+                    _a = dataset;
+                    return [3, 3];
+                case 1: return [4, dataset.iterator()];
+                case 2:
+                    _a = _b.sent();
+                    _b.label = 3;
+                case 3:
+                    dataIterator = _a;
+                    numExamples = 0;
+                    _loop_1 = function (batch) {
+                        var iteratorOut, xsAndYs, batchOuts, i, batchSize, _loop_3, i;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, dataIterator.next()];
+                                case 1:
+                                    iteratorOut = _a.sent();
+                                    if (iteratorOut.done) {
+                                        console.warn('Your dataset iterator ran out of data during evaluateDataset(). ' +
+                                            'Interrupting evalution. Make sure that your ' +
+                                            'dataset can generate at least `batches` ' +
+                                            ("batches (in this case, " + config.batches + " batches). ") +
+                                            'You may need to use the repeat() function when building ' +
+                                            'your dataset.');
+                                        return [2, "break"];
+                                    }
+                                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                                    batchOuts = tfc.tidy(function () { return f(xsAndYs); });
+                                    tfc.dispose(xsAndYs);
+                                    if (batch === 0) {
+                                        for (i = 0; i < batchOuts.length; ++i) {
+                                            outs.push(state_1.getScalar(0));
+                                        }
+                                    }
+                                    batchSize = xsAndYs[0].shape[0];
+                                    _loop_3 = function (i) {
+                                        var batchOut = batchOuts[i];
+                                        var oldScalar = outs[i];
+                                        outs[i] = tfc.tidy(function () { return tfc.add(outs[i], tfc.mul(state_1.getScalar(batchSize), batchOut)); });
+                                        if (batch > 0) {
+                                            tfc.dispose(oldScalar);
+                                        }
+                                    };
+                                    for (i = 0; i < batchOuts.length; ++i) {
+                                        _loop_3(i);
+                                    }
+                                    tfc.dispose(batchOuts);
+                                    numExamples += batchSize;
+                                    return [2];
+                            }
+                        });
+                    };
+                    batch = 0;
+                    _b.label = 4;
+                case 4:
+                    if (!(batch < config.batches)) return [3, 7];
+                    return [5, _loop_1(batch)];
+                case 5:
+                    state_2 = _b.sent();
+                    if (state_2 === "break")
+                        return [3, 7];
+                    _b.label = 6;
+                case 6:
+                    ++batch;
+                    return [3, 4];
+                case 7:
+                    _loop_2 = function (i) {
+                        var oldScalar = outs[i];
+                        outs[i] =
+                            tfc.tidy(function () { return tfc.div(outs[i], state_1.getScalar(numExamples)); });
+                        tfc.dispose(oldScalar);
+                    };
+                    for (i = 0; i < outs.length; ++i) {
+                        _loop_2(i);
+                    }
+                    return [2, generic_utils_1.singletonOrArray(outs)];
+            }
+        });
+    });
+}
+exports.evaluateDataset = evaluateDataset;
+
+},{"../backend/state":219,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/generic_utils":262,"./dataset_stub":226,"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfjs_backend_1 = require("../backend/tfjs_backend");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var math_utils_1 = require("../utils/math_utils");
+function checkBatchSize(batchSize) {
+    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
+}
+exports.checkBatchSize = checkBatchSize;
+function sliceArrays(arrays, start, stop) {
+    if (arrays == null) {
+        return [null];
+    }
+    else if (Array.isArray(arrays)) {
+        return arrays.map(function (array) { return tfjs_backend_1.sliceAlongFirstAxis(array, start, stop - start); });
+    }
+    else {
+        return tfjs_backend_1.sliceAlongFirstAxis(arrays, start, stop - start);
+    }
+}
+exports.sliceArrays = sliceArrays;
+function sliceArraysByIndices(arrays, indices) {
+    return tfc.tidy(function () {
+        if (arrays == null) {
+            return null;
+        }
+        else if (Array.isArray(arrays)) {
+            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
+        }
+        else {
+            return tfjs_backend_1.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
+        }
+    });
+}
+exports.sliceArraysByIndices = sliceArraysByIndices;
+function makeBatches(size, batchSize) {
+    var output = [];
+    var batchStart = 0;
+    var batchEnd = null;
+    while (batchStart < size) {
+        batchEnd = batchStart + batchSize;
+        if (batchEnd >= size) {
+            batchEnd = size;
+        }
+        output.push([batchStart, batchEnd]);
+        batchStart = batchEnd;
+    }
+    return output;
+}
+exports.makeBatches = makeBatches;
+function fitLoop(model, f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, numTrainSamples, indexArray, _a, callbackList, history, _loop_1, epoch, state_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (batchSize == null) {
+                        batchSize = 32;
+                    }
+                    if (epochs == null) {
+                        epochs = 1;
+                    }
+                    if (shuffle == null) {
+                        shuffle = true;
+                    }
+                    if (initialEpoch == null) {
+                        initialEpoch = 0;
+                    }
+                    doValidation = false;
+                    if (valF != null && valIns != null) {
+                        doValidation = true;
+                    }
+                    if (validationSteps != null) {
+                        doValidation = true;
+                        if (stepsPerEpoch == null) {
+                            throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
+                                'i.e., `stepsPerEpoch` must be set.');
+                        }
+                    }
+                    numTrainSamples = model.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
+                    if (numTrainSamples != null) {
+                        indexArray = math_utils_1.range(0, numTrainSamples);
+                    }
+                    if (verbose == null) {
+                        verbose = 1;
+                    }
+                    _a = base_callbacks_1.configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics), callbackList = _a.callbackList, history = _a.history;
+                    callbackList.setModel(model);
+                    model.history = history;
+                    return [4, callbackList.onTrainBegin()];
+                case 1:
+                    _b.sent();
+                    model.stopTraining_ = false;
+                    _loop_1 = function (epoch) {
+                        var epochLogs, epochIndexArray1D_1, batches_1, _loop_2, batchIndex, state_2;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, callbackList.onEpochBegin(epoch)];
+                                case 1:
+                                    _a.sent();
+                                    epochLogs = {};
+                                    if (!(stepsPerEpoch != null)) return [3, 2];
+                                    throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
+                                case 2:
+                                    if (shuffle === 'batch') {
+                                        throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
+                                    }
+                                    else if (shuffle) {
+                                        tfjs_core_1.util.shuffle(indexArray);
+                                    }
+                                    epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
+                                    batches_1 = makeBatches(numTrainSamples, batchSize);
+                                    _loop_2 = function (batchIndex) {
+                                        var batchLogs;
+                                        return __generator(this, function (_a) {
+                                            switch (_a.label) {
+                                                case 0:
+                                                    batchLogs = {};
+                                                    return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
+                                                case 1:
+                                                    _a.sent();
+                                                    tfc.tidy(function () {
+                                                        var batchStart = batches_1[batchIndex][0];
+                                                        var batchEnd = batches_1[batchIndex][1];
+                                                        var batchIds = tfjs_backend_1.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
+                                                        batchLogs['batch'] = batchIndex;
+                                                        batchLogs['size'] = batchEnd - batchStart;
+                                                        var insBatch = sliceArraysByIndices(ins, batchIds);
+                                                        var outs = f(insBatch);
+                                                        for (var i = 0; i < outLabels.length; ++i) {
+                                                            var label = outLabels[i];
+                                                            var out = outs[i];
+                                                            batchLogs[label] = out;
+                                                            tfc.keep(out);
+                                                        }
+                                                        if (batchIndex === batches_1.length - 1) {
+                                                            if (doValidation) {
+                                                                var valOuts = model.testLoop(valF, valIns, batchSize);
+                                                                for (var i = 0; i < outLabels.length; ++i) {
+                                                                    var label = outLabels[i];
+                                                                    var out = valOuts[i];
+                                                                    tfc.keep(out);
+                                                                    epochLogs['val_' + label] = out;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                                                case 2:
+                                                    _a.sent();
+                                                    logs_1.disposeTensorsInLogs(batchLogs);
+                                                    if (model.stopTraining_) {
+                                                        return [2, "break"];
+                                                    }
+                                                    return [2];
+                                            }
+                                        });
+                                    };
+                                    batchIndex = 0;
+                                    _a.label = 3;
+                                case 3:
+                                    if (!(batchIndex < batches_1.length)) return [3, 6];
+                                    return [5, _loop_2(batchIndex)];
+                                case 4:
+                                    state_2 = _a.sent();
+                                    if (state_2 === "break")
+                                        return [3, 6];
+                                    _a.label = 5;
+                                case 5:
+                                    ++batchIndex;
+                                    return [3, 3];
+                                case 6:
+                                    epochIndexArray1D_1.dispose();
+                                    _a.label = 7;
+                                case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                                case 8:
+                                    _a.sent();
+                                    if (model.stopTraining_) {
+                                        return [2, "break"];
+                                    }
+                                    return [2];
+                            }
+                        });
+                    };
+                    epoch = initialEpoch;
+                    _b.label = 2;
+                case 2:
+                    if (!(epoch < epochs)) return [3, 5];
+                    return [5, _loop_1(epoch)];
+                case 3:
+                    state_1 = _b.sent();
+                    if (state_1 === "break")
+                        return [3, 5];
+                    _b.label = 4;
+                case 4:
+                    ++epoch;
+                    return [3, 2];
+                case 5: return [4, callbackList.onTrainEnd()];
+                case 6:
+                    _b.sent();
+                    return [4, model.history.syncData()];
+                case 7:
+                    _b.sent();
+                    return [2, model.history];
+            }
+        });
+    });
+}
+function fitTensors(model, x, y, config) {
+    if (config === void 0) { config = {}; }
+    return __awaiter(this, void 0, void 0, function () {
+        var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, , 3, 4]);
+                    batchSize = config.batchSize == null ? 32 : config.batchSize;
+                    checkBatchSize(batchSize);
+                    standardizedOuts = model.standardizeUserData(x, y, false, batchSize);
+                    inputs = standardizedOuts[0];
+                    targets = standardizedOuts[1];
+                    doValidation = false;
+                    valX = void 0;
+                    valY = void 0;
+                    valIns = void 0;
+                    needValidationDisposal = false;
+                    if (config.validationData != null && config.validationData.length > 0) {
+                        doValidation = true;
+                        if (config.validationData.length === 2) {
+                            valX = config.validationData[0];
+                            valY = config.validationData[1];
+                        }
+                        else if (config.validationData.length === 3) {
+                            throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
+                        }
+                        else {
+                            throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
+                                "or 3 (valX, valY, valSampleWeight) items; " +
+                                (config.validationData + " is invalid."));
+                        }
+                        valStandardized = model.standardizeUserData(valX, valY, true, batchSize);
+                        valX = valStandardized[0];
+                        valY = valStandardized[1];
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSplit != null && config.validationSplit > 0 &&
+                        config.validationSplit < 1) {
+                        doValidation = true;
+                        splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
+                        originalBatchSize = inputs[0].shape[0];
+                        valX = sliceArrays(inputs, splitAt, originalBatchSize);
+                        inputs = sliceArrays(inputs, 0, splitAt);
+                        valY = sliceArrays(targets, splitAt, originalBatchSize);
+                        targets = sliceArrays(targets, 0, splitAt);
+                        needValidationDisposal = true;
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSteps != null) {
+                        doValidation = true;
+                    }
+                    ins = inputs.concat(targets);
+                    model.checkTrainableWeightsConsistency();
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    valFunction = void 0;
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        model.makeTestFunction();
+                        valFunction = model.testFunction;
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        valFunction = null;
+                        valIns = [];
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    return [4, fitLoop(model, trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
+                case 2:
+                    out = _a.sent();
+                    if (needValidationDisposal) {
+                        valIns.forEach(function (tensor) { return tensor.dispose(); });
+                        inputs.forEach(function (tensor) { return tensor.dispose(); });
+                        targets.forEach(function (tensor) { return tensor.dispose(); });
+                    }
+                    model.isTraining = false;
+                    return [2, out];
+                case 3:
+                    model.isTraining = false;
+                    return [7];
+                case 4: return [2];
+            }
+        });
+    });
+}
+exports.fitTensors = fitTensors;
+
+},{"../backend/tfjs_backend":220,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/math_utils":264,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31100,12 +33115,13 @@ var IndexError = (function (_super) {
 }(Error));
 exports.IndexError = IndexError;
 
-},{}],211:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
 var training_1 = require("./engine/training");
 var models_1 = require("./models");
+var base_callbacks_1 = require("./base_callbacks");
 function model(config) {
     return new training_1.Model(config);
 }
@@ -31123,8 +33139,12 @@ function input(config) {
     return input_layer_1.Input(config);
 }
 exports.input = input;
+function registerCallbackConstructor(verbosityLevel, callbackConstructor) {
+    base_callbacks_1.CallbackConstructorRegistry.registerCallbackConstructor(verbosityLevel, callbackConstructor);
+}
+exports.registerCallbackConstructor = registerCallbackConstructor;
 
-},{"./engine/input_layer":207,"./engine/training":209,"./models":234}],212:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/input_layer":228,"./engine/training":230,"./models":258}],235:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints_1 = require("./constraints");
@@ -31145,7 +33165,7 @@ function minMaxNorm(config) {
 }
 exports.minMaxNorm = minMaxNorm;
 
-},{"./constraints":204}],213:[function(require,module,exports){
+},{"./constraints":224}],236:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var initializers_1 = require("./initializers");
@@ -31202,7 +33222,7 @@ function orthogonal(config) {
 }
 exports.orthogonal = orthogonal;
 
-},{"./initializers":218}],214:[function(require,module,exports){
+},{"./initializers":242}],237:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
@@ -31331,6 +33351,10 @@ function multiply(config) {
     return new merge_1.Multiply(config);
 }
 exports.multiply = multiply;
+function dot(config) {
+    return new merge_1.Dot(config);
+}
+exports.dot = dot;
 function batchNormalization(config) {
     return new normalization_1.BatchNormalization(config);
 }
@@ -31432,7 +33456,7 @@ exports.globalMaxPool2d = globalMaxPooling2d;
 exports.maxPool1d = maxPooling1d;
 exports.maxPool2d = maxPooling2d;
 
-},{"./engine/input_layer":207,"./engine/topology":208,"./exports":211,"./layers/advanced_activations":219,"./layers/convolutional":220,"./layers/convolutional_depthwise":221,"./layers/core":222,"./layers/embeddings":223,"./layers/merge":224,"./layers/normalization":225,"./layers/padding":226,"./layers/pooling":227,"./layers/recurrent":228,"./layers/wrappers":230}],215:[function(require,module,exports){
+},{"./engine/input_layer":228,"./engine/topology":229,"./exports":234,"./layers/advanced_activations":243,"./layers/convolutional":244,"./layers/convolutional_depthwise":245,"./layers/core":246,"./layers/embeddings":247,"./layers/merge":248,"./layers/normalization":249,"./layers/padding":250,"./layers/pooling":251,"./layers/recurrent":252,"./layers/wrappers":254}],238:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var losses = require("./losses");
@@ -31453,6 +33477,14 @@ function categoricalCrossentropy(yTrue, yPred) {
     return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 exports.categoricalCrossentropy = categoricalCrossentropy;
+function precision(yTrue, yPred) {
+    return metrics.precision(yTrue, yPred);
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return metrics.recall(yTrue, yPred);
+}
+exports.recall = recall;
 function cosineProximity(yTrue, yPred) {
     return losses.cosineProximity(yTrue, yPred);
 }
@@ -31486,7 +33518,13 @@ function mse(yTrue, yPred) {
 }
 exports.mse = mse;
 
-},{"./losses":232,"./metrics":233}],216:[function(require,module,exports){
+},{"./losses":256,"./metrics":257}],239:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var models_1 = require("./models");
+exports.modelFromJSON = models_1.modelFromJSON;
+
+},{"./models":258}],240:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var regularizers = require("./regularizers");
@@ -31504,7 +33542,7 @@ function l2(config) {
 }
 exports.l2 = l2;
 
-},{"./regularizers":236}],217:[function(require,module,exports){
+},{"./regularizers":260}],241:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints = require("./exports_constraints");
@@ -31513,6 +33551,8 @@ var initializers = require("./exports_initializers");
 exports.initializers = initializers;
 var layers = require("./exports_layers");
 exports.layers = layers;
+var models = require("./exports_models");
+exports.models = models;
 var metrics = require("./exports_metrics");
 exports.metrics = metrics;
 var regularizers = require("./exports_regularizers");
@@ -31524,6 +33564,7 @@ exports.History = base_callbacks_1.History;
 var callbacks_1 = require("./callbacks");
 exports.Callback = callbacks_1.Callback;
 var topology_1 = require("./engine/topology");
+exports.InputSpec = topology_1.InputSpec;
 exports.SymbolicTensor = topology_1.SymbolicTensor;
 var training_1 = require("./engine/training");
 exports.Model = training_1.Model;
@@ -31531,6 +33572,7 @@ var exports_1 = require("./exports");
 exports.input = exports_1.input;
 exports.loadModel = exports_1.loadModel;
 exports.model = exports_1.model;
+exports.registerCallbackConstructor = exports_1.registerCallbackConstructor;
 exports.sequential = exports_1.sequential;
 var recurrent_1 = require("./layers/recurrent");
 exports.RNN = recurrent_1.RNN;
@@ -31541,7 +33583,7 @@ exports.LayerVariable = variables_1.LayerVariable;
 var version_1 = require("./version");
 exports.version_layers = version_1.version;
 
-},{"./base_callbacks":201,"./callbacks":202,"./engine/topology":208,"./engine/training":209,"./exports":211,"./exports_constraints":212,"./exports_initializers":213,"./exports_layers":214,"./exports_metrics":215,"./exports_regularizers":216,"./layers/recurrent":228,"./models":234,"./variables":244,"./version":245}],218:[function(require,module,exports){
+},{"./base_callbacks":221,"./callbacks":222,"./engine/topology":229,"./engine/training":230,"./exports":234,"./exports_constraints":235,"./exports_initializers":236,"./exports_layers":237,"./exports_metrics":238,"./exports_models":239,"./exports_regularizers":240,"./layers/recurrent":252,"./models":258,"./variables":268,"./version":269}],242:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31597,7 +33639,7 @@ var Zeros = (function (_super) {
     return Zeros;
 }(Initializer));
 exports.Zeros = Zeros;
-tfjs_core_1.serialization.SerializationMap.register(Zeros);
+tfjs_core_1.serialization.registerClass(Zeros);
 var Ones = (function (_super) {
     __extends(Ones, _super);
     function Ones() {
@@ -31610,7 +33652,7 @@ var Ones = (function (_super) {
     return Ones;
 }(Initializer));
 exports.Ones = Ones;
-tfjs_core_1.serialization.SerializationMap.register(Ones);
+tfjs_core_1.serialization.registerClass(Ones);
 var Constant = (function (_super) {
     __extends(Constant, _super);
     function Constant(config) {
@@ -31637,7 +33679,7 @@ var Constant = (function (_super) {
     return Constant;
 }(Initializer));
 exports.Constant = Constant;
-tfjs_core_1.serialization.SerializationMap.register(Constant);
+tfjs_core_1.serialization.registerClass(Constant);
 var RandomUniform = (function (_super) {
     __extends(RandomUniform, _super);
     function RandomUniform(config) {
@@ -31659,7 +33701,7 @@ var RandomUniform = (function (_super) {
     return RandomUniform;
 }(Initializer));
 exports.RandomUniform = RandomUniform;
-tfjs_core_1.serialization.SerializationMap.register(RandomUniform);
+tfjs_core_1.serialization.registerClass(RandomUniform);
 var RandomNormal = (function (_super) {
     __extends(RandomNormal, _super);
     function RandomNormal(config) {
@@ -31672,8 +33714,9 @@ var RandomNormal = (function (_super) {
         return _this;
     }
     RandomNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
         }
         return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31684,7 +33727,7 @@ var RandomNormal = (function (_super) {
     return RandomNormal;
 }(Initializer));
 exports.RandomNormal = RandomNormal;
-tfjs_core_1.serialization.SerializationMap.register(RandomNormal);
+tfjs_core_1.serialization.registerClass(RandomNormal);
 var TruncatedNormal = (function (_super) {
     __extends(TruncatedNormal, _super);
     function TruncatedNormal(config) {
@@ -31697,8 +33740,9 @@ var TruncatedNormal = (function (_super) {
         return _this;
     }
     TruncatedNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("truncatedNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("truncatedNormal does not support dType " + dtype + ".");
         }
         return tfjs_core_1.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31709,7 +33753,7 @@ var TruncatedNormal = (function (_super) {
     return TruncatedNormal;
 }(Initializer));
 exports.TruncatedNormal = TruncatedNormal;
-tfjs_core_1.serialization.SerializationMap.register(TruncatedNormal);
+tfjs_core_1.serialization.registerClass(TruncatedNormal);
 var Identity = (function (_super) {
     __extends(Identity, _super);
     function Identity(config) {
@@ -31736,7 +33780,7 @@ var Identity = (function (_super) {
     return Identity;
 }(Initializer));
 exports.Identity = Identity;
-tfjs_core_1.serialization.SerializationMap.register(Identity);
+tfjs_core_1.serialization.registerClass(Identity);
 function computeFans(shape, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var fanIn;
@@ -31796,8 +33840,9 @@ var VarianceScaling = (function (_super) {
         }
         if (this.distribution === 'normal') {
             var stddev = Math.sqrt(scale);
-            if (dtype === 'bool') {
-                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType bool.");
+            dtype = dtype || 'float32';
+            if (dtype !== 'float32' && dtype !== 'int32') {
+                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType " + dtype + ".");
             }
             return tfjs_core_1.truncatedNormal(shape, 0, stddev, dtype, this.seed);
         }
@@ -31818,7 +33863,7 @@ var VarianceScaling = (function (_super) {
     return VarianceScaling;
 }(Initializer));
 exports.VarianceScaling = VarianceScaling;
-tfjs_core_1.serialization.SerializationMap.register(VarianceScaling);
+tfjs_core_1.serialization.registerClass(VarianceScaling);
 var GlorotUniform = (function (_super) {
     __extends(GlorotUniform, _super);
     function GlorotUniform(config) {
@@ -31832,9 +33877,11 @@ var GlorotUniform = (function (_super) {
     GlorotUniform.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotUniform.className = 'GlorotUniform';
     return GlorotUniform;
 }(VarianceScaling));
 exports.GlorotUniform = GlorotUniform;
+tfjs_core_1.serialization.registerClass(GlorotUniform);
 var GlorotNormal = (function (_super) {
     __extends(GlorotNormal, _super);
     function GlorotNormal(config) {
@@ -31848,9 +33895,11 @@ var GlorotNormal = (function (_super) {
     GlorotNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotNormal.className = 'GlorotNormal';
     return GlorotNormal;
 }(VarianceScaling));
 exports.GlorotNormal = GlorotNormal;
+tfjs_core_1.serialization.registerClass(GlorotNormal);
 var HeNormal = (function (_super) {
     __extends(HeNormal, _super);
     function HeNormal(config) {
@@ -31864,9 +33913,11 @@ var HeNormal = (function (_super) {
     HeNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    HeNormal.className = 'HeNormal';
     return HeNormal;
 }(VarianceScaling));
 exports.HeNormal = HeNormal;
+tfjs_core_1.serialization.registerClass(HeNormal);
 var LeCunNormal = (function (_super) {
     __extends(LeCunNormal, _super);
     function LeCunNormal(config) {
@@ -31880,9 +33931,11 @@ var LeCunNormal = (function (_super) {
     LeCunNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    LeCunNormal.className = 'LeCunNormal';
     return LeCunNormal;
 }(VarianceScaling));
 exports.LeCunNormal = LeCunNormal;
+tfjs_core_1.serialization.registerClass(LeCunNormal);
 var Orthogonal = (function (_super) {
     __extends(Orthogonal, _super);
     function Orthogonal(config) {
@@ -31925,7 +33978,7 @@ var Orthogonal = (function (_super) {
     return Orthogonal;
 }(Initializer));
 exports.Orthogonal = Orthogonal;
-tfjs_core_1.serialization.SerializationMap.register(Orthogonal);
+tfjs_core_1.serialization.registerClass(Orthogonal);
 exports.INITIALIZER_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'constant': 'Constant',
     'glorotNormal': 'GlorotNormal',
@@ -31980,7 +34033,7 @@ function getInitializer(identifier) {
 }
 exports.getInitializer = getInitializer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./common":203,"./errors":210,"./utils/generic_utils":238,"./utils/math_utils":240,"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./common":223,"./errors":233,"./utils/generic_utils":262,"./utils/math_utils":264,"@tensorflow/tfjs-core":68}],243:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32031,7 +34084,7 @@ var ReLU = (function (_super) {
     return ReLU;
 }(topology_1.Layer));
 exports.ReLU = ReLU;
-tfjs_core_1.serialization.SerializationMap.register(ReLU);
+tfjs_core_1.serialization.registerClass(ReLU);
 var LeakyReLU = (function (_super) {
     __extends(LeakyReLU, _super);
     function LeakyReLU(config) {
@@ -32060,7 +34113,7 @@ var LeakyReLU = (function (_super) {
     return LeakyReLU;
 }(topology_1.Layer));
 exports.LeakyReLU = LeakyReLU;
-tfjs_core_1.serialization.SerializationMap.register(LeakyReLU);
+tfjs_core_1.serialization.registerClass(LeakyReLU);
 var ELU = (function (_super) {
     __extends(ELU, _super);
     function ELU(config) {
@@ -32093,7 +34146,7 @@ var ELU = (function (_super) {
     return ELU;
 }(topology_1.Layer));
 exports.ELU = ELU;
-tfjs_core_1.serialization.SerializationMap.register(ELU);
+tfjs_core_1.serialization.registerClass(ELU);
 var ThresholdedReLU = (function (_super) {
     __extends(ThresholdedReLU, _super);
     function ThresholdedReLU(config) {
@@ -32123,7 +34176,7 @@ var ThresholdedReLU = (function (_super) {
     return ThresholdedReLU;
 }(topology_1.Layer));
 exports.ThresholdedReLU = ThresholdedReLU;
-tfjs_core_1.serialization.SerializationMap.register(ThresholdedReLU);
+tfjs_core_1.serialization.registerClass(ThresholdedReLU);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax(config) {
@@ -32153,9 +34206,9 @@ var Softmax = (function (_super) {
     return Softmax;
 }(topology_1.Layer));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],244:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32470,7 +34523,7 @@ var Conv2D = (function (_super) {
     return Conv2D;
 }(Conv));
 exports.Conv2D = Conv2D;
-tfjs_core_1.serialization.SerializationMap.register(Conv2D);
+tfjs_core_1.serialization.registerClass(Conv2D);
 var Conv2DTranspose = (function (_super) {
     __extends(Conv2DTranspose, _super);
     function Conv2DTranspose(config) {
@@ -32586,7 +34639,7 @@ var Conv2DTranspose = (function (_super) {
     return Conv2DTranspose;
 }(Conv2D));
 exports.Conv2DTranspose = Conv2DTranspose;
-tfjs_core_1.serialization.SerializationMap.register(Conv2DTranspose);
+tfjs_core_1.serialization.registerClass(Conv2DTranspose);
 var SeparableConv = (function (_super) {
     __extends(SeparableConv, _super);
     function SeparableConv(rank, config) {
@@ -32713,7 +34766,7 @@ var SeparableConv2D = (function (_super) {
     return SeparableConv2D;
 }(SeparableConv));
 exports.SeparableConv2D = SeparableConv2D;
-tfjs_core_1.serialization.SerializationMap.register(SeparableConv2D);
+tfjs_core_1.serialization.registerClass(SeparableConv2D);
 var Conv1D = (function (_super) {
     __extends(Conv1D, _super);
     function Conv1D(config) {
@@ -32738,7 +34791,7 @@ var Conv1D = (function (_super) {
     return Conv1D;
 }(Conv));
 exports.Conv1D = Conv1D;
-tfjs_core_1.serialization.SerializationMap.register(Conv1D);
+tfjs_core_1.serialization.registerClass(Conv1D);
 var Cropping2D = (function (_super) {
     __extends(Cropping2D, _super);
     function Cropping2D(config) {
@@ -32762,15 +34815,17 @@ var Cropping2D = (function (_super) {
     Cropping2D.prototype.computeOutputShape = function (inputShape) {
         if (this.dataFormat === 'channelsFirst')
             return [
-                inputShape[0], inputShape[1],
+                inputShape[0],
+                inputShape[1],
                 inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+                inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
             ];
         else
             return [
                 inputShape[0],
                 inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+                inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+                inputShape[3]
             ];
     };
     Cropping2D.prototype.call = function (inputs, kwargs) {
@@ -32797,7 +34852,7 @@ var Cropping2D = (function (_super) {
     return Cropping2D;
 }(topology_1.Layer));
 exports.Cropping2D = Cropping2D;
-tfjs_core_1.serialization.SerializationMap.register(Cropping2D);
+tfjs_core_1.serialization.registerClass(Cropping2D);
 var UpSampling2D = (function (_super) {
     __extends(UpSampling2D, _super);
     function UpSampling2D(config) {
@@ -32850,9 +34905,9 @@ var UpSampling2D = (function (_super) {
     return UpSampling2D;
 }(topology_1.Layer));
 exports.UpSampling2D = UpSampling2D;
-tfjs_core_1.serialization.SerializationMap.register(UpSampling2D);
+tfjs_core_1.serialization.registerClass(UpSampling2D);
 
-},{"../activations":197,"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
+},{"../activations":217,"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32983,9 +35038,9 @@ var DepthwiseConv2D = (function (_super) {
     return DepthwiseConv2D;
 }(convolutional_1.BaseConv));
 exports.DepthwiseConv2D = DepthwiseConv2D;
-tfjs_core_1.serialization.SerializationMap.register(DepthwiseConv2D);
+tfjs_core_1.serialization.registerClass(DepthwiseConv2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],246:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33068,7 +35123,7 @@ var Dropout = (function (_super) {
     return Dropout;
 }(topology_1.Layer));
 exports.Dropout = Dropout;
-tfjs_core_1.serialization.SerializationMap.register(Dropout);
+tfjs_core_1.serialization.registerClass(Dropout);
 var Dense = (function (_super) {
     __extends(Dense, _super);
     function Dense(config) {
@@ -33158,7 +35213,7 @@ var Dense = (function (_super) {
     return Dense;
 }(topology_1.Layer));
 exports.Dense = Dense;
-tfjs_core_1.serialization.SerializationMap.register(Dense);
+tfjs_core_1.serialization.registerClass(Dense);
 var Flatten = (function (_super) {
     __extends(Flatten, _super);
     function Flatten(config) {
@@ -33190,7 +35245,7 @@ var Flatten = (function (_super) {
     return Flatten;
 }(topology_1.Layer));
 exports.Flatten = Flatten;
-tfjs_core_1.serialization.SerializationMap.register(Flatten);
+tfjs_core_1.serialization.registerClass(Flatten);
 var Activation = (function (_super) {
     __extends(Activation, _super);
     function Activation(config) {
@@ -33217,7 +35272,7 @@ var Activation = (function (_super) {
     return Activation;
 }(topology_1.Layer));
 exports.Activation = Activation;
-tfjs_core_1.serialization.SerializationMap.register(Activation);
+tfjs_core_1.serialization.registerClass(Activation);
 var RepeatVector = (function (_super) {
     __extends(RepeatVector, _super);
     function RepeatVector(config) {
@@ -33248,7 +35303,7 @@ var RepeatVector = (function (_super) {
     return RepeatVector;
 }(topology_1.Layer));
 exports.RepeatVector = RepeatVector;
-tfjs_core_1.serialization.SerializationMap.register(RepeatVector);
+tfjs_core_1.serialization.registerClass(RepeatVector);
 var Reshape = (function (_super) {
     __extends(Reshape, _super);
     function Reshape(config) {
@@ -33332,7 +35387,7 @@ var Reshape = (function (_super) {
     return Reshape;
 }(topology_1.Layer));
 exports.Reshape = Reshape;
-tfjs_core_1.serialization.SerializationMap.register(Reshape);
+tfjs_core_1.serialization.registerClass(Reshape);
 var Permute = (function (_super) {
     __extends(Permute, _super);
     function Permute(config) {
@@ -33378,9 +35433,9 @@ var Permute = (function (_super) {
     return Permute;
 }(topology_1.Layer));
 exports.Permute = Permute;
-tfjs_core_1.serialization.SerializationMap.register(Permute);
+tfjs_core_1.serialization.registerClass(Permute);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],223:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],247:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33497,9 +35552,9 @@ var Embedding = (function (_super) {
     return Embedding;
 }(topology_1.Layer));
 exports.Embedding = Embedding;
-tfjs_core_1.serialization.SerializationMap.register(Embedding);
+tfjs_core_1.serialization.registerClass(Embedding);
 
-},{"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],224:[function(require,module,exports){
+},{"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],248:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33518,6 +35573,7 @@ var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
 var topology_1 = require("../engine/topology");
 var errors_1 = require("../errors");
+var losses_1 = require("../losses");
 var generic_utils = require("../utils/generic_utils");
 var mathUtils = require("../utils/math_utils");
 var types_utils_1 = require("../utils/types_utils");
@@ -33695,6 +35751,9 @@ var Merge = (function (_super) {
         }
         return outputShape;
     };
+    Merge.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Merge yet');
+    };
     return Merge;
 }(topology_1.Layer));
 exports.Merge = Merge;
@@ -33716,7 +35775,7 @@ var Add = (function (_super) {
     return Add;
 }(Merge));
 exports.Add = Add;
-tfjs_core_1.serialization.SerializationMap.register(Add);
+tfjs_core_1.serialization.registerClass(Add);
 function add(config) {
     if (Array.isArray(config)) {
         var layer = new Add({});
@@ -33745,7 +35804,7 @@ var Multiply = (function (_super) {
     return Multiply;
 }(Merge));
 exports.Multiply = Multiply;
-tfjs_core_1.serialization.SerializationMap.register(Multiply);
+tfjs_core_1.serialization.registerClass(Multiply);
 function multiply(config) {
     if (Array.isArray(config)) {
         var layer = new Multiply({});
@@ -33774,7 +35833,7 @@ var Average = (function (_super) {
     return Average;
 }(Merge));
 exports.Average = Average;
-tfjs_core_1.serialization.SerializationMap.register(Average);
+tfjs_core_1.serialization.registerClass(Average);
 function average(config) {
     if (Array.isArray(config)) {
         var layer = new Average({});
@@ -33803,7 +35862,7 @@ var Maximum = (function (_super) {
     return Maximum;
 }(Merge));
 exports.Maximum = Maximum;
-tfjs_core_1.serialization.SerializationMap.register(Maximum);
+tfjs_core_1.serialization.registerClass(Maximum);
 function maximum(config) {
     if (Array.isArray(config)) {
         var layer = new Maximum({});
@@ -33832,7 +35891,7 @@ var Minimum = (function (_super) {
     return Minimum;
 }(Merge));
 exports.Minimum = Minimum;
-tfjs_core_1.serialization.SerializationMap.register(Minimum);
+tfjs_core_1.serialization.registerClass(Minimum);
 function minimum(config) {
     if (Array.isArray(config)) {
         var layer = new Minimum({});
@@ -33919,6 +35978,9 @@ var Concatenate = (function (_super) {
         }
         return outputShape;
     };
+    Concatenate.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Concatenate yet');
+    };
     Concatenate.prototype.getConfig = function () {
         var config = {
             'axis': this.axis,
@@ -33931,7 +35993,7 @@ var Concatenate = (function (_super) {
     return Concatenate;
 }(Merge));
 exports.Concatenate = Concatenate;
-tfjs_core_1.serialization.SerializationMap.register(Concatenate);
+tfjs_core_1.serialization.registerClass(Concatenate);
 function concatenate(config) {
     if (Array.isArray(config)) {
         var layer = new Concatenate({});
@@ -33942,8 +36004,184 @@ function concatenate(config) {
     }
 }
 exports.concatenate = concatenate;
+function interpretAxis(axis, dim) {
+    while (axis < 0) {
+        axis += dim;
+    }
+    return axis;
+}
+function batchDot(x, y, axes) {
+    if (x.shape.length > 3 || y.shape.length > 3) {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for tensors of 4D or higher rank yet');
+    }
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of x to be >= 2, " +
+        ("but got " + x.shape.length));
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of y to be >= 2, " +
+        ("but got " + y.shape.length));
+    if (typeof axes === 'number') {
+        axes = [axes, axes];
+    }
+    if (x.dtype === 'complex64' || y.dtype === 'complex64') {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for complex64-type Tensors yet.');
+    }
+    var xNDim = x.shape.length;
+    var yNDim = y.shape.length;
+    if (axes == null) {
+        axes = [xNDim - 1, yNDim - 2];
+    }
+    var axesArray = axes;
+    return tfc.tidy(function () {
+        var diff;
+        if (xNDim > yNDim) {
+            diff = xNDim - yNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            y = y.reshape(y.shape.concat(diffShape));
+        }
+        else if (yNDim > xNDim) {
+            diff = yNDim - xNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            x = x.reshape(x.shape.concat(diffShape));
+        }
+        else {
+            diff = 0;
+        }
+        var out;
+        if (x.shape.length === 2 && y.shape.length === 2) {
+            if (axesArray[0] === axesArray[1]) {
+                out = x.mulStrict(y).sum(axesArray[0]);
+            }
+            else {
+                out = x.transpose([1, 0]).mulStrict(y).sum(axesArray[1]);
+            }
+        }
+        else {
+            var adjX = axesArray[0] === x.shape.length - 1 ? null : true;
+            var adjY = axesArray[1] === y.shape.length - 1 ? true : null;
+            out = x.matMul(y, adjX, adjY);
+        }
+        if (diff > 0) {
+            var idx = void 0;
+            if (xNDim > yNDim) {
+                idx = xNDim + yNDim - 3;
+            }
+            else {
+                idx = xNDim - 1;
+            }
+            var squeezeAxes = [];
+            for (var i = idx; i < idx + diff; ++i) {
+                squeezeAxes.push(i);
+            }
+            out = out.squeeze(squeezeAxes);
+        }
+        if (out.shape.length === 1) {
+            out = out.expandDims(1);
+        }
+        return out;
+    });
+}
+var Dot = (function (_super) {
+    __extends(Dot, _super);
+    function Dot(config) {
+        var _this = _super.call(this, config) || this;
+        _this.axes = config.axes;
+        _this.normalize = config.normalize == null ? false : config.normalize;
+        _this.supportsMasking = true;
+        _this.reshapeRequired = false;
+        return _this;
+    }
+    Dot.prototype.build = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0];
+        var shape2 = inputShape[1];
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        if (shape1[axes[0]] !== shape2[axes[1]]) {
+            throw new errors_1.ValueError("Dimension incompatibility: " +
+                (shape1[axes[0]] + " !== " + shape2[axes[1]]));
+        }
+    };
+    Dot.prototype.mergeFunction = function (inputs) {
+        if (inputs.length !== 2) {
+            throw new errors_1.ValueError('A `Dot` layer must be called on exactly 2 inputs, ' +
+                ("but received " + inputs.length + " input(s)."));
+        }
+        var x1 = inputs[0];
+        var x2 = inputs[1];
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, x1.shape.length),
+                interpretAxis(this.axes, x2.shape.length)
+            ];
+        }
+        else {
+            axes = this.axes.map(function (axis, i) { return interpretAxis(axis, inputs[i].shape.length); });
+        }
+        if (this.normalize) {
+            x1 = losses_1.l2Normalize(x1, axes[0]);
+            x2 = losses_1.l2Normalize(x2, axes[1]);
+        }
+        return batchDot(x1, x2, axes);
+    };
+    Dot.prototype.interpretAxes = function (shape1, shape2) {
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, shape1.length),
+                interpretAxis(this.axes, shape2.length)
+            ];
+        }
+        else {
+            axes = this.axes;
+        }
+        return axes;
+    };
+    Dot.prototype.computeOutputShape = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0].slice();
+        var shape2 = inputShape[1].slice();
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        shape1.splice(axes[0], 1);
+        shape2.splice(axes[1], 1);
+        shape2.splice(0, 1);
+        var outputShape = shape1.concat(shape2);
+        if (outputShape.length === 1) {
+            outputShape.push(1);
+        }
+        return outputShape;
+    };
+    Dot.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Dot yet');
+    };
+    Dot.prototype.getConfig = function () {
+        var config = {
+            'axes': this.axes,
+            'normalize': this.normalize
+        };
+        var baseConfig = _super.prototype.getConfig.call(this);
+        Object.assign(config, baseConfig);
+        return config;
+    };
+    Dot.className = 'Dot';
+    return Dot;
+}(Merge));
+exports.Dot = Dot;
+tfjs_core_1.serialization.registerClass(Dot);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../losses":256,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],249:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33980,7 +36218,7 @@ function batchNormalization(x, mean, variance, beta, gamma, epsilon) {
         out = tfc.batchNormalization4d(x, mean, variance, epsilon, gamma, beta);
     }
     else {
-        throw new errors_1.NotImplementedError("batchNormalization is not implememnted for array of rank " + x.rank + " " +
+        throw new errors_1.NotImplementedError("batchNormalization is not implemented for array of rank " + x.rank + " " +
             "yet");
     }
     return out;
@@ -34033,7 +36271,11 @@ exports.normalizeBatchInTraining = normalizeBatchInTraining;
 var BatchNormalization = (function (_super) {
     __extends(BatchNormalization, _super);
     function BatchNormalization(config) {
-        var _this = _super.call(this, config) || this;
+        var _this = this;
+        if (config == null) {
+            config = {};
+        }
+        _this = _super.call(this, config) || this;
         _this.supportsMasking = true;
         _this.axis = config.axis == null ? -1 : config.axis;
         _this.momentum = config.momentum == null ? 0.99 : config.momentum;
@@ -34144,9 +36386,9 @@ var BatchNormalization = (function (_super) {
     return BatchNormalization;
 }(topology_1.Layer));
 exports.BatchNormalization = BatchNormalization;
-tfjs_core_1.serialization.SerializationMap.register(BatchNormalization);
+tfjs_core_1.serialization.registerClass(BatchNormalization);
 
-},{"../backend/state":199,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+},{"../backend/state":219,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],250:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34316,9 +36558,9 @@ var ZeroPadding2D = (function (_super) {
     return ZeroPadding2D;
 }(topology_1.Layer));
 exports.ZeroPadding2D = ZeroPadding2D;
-tfjs_core_1.serialization.SerializationMap.register(ZeroPadding2D);
+tfjs_core_1.serialization.registerClass(ZeroPadding2D);
 
-},{"../backend/common":198,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],227:[function(require,module,exports){
+},{"../backend/common":218,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],251:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34460,7 +36702,7 @@ var MaxPooling1D = (function (_super) {
     return MaxPooling1D;
 }(Pooling1D));
 exports.MaxPooling1D = MaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling1D);
+tfjs_core_1.serialization.registerClass(MaxPooling1D);
 var AveragePooling1D = (function (_super) {
     __extends(AveragePooling1D, _super);
     function AveragePooling1D(config) {
@@ -34475,7 +36717,7 @@ var AveragePooling1D = (function (_super) {
     return AveragePooling1D;
 }(Pooling1D));
 exports.AveragePooling1D = AveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling1D);
+tfjs_core_1.serialization.registerClass(AveragePooling1D);
 var Pooling2D = (function (_super) {
     __extends(Pooling2D, _super);
     function Pooling2D(config) {
@@ -34559,7 +36801,7 @@ var MaxPooling2D = (function (_super) {
     return MaxPooling2D;
 }(Pooling2D));
 exports.MaxPooling2D = MaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling2D);
+tfjs_core_1.serialization.registerClass(MaxPooling2D);
 var AveragePooling2D = (function (_super) {
     __extends(AveragePooling2D, _super);
     function AveragePooling2D(config) {
@@ -34574,7 +36816,7 @@ var AveragePooling2D = (function (_super) {
     return AveragePooling2D;
 }(Pooling2D));
 exports.AveragePooling2D = AveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling2D);
+tfjs_core_1.serialization.registerClass(AveragePooling2D);
 var GlobalPooling1D = (function (_super) {
     __extends(GlobalPooling1D, _super);
     function GlobalPooling1D(config) {
@@ -34606,7 +36848,7 @@ var GlobalAveragePooling1D = (function (_super) {
     return GlobalAveragePooling1D;
 }(GlobalPooling1D));
 exports.GlobalAveragePooling1D = GlobalAveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling1D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling1D);
 var GlobalMaxPooling1D = (function (_super) {
     __extends(GlobalMaxPooling1D, _super);
     function GlobalMaxPooling1D(config) {
@@ -34622,7 +36864,7 @@ var GlobalMaxPooling1D = (function (_super) {
     return GlobalMaxPooling1D;
 }(GlobalPooling1D));
 exports.GlobalMaxPooling1D = GlobalMaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling1D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling1D);
 var GlobalPooling2D = (function (_super) {
     __extends(GlobalPooling2D, _super);
     function GlobalPooling2D(config) {
@@ -34675,7 +36917,7 @@ var GlobalAveragePooling2D = (function (_super) {
     return GlobalAveragePooling2D;
 }(GlobalPooling2D));
 exports.GlobalAveragePooling2D = GlobalAveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling2D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling2D);
 var GlobalMaxPooling2D = (function (_super) {
     __extends(GlobalMaxPooling2D, _super);
     function GlobalMaxPooling2D() {
@@ -34697,9 +36939,9 @@ var GlobalMaxPooling2D = (function (_super) {
     return GlobalMaxPooling2D;
 }(GlobalPooling2D));
 exports.GlobalMaxPooling2D = GlobalMaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling2D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],252:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34755,9 +36997,10 @@ function standardizeArgs(inputs, initialState, constants, numConstants) {
     return { inputs: inputs, initialState: initialState, constants: constants };
 }
 exports.standardizeArgs = standardizeArgs;
-function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, inputLength) {
+function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, needPerStepOutputs) {
     if (goBackwards === void 0) { goBackwards = false; }
     if (unroll === void 0) { unroll = false; }
+    if (needPerStepOutputs === void 0) { needPerStepOutputs = false; }
     var ndim = inputs.shape.length;
     if (ndim < 3) {
         throw new errors_1.ValueError("Input should be at least 3D, but is " + ndim + "D.");
@@ -34783,24 +37026,27 @@ function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, 
     var lastOutput;
     var states = initialStates;
     var timeSteps = inputs.shape[0];
-    for (var t = 0; t < timeSteps; ++t) {
+    var _loop_1 = function (t) {
         var currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
         currentInput = currentInput.reshape(currentInput.shape.slice(1));
-        var stepOutputs = stepFunction(currentInput, states);
+        var stepOutputs = tfc.tidy(function () { return stepFunction(currentInput, states); });
         lastOutput = stepOutputs[0];
-        if (t === 0) {
-            outputs = lastOutput.reshape([1].concat(lastOutput.shape));
-        }
-        else {
-            outputs = K.concatAlongFirstAxis(outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        if (needPerStepOutputs) {
+            if (t === 0) {
+                outputs = lastOutput.expandDims(1);
+            }
+            else {
+                var newOutputs = tfc.concat([outputs, lastOutput.expandDims(1)], 1);
+                outputs.dispose();
+                outputs = newOutputs;
+            }
         }
         states = stepOutputs[1];
+    };
+    for (var t = 0; t < timeSteps; ++t) {
+        _loop_1(t);
     }
-    return [
-        lastOutput,
-        tfc.transpose(outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
-        states
-    ];
+    return [lastOutput, outputs, states];
 }
 exports.rnn = rnn;
 var RNN = (function (_super) {
@@ -35049,8 +37295,6 @@ var RNN = (function (_super) {
                 throw new errors_1.ValueError("RNN Layer has " + numStates + " state(s) but was passed " +
                     (initialState.length + " initial state(s)."));
             }
-            var inputShape = inputs.shape;
-            var timesteps = inputShape[1];
             if (_this.unroll) {
                 console.warn('Ignoring unroll = true for RNN layer, due to imperative backend.');
             }
@@ -35059,7 +37303,7 @@ var RNN = (function (_super) {
                 var outputs = _this.cell.call([inputs].concat(states), cellCallKwargs);
                 return [outputs[0], outputs.slice(1)];
             };
-            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, timesteps);
+            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, _this.returnSequences);
             var lastOutput = rnnOutputs[0];
             var outputs = rnnOutputs[1];
             var states = rnnOutputs[2];
@@ -35135,7 +37379,7 @@ var RNN = (function (_super) {
     return RNN;
 }(topology_2.Layer));
 exports.RNN = RNN;
-tfjs_core_1.serialization.SerializationMap.register(RNN);
+tfjs_core_1.serialization.registerClass(RNN);
 var RNNCell = (function (_super) {
     __extends(RNNCell, _super);
     function RNNCell() {
@@ -35254,7 +37498,7 @@ var SimpleRNNCell = (function (_super) {
     return SimpleRNNCell;
 }(RNNCell));
 exports.SimpleRNNCell = SimpleRNNCell;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNNCell);
+tfjs_core_1.serialization.registerClass(SimpleRNNCell);
 var SimpleRNN = (function (_super) {
     __extends(SimpleRNN, _super);
     function SimpleRNN(config) {
@@ -35405,7 +37649,7 @@ var SimpleRNN = (function (_super) {
     return SimpleRNN;
 }(RNN));
 exports.SimpleRNN = SimpleRNN;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNN);
+tfjs_core_1.serialization.registerClass(SimpleRNN);
 var GRUCell = (function (_super) {
     __extends(GRUCell, _super);
     function GRUCell(config) {
@@ -35580,7 +37824,7 @@ var GRUCell = (function (_super) {
     return GRUCell;
 }(RNNCell));
 exports.GRUCell = GRUCell;
-tfjs_core_1.serialization.SerializationMap.register(GRUCell);
+tfjs_core_1.serialization.registerClass(GRUCell);
 var GRU = (function (_super) {
     __extends(GRU, _super);
     function GRU(config) {
@@ -35757,7 +38001,7 @@ var GRU = (function (_super) {
     return GRU;
 }(RNN));
 exports.GRU = GRU;
-tfjs_core_1.serialization.SerializationMap.register(GRU);
+tfjs_core_1.serialization.registerClass(GRU);
 var LSTMCell = (function (_super) {
     __extends(LSTMCell, _super);
     function LSTMCell(config) {
@@ -35967,7 +38211,7 @@ var LSTMCell = (function (_super) {
     return LSTMCell;
 }(RNNCell));
 exports.LSTMCell = LSTMCell;
-tfjs_core_1.serialization.SerializationMap.register(LSTMCell);
+tfjs_core_1.serialization.registerClass(LSTMCell);
 var LSTM = (function (_super) {
     __extends(LSTM, _super);
     function LSTM(config) {
@@ -36152,7 +38396,7 @@ var LSTM = (function (_super) {
     return LSTM;
 }(RNN));
 exports.LSTM = LSTM;
-tfjs_core_1.serialization.SerializationMap.register(LSTM);
+tfjs_core_1.serialization.registerClass(LSTM);
 var StackedRNNCells = (function (_super) {
     __extends(StackedRNNCells, _super);
     function StackedRNNCells(config) {
@@ -36316,7 +38560,7 @@ var StackedRNNCells = (function (_super) {
     return StackedRNNCells;
 }(RNNCell));
 exports.StackedRNNCells = StackedRNNCells;
-tfjs_core_1.serialization.SerializationMap.register(StackedRNNCells);
+tfjs_core_1.serialization.registerClass(StackedRNNCells);
 function generateDropoutMask(ones, rate, training, count) {
     if (training === void 0) { training = null; }
     if (count === void 0) { count = 1; }
@@ -36336,7 +38580,7 @@ function generateDropoutMask(ones, rate, training, count) {
     }
 }
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"../variables":244,"./serialization":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"../variables":268,"./serialization":253,"@tensorflow/tfjs-core":68}],253:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -36347,7 +38591,7 @@ function deserialize(config, customObjects) {
 }
 exports.deserialize = deserialize;
 
-},{"../utils/generic_utils":238,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
+},{"../utils/generic_utils":262,"@tensorflow/tfjs-core":68}],254:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36488,10 +38732,10 @@ var TimeDistributed = (function (_super) {
         return tfjs_core_1.tidy(function () {
             inputs = types_utils_1.getExactlyOneTensor(inputs);
             var step = function (inputs, states) {
-                var output = _this.layer.call(inputs, kwargs);
+                var output = types_utils_1.getExactlyOneTensor(_this.layer.call(inputs, kwargs));
                 return [output, []];
             };
-            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, true);
             var y = rnnOutputs[1];
             return y;
         });
@@ -36500,7 +38744,7 @@ var TimeDistributed = (function (_super) {
     return TimeDistributed;
 }(Wrapper));
 exports.TimeDistributed = TimeDistributed;
-tfjs_core_1.serialization.SerializationMap.register(TimeDistributed);
+tfjs_core_1.serialization.registerClass(TimeDistributed);
 exports.VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
 function checkBidirectionalMergeMode(value) {
     generic_utils.checkStringTypeUnionValue(exports.VALID_BIDIRECTIONAL_MERGE_MODES, 'BidirectionalMergeMode', value);
@@ -36671,7 +38915,7 @@ var Bidirectional = (function (_super) {
                 var forwardState = initialState.slice(0, initialState.length / 2);
                 var backwardState = initialState.slice(initialState.length / 2);
                 y = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: forwardState }));
-                yRev = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
+                yRev = _this.backwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
             }
             var states;
             if (_this.returnState) {
@@ -36762,9 +39006,9 @@ var Bidirectional = (function (_super) {
     return Bidirectional;
 }(Wrapper));
 exports.Bidirectional = Bidirectional;
-tfjs_core_1.serialization.SerializationMap.register(Bidirectional);
+tfjs_core_1.serialization.registerClass(Bidirectional);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"./recurrent":228,"./serialization":229,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"./recurrent":252,"./serialization":253,"@tensorflow/tfjs-core":68}],255:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36850,14 +39094,14 @@ function disposeTensorsInLogs(logs) {
 }
 exports.disposeTensorsInLogs = disposeTensorsInLogs;
 
-},{"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],256:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var common_1 = require("./backend/common");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 function l2Normalize(x, axis) {
     return tfjs_core_1.tidy(function () {
@@ -37034,7 +39278,13 @@ function get(identifierOrFn) {
         if (identifierOrFn in lossesMap) {
             return lossesMap[identifierOrFn];
         }
-        throw new errors_1.ValueError("Unknown loss " + identifierOrFn);
+        var errMsg = "Unknown loss " + identifierOrFn;
+        if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+            errMsg = "Unknown loss " + identifierOrFn + ". " +
+                'Use "categoricalCrossentropy" as the string name for ' +
+                'tf.losses.softmaxCrossEntropy';
+        }
+        throw new errors_1.ValueError(errMsg);
     }
     else {
         return identifierOrFn;
@@ -37042,13 +39292,13 @@ function get(identifierOrFn) {
 }
 exports.get = get;
 
-},{"./backend/common":198,"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"@tensorflow/tfjs-core":68}],257:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 var losses_1 = require("./losses");
 var losses_2 = require("./losses");
@@ -37064,6 +39314,54 @@ function categoricalAccuracy(yTrue, yPred) {
     return tfjs_core_1.tidy(function () { return K.cast(tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'); });
 }
 exports.categoricalAccuracy = categoricalAccuracy;
+function truePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function falseNegatives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(zero))
+            .sum()
+            .cast('float32');
+    });
+}
+function falsePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function precision(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fp = falsePositives(yTrue, yPred);
+        var denominator = tp.add(fp);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fn = falseNegatives(yTrue, yPred);
+        var denominator = tp.add(fn);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.recall = recall;
 function binaryCrossentropy(yTrue, yPred) {
     return losses_2.binaryCrossentropy(yTrue, yPred);
 }
@@ -37093,6 +39391,7 @@ function get(identifier) {
     var metricsMap = {
         binaryAccuracy: binaryAccuracy,
         categoricalAccuracy: categoricalAccuracy,
+        precision: precision,
         categoricalCrossentropy: exports.categoricalCrossentropy,
         sparseCategoricalCrossentropy: exports.sparseCategoricalCrossentropy,
         mse: exports.mse,
@@ -37115,7 +39414,7 @@ function get(identifier) {
 }
 exports.get = get;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"./losses":232,"@tensorflow/tfjs-core":68}],234:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"./losses":256,"@tensorflow/tfjs-core":68}],258:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37179,6 +39478,10 @@ function modelFromJSON(modelAndWeightsConfig, customObjects) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
+                    if (!('modelTopology' in modelAndWeightsConfig)) {
+                        modelAndWeightsConfig = { modelTopology: modelAndWeightsConfig };
+                    }
+                    modelAndWeightsConfig = modelAndWeightsConfig;
                     modelTopology = modelAndWeightsConfig.modelTopology;
                     if (modelTopology['model_config'] != null) {
                         modelTopology = modelTopology['model_config'];
@@ -37277,6 +39580,14 @@ var Sequential = (function (_super) {
         }
         return _this;
     }
+    Sequential.prototype.checkShape = function (layer) {
+        var shape = layer.inboundNodes[0].outputTensors[0].shape;
+        if (shape.some(function (x) { return x < 0; })) {
+            throw new errors_1.ValueError('Negative dimension size caused by adding layer ' +
+                (layer.name + " with input shape [") +
+                (layer.inboundNodes[0].inputTensors[0].shape + "]"));
+        }
+    };
     Sequential.prototype.add = function (layer) {
         var isLayerModelInstance = layer instanceof Sequential || layer instanceof training_1.Model;
         var modelLayer;
@@ -37325,6 +39636,7 @@ var Sequential = (function (_super) {
                         'For multi-output layers, ' +
                         'use the functional API.');
                 }
+                this.checkShape(layer);
                 this.outputs = [layer.inboundNodes[0].outputTensors[0]];
                 this.inputs = topology_1.getSourceInputs(this.outputs[0]);
             }
@@ -37350,6 +39662,7 @@ var Sequential = (function (_super) {
                     'For multi-output layers, ' +
                     'use the functional API.');
             }
+            this.checkShape(layer);
             this.outputs = [outputTensor];
             this.inboundNodes[0].outputTensors = this.outputs;
             this.inboundNodes[0].outputShapes = [this.outputs[0].shape];
@@ -37446,6 +39759,16 @@ var Sequential = (function (_super) {
         }
         return this.model.evaluate(x, y, config);
     };
+    Sequential.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before being used.');
+                }
+                return [2, this.model.evaluateDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.prototype.predict = function (x, config) {
         if (config === void 0) { config = {}; }
         if (this.model == null) {
@@ -37480,19 +39803,40 @@ var Sequential = (function (_super) {
             });
         });
     };
+    Sequential.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before ' +
+                        'being used.');
+                }
+                return [2, this.model.fitDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.fromConfig = function (cls, config) {
-        var model = new cls({});
+        var configArray;
+        var extraModelConfig = {};
+        if (config instanceof Array) {
+            if (!(config[0].className != null) ||
+                config[0]['className'] === 'Merge') {
+                throw new errors_1.ValueError('Legacy serialization format not supported yet.');
+            }
+            configArray = config;
+        }
+        else {
+            tfjs_core_1.util.assert(config['layers'] != null, "When the config data for a Sequential model is not an Array, " +
+                "it must be an Object that contains the 'layers' field.");
+            configArray = config['layers'];
+            delete config['layers'];
+            extraModelConfig = config;
+        }
+        var model = new cls(extraModelConfig);
         if (!(model instanceof Sequential)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called on non-Sequential input: " + model);
+            throw new errors_1.NotImplementedError("Sequential.fromConfig called on non-Sequential input: " + model);
         }
-        if (!(config instanceof Array)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called without an array of configs");
-        }
-        if (!(config[0].className != null) || config[0]['className'] === 'Merge') {
-            throw new errors_1.ValueError('Legacy serialization format not supported yet.');
-        }
-        for (var _i = 0, _a = config; _i < _a.length; _i++) {
-            var conf = _a[_i];
+        for (var _i = 0, configArray_1 = configArray; _i < configArray_1.length; _i++) {
+            var conf = configArray_1[_i];
             var layer = serialization_1.deserialize(conf);
             model.add(layer);
         }
@@ -37520,9 +39864,9 @@ var Sequential = (function (_super) {
     return Sequential;
 }(training_1.Model));
 exports.Sequential = Sequential;
-tfjs_core_1.serialization.SerializationMap.register(Sequential);
+tfjs_core_1.serialization.registerClass(Sequential);
 
-},{"./backend/state":199,"./engine/input_layer":207,"./engine/topology":208,"./engine/training":209,"./errors":210,"./layers/serialization":229,"./utils/generic_utils":238,"./utils/serialization_utils":241,"./utils/types_utils":242,"@tensorflow/tfjs-core":68}],235:[function(require,module,exports){
+},{"./backend/state":219,"./engine/input_layer":228,"./engine/topology":229,"./engine/training":230,"./errors":233,"./layers/serialization":253,"./utils/generic_utils":262,"./utils/serialization_utils":265,"./utils/types_utils":266,"@tensorflow/tfjs-core":68}],259:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -37550,7 +39894,7 @@ function getOptimizer(identifier) {
 }
 exports.getOptimizer = getOptimizer;
 
-},{"./backend/common":198,"./errors":210,"@tensorflow/tfjs-core":68}],236:[function(require,module,exports){
+},{"./backend/common":218,"./errors":233,"@tensorflow/tfjs-core":68}],260:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37612,7 +39956,7 @@ var L1L2 = (function (_super) {
     return L1L2;
 }(Regularizer));
 exports.L1L2 = L1L2;
-tfjs_core_1.serialization.SerializationMap.register(L1L2);
+tfjs_core_1.serialization.registerClass(L1L2);
 function l1(config) {
     return new L1L2({ l1: config != null ? config.l1 : null, l2: 0 });
 }
@@ -37653,7 +39997,7 @@ function getRegularizer(identifier) {
 }
 exports.getRegularizer = getRegularizer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],237:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],261:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37713,7 +40057,7 @@ function deconvLength(dimSize, strideSize, kernelSize, padding) {
 }
 exports.deconvLength = deconvLength;
 
-},{"../errors":210,"./generic_utils":238,"./math_utils":240}],238:[function(require,module,exports){
+},{"../errors":233,"./generic_utils":262,"./math_utils":264}],262:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -37982,7 +40326,7 @@ function checkArrayTypeAndLength(x, expectedType, minLength, maxLength) {
 }
 exports.checkArrayTypeAndLength = checkArrayTypeAndLength;
 
-},{"../errors":210}],239:[function(require,module,exports){
+},{"../errors":233}],263:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var variable_utils_1 = require("./variable_utils");
@@ -38142,7 +40486,7 @@ function printLayerSummaryWithConnections(layer, positions, relevantNodes, print
     }
 }
 
-},{"./variable_utils":243}],240:[function(require,module,exports){
+},{"./variable_utils":267}],264:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38214,7 +40558,7 @@ function range(begin, end) {
 }
 exports.range = range;
 
-},{"../errors":210,"@tensorflow/tfjs-core":68}],241:[function(require,module,exports){
+},{"../errors":233,"@tensorflow/tfjs-core":68}],265:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils = require("../utils/generic_utils");
@@ -38308,7 +40652,7 @@ function convertTsToPythonic(tsConfig, key) {
 }
 exports.convertTsToPythonic = convertTsToPythonic;
 
-},{"../utils/generic_utils":238}],242:[function(require,module,exports){
+},{"../utils/generic_utils":262}],266:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -38356,7 +40700,7 @@ function getExactlyOneShape(shapes) {
 }
 exports.getExactlyOneShape = getExactlyOneShape;
 
-},{"../errors":210}],243:[function(require,module,exports){
+},{"../errors":233}],267:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function countParamsInWeights(weights) {
@@ -38374,7 +40718,7 @@ function countParamsInWeights(weights) {
 }
 exports.countParamsInWeights = countParamsInWeights;
 
-},{}],244:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38467,8 +40811,9 @@ function truncatedNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'truncatedNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38477,8 +40822,9 @@ function randomNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'randomNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38513,13 +40859,13 @@ function gradients(lossFn, variables) {
 }
 exports.gradients = gradients;
 
-},{"./backend/state":199,"./common":203,"./errors":210,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
+},{"./backend/state":219,"./common":223,"./errors":233,"@tensorflow/tfjs-core":68}],269:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.7.5';
+var version = '0.8.3';
 exports.version = version;
 
-},{}],246:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -38539,13 +40885,13 @@ exports.version = {
     'tfjs': version_1.version
 };
 
-},{"./version":247,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":217}],247:[function(require,module,exports){
+},{"./version":271,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":241}],271:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.7';
+var version = '0.13.3';
 exports.version = version;
 
-},{}],248:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -38663,7 +41009,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],249:[function(require,module,exports){
+},{}],273:[function(require,module,exports){
 /**
  * Bit twiddling hacks for JavaScript.
  *
@@ -38869,9 +41215,9 @@ exports.nextCombination = function(v) {
 }
 
 
-},{}],250:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 
-},{}],251:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -40609,7 +42955,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":248,"ieee754":260}],252:[function(require,module,exports){
+},{"base64-js":272,"ieee754":284}],276:[function(require,module,exports){
 (function (Buffer){
 var clone = (function() {
 'use strict';
@@ -40779,7 +43125,7 @@ if (typeof module === 'object' && module.exports) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":251}],253:[function(require,module,exports){
+},{"buffer":275}],277:[function(require,module,exports){
 "use strict"
 
 var createThunk = require("./lib/thunk.js")
@@ -40890,7 +43236,7 @@ function compileCwise(user_args) {
 
 module.exports = compileCwise
 
-},{"./lib/thunk.js":255}],254:[function(require,module,exports){
+},{"./lib/thunk.js":279}],278:[function(require,module,exports){
 "use strict"
 
 var uniq = require("uniq")
@@ -41250,7 +43596,7 @@ function generateCWiseOp(proc, typesig) {
 }
 module.exports = generateCWiseOp
 
-},{"uniq":301}],255:[function(require,module,exports){
+},{"uniq":325}],279:[function(require,module,exports){
 "use strict"
 
 // The function below is called when constructing a cwise function object, and does the following:
@@ -41338,9 +43684,9 @@ function createThunk(proc) {
 
 module.exports = createThunk
 
-},{"./compile.js":254}],256:[function(require,module,exports){
+},{"./compile.js":278}],280:[function(require,module,exports){
 module.exports = require("cwise-compiler")
-},{"cwise-compiler":253}],257:[function(require,module,exports){
+},{"cwise-compiler":277}],281:[function(require,module,exports){
 "use strict"
 
 function dupe_array(count, value, i) {
@@ -41390,7 +43736,7 @@ function dupe(count, value) {
 }
 
 module.exports = dupe
-},{}],258:[function(require,module,exports){
+},{}],282:[function(require,module,exports){
 'use strict';
 
 function FFT(size) {
@@ -41899,7 +44245,7 @@ FFT.prototype._singleRealTransform4 = function _singleRealTransform4(outOff,
   out[outOff + 7] = FDi;
 };
 
-},{}],259:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 1.3.2
@@ -42089,7 +44435,7 @@ if (typeof module !== "undefined" && module.exports) {
   });
 }
 
-},{}],260:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -42175,7 +44521,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],261:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 "use strict"
 
 function iota(n) {
@@ -42187,7 +44533,7 @@ function iota(n) {
 }
 
 module.exports = iota
-},{}],262:[function(require,module,exports){
+},{}],286:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -42210,10 +44556,10 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],263:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 !function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.MidiConvert=e():t.MidiConvert=e()}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="",e(e.s=7)}([function(t,e,n){"use strict";n.d(e,"a",function(){return r}),n.d(e,"b",function(){return i}),n.d(e,"c",function(){return a});var r=["acoustic grand piano","bright acoustic piano","electric grand piano","honky-tonk piano","electric piano 1","electric piano 2","harpsichord","clavi","celesta","glockenspiel","music box","vibraphone","marimba","xylophone","tubular bells","dulcimer","drawbar organ","percussive organ","rock organ","church organ","reed organ","accordion","harmonica","tango accordion","acoustic guitar (nylon)","acoustic guitar (steel)","electric guitar (jazz)","electric guitar (clean)","electric guitar (muted)","overdriven guitar","distortion guitar","guitar harmonics","acoustic bass","electric bass (finger)","electric bass (pick)","fretless bass","slap bass 1","slap bass 2","synth bass 1","synth bass 2","violin","viola","cello","contrabass","tremolo strings","pizzicato strings","orchestral harp","timpani","string ensemble 1","string ensemble 2","synthstrings 1","synthstrings 2","choir aahs","voice oohs","synth voice","orchestra hit","trumpet","trombone","tuba","muted trumpet","french horn","brass section","synthbrass 1","synthbrass 2","soprano sax","alto sax","tenor sax","baritone sax","oboe","english horn","bassoon","clarinet","piccolo","flute","recorder","pan flute","blown bottle","shakuhachi","whistle","ocarina","lead 1 (square)","lead 2 (sawtooth)","lead 3 (calliope)","lead 4 (chiff)","lead 5 (charang)","lead 6 (voice)","lead 7 (fifths)","lead 8 (bass + lead)","pad 1 (new age)","pad 2 (warm)","pad 3 (polysynth)","pad 4 (choir)","pad 5 (bowed)","pad 6 (metallic)","pad 7 (halo)","pad 8 (sweep)","fx 1 (rain)","fx 2 (soundtrack)","fx 3 (crystal)","fx 4 (atmosphere)","fx 5 (brightness)","fx 6 (goblins)","fx 7 (echoes)","fx 8 (sci-fi)","sitar","banjo","shamisen","koto","kalimba","bag pipe","fiddle","shanai","tinkle bell","agogo","steel drums","woodblock","taiko drum","melodic tom","synth drum","reverse cymbal","guitar fret noise","breath noise","seashore","bird tweet","telephone ring","helicopter","applause","gunshot"],i=["piano","chromatic percussion","organ","guitar","bass","strings","ensemble","brass","reed","pipe","synth lead","synth pad","synth effects","ethnic","percussive","sound effects"],a={0:"standard kit",8:"room kit",16:"power kit",24:"electronic kit",25:"tr-808 kit",32:"jazz kit",40:"brush kit",48:"orchestra kit",56:"sound fx kit"}},function(t,e,n){"use strict";function r(t){return t.replace(/\u0000/g,"")}function i(t,e){return 60/e.bpm*(t/e.PPQ)}function a(t){return"number"==typeof t}function o(t){return"string"==typeof t}function s(t){return["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"][t%12]+(Math.floor(t/12)-1)}e.b=r,e.a=i,e.c=a,n.d(e,"d",function(){return u}),e.e=s,n.d(e,"f",function(){return c});var u=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i;return function(e){return o(e)&&t.test(e)}}(),c=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,e={cbb:-2,cb:-1,c:0,"c#":1,cx:2,dbb:0,db:1,d:2,"d#":3,dx:4,ebb:2,eb:3,e:4,"e#":5,ex:6,fbb:3,fb:4,f:5,"f#":6,fx:7,gbb:5,gb:6,g:7,"g#":8,gx:9,abb:7,ab:8,a:9,"a#":10,ax:11,bbb:9,bb:10,b:11,"b#":12,bx:13};return function(n){var r=t.exec(n),i=r[1],a=r[2];return e[i.toLowerCase()]+12*(parseInt(a)+1)}}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(11),a=(n.n(i),n(10)),o=(n.n(a),n(1)),s=n(9),u=n(5),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(){r(this,t),this.header={bpm:120,timeSignature:[4,4],PPQ:480},this.tracks=[]}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t;return n.header=e.header,e.tracks.forEach(function(t){var e=s.a.fromJSON(t);n.tracks.push(e)}),n}}]),c(t,[{key:"load",value:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:null,r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"GET";return new Promise(function(i,a){var o=new XMLHttpRequest;o.open(r,t),o.responseType="arraybuffer",o.addEventListener("load",function(){4===o.readyState&&200===o.status?i(e.decode(o.response)):a(o.status)}),o.addEventListener("error",a),o.send(n)}).catch(function(t){console.log(t)})}},{key:"decode",value:function(t){var e=this;if(t instanceof ArrayBuffer){var r=new Uint8Array(t);t=String.fromCharCode.apply(null,r)}var a=i(t);return this.header=n.i(u.a)(a),this.tracks=[],a.tracks.forEach(function(t,n){var r=new s.a;r.id=n,e.tracks.push(r);var i=0;t.forEach(function(t){i+=o.a(t.deltaTime,e.header),"meta"===t.type&&"trackName"===t.subtype?r.name=o.b(t.text):"noteOn"===t.subtype?(r.noteOn(t.noteNumber,i,t.velocity/127),-1===r.channelNumber&&(r.channelNumber=t.channel)):"noteOff"===t.subtype?r.noteOff(t.noteNumber,i):"controller"===t.subtype&&t.controllerType?r.cc(t.controllerType,i,t.value/127):"meta"===t.type&&"instrumentName"===t.subtype?r.instrument=t.text:"channel"===t.type&&"programChange"===t.subtype&&(r.patch(t.programNumber),r.channelNumber=t.channel)}),e.header.name||r.length||!r.name||(e.header.name=r.name)}),this}},{key:"encode",value:function(){var t=this,e=new a.File({ticks:this.header.PPQ}),n=this.tracks.filter(function(t){return!t.length})[0];if(this.header.name&&(!n||n.name!==this.header.name)){e.addTrack().addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:this.header.name}))}return this.tracks.forEach(function(n){var r=e.addTrack();r.setTempo(t.bpm),n.name&&r.addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:n.name})),n.encode(r,t.header)}),e.toBytes()}},{key:"toArray",value:function(){for(var t=this.encode(),e=new Array(t.length),n=0;n<t.length;n++)e[n]=t.charCodeAt(n);return e}},{key:"toJSON",value:function(){var t={header:this.header,startTime:this.startTime,duration:this.duration,tracks:(this.tracks||[]).map(function(t){return t.toJSON()})};return t.header.name||(t.header.name=""),t}},{key:"track",value:function(t){var e=new s.a(t);return this.tracks.push(e),e}},{key:"get",value:function(t){return o.c(t)?this.tracks[t]:this.tracks.find(function(e){return e.name===t})}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=new t;return r.header=this.header,r.tracks=this.tracks.map(function(t){return t.slice(e,n)}),r}},{key:"startTime",get:function(){var t=this.tracks.map(function(t){return t.startTime});return t.length?Math.min.apply(Math,t)||0:0}},{key:"bpm",get:function(){return this.header.bpm},set:function(t){var e=this.header.bpm;this.header.bpm=t;var n=e/t;this.tracks.forEach(function(t){return t.scale(n)})}},{key:"timeSignature",get:function(){return this.header.timeSignature},set:function(t){this.header.timeSignature=t}},{key:"duration",get:function(){var t=this.tracks.map(function(t){return t.duration});return t.length?Math.max.apply(Math,t)||0:0}}]),t}()},function(t,e,n){"use strict";function r(t,e){var n=0,r=t.length,i=r;if(r>0&&t[r-1].time<=e)return r-1;for(;n<i;){var a=Math.floor(n+(i-n)/2),o=t[a],s=t[a+1];if(o.time===e){for(var u=a;u<t.length;u++){t[u].time===e&&(a=u)}return a}if(o.time<e&&s.time>e)return a;o.time>e?i=a:o.time<e&&(n=a+1)}return-1}function i(t,e){if(t.length){var n=r(t,e.time);t.splice(n+1,0,e)}else t.push(e)}n.d(e,"a",function(){return i})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),a={1:"modulationWheel",2:"breath",4:"footController",5:"portamentoTime",7:"volume",8:"balance",10:"pan",64:"sustain",65:"portamentoTime",66:"sostenuto",67:"softPedal",68:"legatoFootswitch",84:"portamentoContro"},o=function(){function t(e,n,i){r(this,t),this.number=e,this.time=n,this.value=i}return i(t,[{key:"name",get:function(){if(a.hasOwnProperty(this.number))return a[this.number]}}]),t}()},function(t,e,n){"use strict";function r(t){for(var e={PPQ:t.header.ticksPerBeat},n=0;n<t.tracks.length;n++)for(var r=t.tracks[n],i=0;i<r.length;i++){var a=r[i];"meta"===a.type&&("timeSignature"===a.subtype?e.timeSignature=[a.numerator,a.denominator]:"setTempo"===a.subtype&&(e.bpm||(e.bpm=6e7/a.microsecondsPerBeat)))}return e.bpm=e.bpm||120,e}n.d(e,"a",function(){return r})},function(t,e,n){"use strict";function r(t,e){for(var n=0;n<t.length;n++){var r=t[n],i=e[n];if(r.length>i)return!0}return!1}function i(t,e,n){for(var r=0,i=1/0,a=0;a<t.length;a++){var o=t[a],s=e[a];o[s]&&o[s].time<i&&(r=a,i=o[s].time)}n[r](t[r][e[r]]),e[r]+=1}function a(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];for(var a=e.filter(function(t,e){return e%2==0}),o=new Uint32Array(a.length),s=e.filter(function(t,e){return e%2==1});r(a,o);)i(a,o,s)}n.d(e,"a",function(){return a})},function(t,e,n){"use strict";function r(t){return(new s.a).decode(t)}function i(t,e){var n=(new s.a).load(t);return e&&n.then(e),n}function a(){return new s.a}function o(t){return s.a.fromJSON(t)}Object.defineProperty(e,"__esModule",{value:!0}),e.parse=r,e.load=i,e.create=a,e.fromJSON=o;var s=n(2),u=n(0);n.d(e,"instrumentByPatchID",function(){return u.a}),n.d(e,"instrumentFamilyByID",function(){return u.b}),n.d(e,"drumKitByPatchID",function(){return u.c})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=n(1),a=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),o=function(){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1;if(r(this,t),i.c(e))this.midi=e;else{if(!i.d(e))throw new Error("the midi value must either be in Pitch Notation (e.g. C#4) or a midi value");this.name=e}this.time=n,this.duration=a,this.velocity=o}return a(t,null,[{key:"fromJSON",value:function(e){return new t(e.midi,e.time,e.duration,e.velocity)}}]),a(t,[{key:"match",value:function(t){return i.c(t)?this.midi===t:i.d(t)?this.name.toLowerCase()===t.toLowerCase():void 0}},{key:"toJSON",value:function(){return{name:this.name,midi:this.midi,time:this.time,velocity:this.velocity,duration:this.duration}}},{key:"name",get:function(){return i.e(this.midi)},set:function(t){this.midi=i.f(t)}},{key:"noteOn",get:function(){return this.time},set:function(t){this.time=t}},{key:"noteOff",get:function(){return this.time+this.duration},set:function(t){this.duration=t-this.time}}]),t}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(3),a=n(4),o=n(6),s=n(8),u=n(0),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:-1,i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:-1;r(this,t),this.name=e,this.channelNumber=i,this.notes=[],this.controlChanges={},this.instrumentNumber=n}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t(e.name,e.instrumentNumber,e.channelNumber);return n.id=e.id,e.notes&&e.notes.forEach(function(t){var e=s.a.fromJSON(t);n.notes.push(e)}),e.controlChanges&&(n.controlChanges=e.controlChanges),n}}]),c(t,[{key:"note",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,a=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1,o=new s.a(t,e,r,a);return n.i(i.a)(this.notes,o),this}},{key:"noteOn",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:1,a=new s.a(t,e,0,r);return n.i(i.a)(this.notes,a),this}},{key:"noteOff",value:function(t,e){for(var n=0;n<this.notes.length;n++){var r=this.notes[n];if(r.match(t)&&0===r.duration){r.noteOff=e;break}}return this}},{key:"cc",value:function(t,e,r){this.controlChanges.hasOwnProperty(t)||(this.controlChanges[t]=[]);var o=new a.a(t,e,r);return n.i(i.a)(this.controlChanges[t],o),this}},{key:"patch",value:function(t){return this.instrumentNumber=t,this}},{key:"channel",value:function(t){return this.channelNumber=t,this}},{key:"scale",value:function(t){return this.notes.forEach(function(e){e.time*=t,e.duration*=t}),this}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=Math.max(this.notes.findIndex(function(t){return t.time>=e}),0),i=this.notes.findIndex(function(t){return t.noteOff>=n})+1,a=new t(this.name);return a.notes=this.notes.slice(r,i),a.notes.forEach(function(t){return t.time=t.time-e}),a}},{key:"encode",value:function(t,e){function r(t){var e=Math.floor(i*t),n=Math.max(e-a,0);return a=e,n}var i=e.PPQ/(60/e.bpm),a=0,s=Math.max(0,this.channelNumber);-1!==this.instrumentNumber&&t.instrument(s,this.instrumentNumber),n.i(o.a)(this.noteOns.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOn(s,e.name,r(e.time),Math.floor(127*e.velocity))},this.noteOffs.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOff(s,e.name,r(e.time))})}},{key:"toJSON",value:function(){var t={startTime:this.startTime,duration:this.duration,length:this.length,notes:[],controlChanges:{}};return void 0!==this.id&&(t.id=this.id),t.name=this.name,-1!==this.instrumentNumber&&(t.instrumentNumber=this.instrumentNumber,t.instrument=this.instrument,t.instrumentFamily=this.instrumentFamily),-1!==this.channelNumber&&(t.channelNumber=this.channelNumber,t.isPercussion=this.isPercussion),this.notes.length&&(t.notes=this.notes.map(function(t){return t.toJSON()})),Object.keys(this.controlChanges).length&&(t.controlChanges=this.controlChanges),t}},{key:"noteOns",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOn,midi:e.midi,name:e.name,velocity:e.velocity})}),t}},{key:"noteOffs",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOff,midi:e.midi,name:e.name})}),t}},{key:"length",get:function(){return this.notes.length}},{key:"startTime",get:function(){if(this.notes.length){return this.notes[0].noteOn}return 0}},{key:"duration",get:function(){if(this.notes.length){return this.notes[this.notes.length-1].noteOff}return 0}},{key:"instrument",get:function(){return this.isPercussion?u.c[this.instrumentNumber]:u.a[this.instrumentNumber]},set:function(t){var e=u.a.indexOf(t);-1!==e&&(this.instrumentNumber=e)}},{key:"isPercussion",get:function(){return[9,10].includes(this.channelNumber)}},{key:"instrumentFamily",get:function(){return this.isPercussion?"drums":u.b[Math.floor(this.instrumentNumber/8)]}}]),t}()},function(t,e,n){(function(t){var n={};!function(t){var e=t.DEFAULT_VOLUME=90,n=(t.DEFAULT_DURATION=128,t.DEFAULT_CHANNEL=0,{midi_letter_pitches:{a:21,b:23,c:12,d:14,e:16,f:17,g:19},midiPitchFromNote:function(t){var e=/([a-g])(#+|b+)?([0-9]+)$/i.exec(t),r=e[1].toLowerCase(),i=e[2]||"";return 12*parseInt(e[3],10)+n.midi_letter_pitches[r]+("#"==i.substr(0,1)?1:-1)*i.length},ensureMidiPitch:function(t){return"number"!=typeof t&&/[^0-9]/.test(t)?n.midiPitchFromNote(t):parseInt(t,10)},midi_pitches_letter:{12:"c",13:"c#",14:"d",15:"d#",16:"e",17:"f",18:"f#",19:"g",20:"g#",21:"a",22:"a#",23:"b"},midi_flattened_notes:{"a#":"bb","c#":"db","d#":"eb","f#":"gb","g#":"ab"},noteFromMidiPitch:function(t,e){var r,i=0,a=t,e=e||!1;return t>23&&(i=Math.floor(t/12)-1,a=t-12*i),r=n.midi_pitches_letter[a],e&&r.indexOf("#")>0&&(r=n.midi_flattened_notes[r]),r+i},mpqnFromBpm:function(t){var e=Math.floor(6e7/t),n=[];do{n.unshift(255&e),e>>=8}while(e);for(;n.length<3;)n.push(0);return n},bpmFromMpqn:function(t){var e=t;if(void 0!==t[0]){e=0;for(var n=0,r=t.length-1;r>=0;++n,--r)e|=t[n]<<r}return Math.floor(6e7/t)},codes2Str:function(t){return String.fromCharCode.apply(null,t)},str2Bytes:function(t,e){if(e)for(;t.length/2<e;)t="0"+t;for(var n=[],r=t.length-1;r>=0;r-=2){var i=0===r?t[r]:t[r-1]+t[r];n.unshift(parseInt(i,16))}return n},translateTickTime:function(t){for(var e=127&t;t>>=7;)e<<=8,e|=127&t|128;for(var n=[];;){if(n.push(255&e),!(128&e))break;e>>=8}return n}}),r=function(t){if(!this)return new r(t);!t||null===t.type&&void 0===t.type||null===t.channel&&void 0===t.channel||null===t.param1&&void 0===t.param1||(this.setTime(t.time),this.setType(t.type),this.setChannel(t.channel),this.setParam1(t.param1),this.setParam2(t.param2))};r.NOTE_OFF=128,r.NOTE_ON=144,r.AFTER_TOUCH=160,r.CONTROLLER=176,r.PROGRAM_CHANGE=192,r.CHANNEL_AFTERTOUCH=208,r.PITCH_BEND=224,r.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},r.prototype.setType=function(t){if(t<r.NOTE_OFF||t>r.PITCH_BEND)throw new Error("Trying to set an unknown event: "+t);this.type=t},r.prototype.setChannel=function(t){if(t<0||t>15)throw new Error("Channel is out of bounds.");this.channel=t},r.prototype.setParam1=function(t){this.param1=t},r.prototype.setParam2=function(t){this.param2=t},r.prototype.toBytes=function(){var t=[],e=this.type|15&this.channel;return t.push.apply(t,this.time),t.push(e),t.push(this.param1),void 0!==this.param2&&null!==this.param2&&t.push(this.param2),t};var i=function(t){if(!this)return new i(t);this.setTime(t.time),this.setType(t.type),this.setData(t.data)};i.SEQUENCE=0,i.TEXT=1,i.COPYRIGHT=2,i.TRACK_NAME=3,i.INSTRUMENT=4,i.LYRIC=5,i.MARKER=6,i.CUE_POINT=7,i.CHANNEL_PREFIX=32,i.END_OF_TRACK=47,i.TEMPO=81,i.SMPTE=84,i.TIME_SIG=88,i.KEY_SIG=89,i.SEQ_EVENT=127,i.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},i.prototype.setType=function(t){this.type=t},i.prototype.setData=function(t){this.data=t},i.prototype.toBytes=function(){if(!this.type)throw new Error("Type for meta-event not specified.");var t=[];if(t.push.apply(t,this.time),t.push(255,this.type),Array.isArray(this.data))t.push(this.data.length),t.push.apply(t,this.data);else if("number"==typeof this.data)t.push(1,this.data);else if(null!==this.data&&void 0!==this.data){t.push(this.data.length);var e=this.data.split("").map(function(t){return t.charCodeAt(0)});t.push.apply(t,e)}else t.push(0);return t};var a=function(t){if(!this)return new a(t);var e=t||{};this.events=e.events||[]};a.START_BYTES=[77,84,114,107],a.END_BYTES=[0,255,47,0],a.prototype.addEvent=function(t){return this.events.push(t),this},a.prototype.addNoteOn=a.prototype.noteOn=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_ON,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNoteOff=a.prototype.noteOff=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_OFF,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNote=a.prototype.note=function(t,e,n,r,i){return this.noteOn(t,e,r,i),n&&this.noteOff(t,e,n,i),this},a.prototype.addChord=a.prototype.chord=function(t,e,n,r){if(!Array.isArray(e)&&!e.length)throw new Error("Chord must be an array of pitches");return e.forEach(function(e){this.noteOn(t,e,0,r)},this),e.forEach(function(e,r){0===r?this.noteOff(t,e,n):this.noteOff(t,e)},this),this},a.prototype.setInstrument=a.prototype.instrument=function(t,e,n){return this.events.push(new r({type:r.PROGRAM_CHANGE,channel:t,param1:e,time:n||0})),this},a.prototype.setTempo=a.prototype.tempo=function(t,e){return this.events.push(new i({type:i.TEMPO,data:n.mpqnFromBpm(t),time:e||0})),this},a.prototype.toBytes=function(){var t=0,e=[],r=a.START_BYTES,i=a.END_BYTES,o=function(n){var r=n.toBytes();t+=r.length,e.push.apply(e,r)};this.events.forEach(o),t+=i.length;var s=n.str2Bytes(t.toString(16),4);return r.concat(s,e,i)};var o=function(t){if(!this)return new o(t);var e=t||{};if(e.ticks){if("number"!=typeof e.ticks)throw new Error("Ticks per beat must be a number!");if(e.ticks<=0||e.ticks>=32768||e.ticks%1!=0)throw new Error("Ticks per beat must be an integer between 1 and 32767!")}this.ticks=e.ticks||128,this.tracks=e.tracks||[]};o.HDR_CHUNKID="MThd",o.HDR_CHUNK_SIZE="\0\0\0",o.HDR_TYPE0="\0\0",o.HDR_TYPE1="\0",o.prototype.addTrack=function(t){return t?(this.tracks.push(t),this):(t=new a,this.tracks.push(t),t)},o.prototype.toBytes=function(){var t=this.tracks.length.toString(16),e=o.HDR_CHUNKID+o.HDR_CHUNK_SIZE;return parseInt(t,16)>1?e+=o.HDR_TYPE1:e+=o.HDR_TYPE0,e+=n.codes2Str(n.str2Bytes(t,2)),e+=String.fromCharCode(this.ticks/256,this.ticks%256),this.tracks.forEach(function(t){e+=n.codes2Str(t.toBytes())}),e},t.Util=n,t.File=o,t.Track=a,t.Event=r,t.MetaEvent=i}(n),void 0!==t&&null!==t?t.exports=n:void 0!==e&&null!==e?e=n:this.Midi=n}).call(e,n(12)(t))},function(t,e){function n(t){function e(t){var e=t.read(4),n=t.readInt32();return{id:e,length:n,data:t.read(n)}}var n;stream=r(t);var i=e(stream);if("MThd"!=i.id||6!=i.length)throw"Bad .mid file - header not found";var a=r(i.data),o=a.readInt16(),s=a.readInt16(),u=a.readInt16();if(32768&u)throw"Expressing time division in SMTPE frames is not supported yet";ticksPerBeat=u;for(var c={formatType:o,trackCount:s,ticksPerBeat:ticksPerBeat},h=[],f=0;f<c.trackCount;f++){h[f]=[];var d=e(stream);if("MTrk"!=d.id)throw"Unexpected chunk - expected MTrk, got "+d.id;for(var l=r(d.data);!l.eof();){var p=function(t){var e={};e.deltaTime=t.readVarInt();var r=t.readInt8();if(240==(240&r)){if(255==r){e.type="meta";var i=t.readInt8(),a=t.readVarInt();switch(i){case 0:if(e.subtype="sequenceNumber",2!=a)throw"Expected length for sequenceNumber event is 2, got "+a;return e.number=t.readInt16(),e;case 1:return e.subtype="text",e.text=t.read(a),e;case 2:return e.subtype="copyrightNotice",e.text=t.read(a),e;case 3:return e.subtype="trackName",e.text=t.read(a),e;case 4:return e.subtype="instrumentName",e.text=t.read(a),e;case 5:return e.subtype="lyrics",e.text=t.read(a),e;case 6:return e.subtype="marker",e.text=t.read(a),e;case 7:return e.subtype="cuePoint",e.text=t.read(a),e;case 32:if(e.subtype="midiChannelPrefix",1!=a)throw"Expected length for midiChannelPrefix event is 1, got "+a;return e.channel=t.readInt8(),e;case 47:if(e.subtype="endOfTrack",0!=a)throw"Expected length for endOfTrack event is 0, got "+a;return e;case 81:if(e.subtype="setTempo",3!=a)throw"Expected length for setTempo event is 3, got "+a;return e.microsecondsPerBeat=(t.readInt8()<<16)+(t.readInt8()<<8)+t.readInt8(),e;case 84:if(e.subtype="smpteOffset",5!=a)throw"Expected length for smpteOffset event is 5, got "+a;var o=t.readInt8();return e.frameRate={0:24,32:25,64:29,96:30}[96&o],e.hour=31&o,e.min=t.readInt8(),e.sec=t.readInt8(),e.frame=t.readInt8(),e.subframe=t.readInt8(),e;case 88:if(e.subtype="timeSignature",4!=a)throw"Expected length for timeSignature event is 4, got "+a;return e.numerator=t.readInt8(),e.denominator=Math.pow(2,t.readInt8()),e.metronome=t.readInt8(),e.thirtyseconds=t.readInt8(),e;case 89:if(e.subtype="keySignature",2!=a)throw"Expected length for keySignature event is 2, got "+a;return e.key=t.readInt8(!0),e.scale=t.readInt8(),e;case 127:return e.subtype="sequencerSpecific",e.data=t.read(a),e;default:return e.subtype="unknown",e.data=t.read(a),e}return e.data=t.read(a),e}if(240==r){e.type="sysEx";var a=t.readVarInt();return e.data=t.read(a),e}if(247==r){e.type="dividedSysEx";var a=t.readVarInt();return e.data=t.read(a),e}throw"Unrecognised MIDI event type byte: "+r}var s;0==(128&r)?(s=r,r=n):(s=t.readInt8(),n=r);var u=r>>4;switch(e.channel=15&r,e.type="channel",u){case 8:return e.subtype="noteOff",e.noteNumber=s,e.velocity=t.readInt8(),e;case 9:return e.noteNumber=s,e.velocity=t.readInt8(),0==e.velocity?e.subtype="noteOff":e.subtype="noteOn",e;case 10:return e.subtype="noteAftertouch",e.noteNumber=s,e.amount=t.readInt8(),e;case 11:return e.subtype="controller",e.controllerType=s,e.value=t.readInt8(),e;case 12:return e.subtype="programChange",e.programNumber=s,e;case 13:return e.subtype="channelAftertouch",e.amount=s,e;case 14:return e.subtype="pitchBend",e.value=s+(t.readInt8()<<7),e;default:throw"Unrecognised MIDI event type: "+u}}(l);h[f].push(p)}}return{header:c,tracks:h}}function r(t){function e(e){var n=t.substr(s,e);return s+=e,n}function n(){var e=(t.charCodeAt(s)<<24)+(t.charCodeAt(s+1)<<16)+(t.charCodeAt(s+2)<<8)+t.charCodeAt(s+3);return s+=4,e}function r(){var e=(t.charCodeAt(s)<<8)+t.charCodeAt(s+1);return s+=2,e}function i(e){var n=t.charCodeAt(s);return e&&n>127&&(n-=256),s+=1,n}function a(){return s>=t.length}function o(){for(var t=0;;){var e=i();if(!(128&e))return t+e;t+=127&e,t<<=7}}var s=0;return{eof:a,read:e,readInt32:n,readInt16:r,readInt8:i,readVarInt:o}}t.exports=function(t){return n(t)}},function(t,e){t.exports=function(t){return t.webpackPolyfill||(t.deprecate=function(){},t.paths=[],t.children||(t.children=[]),Object.defineProperty(t,"loaded",{enumerable:!0,get:function(){return t.l}}),Object.defineProperty(t,"id",{enumerable:!0,get:function(){return t.i}}),t.webpackPolyfill=1),t}}])});
 
-},{}],264:[function(require,module,exports){
+},{}],288:[function(require,module,exports){
 'use strict'
 
 var ops = require('ndarray-ops')
@@ -42296,7 +44642,7 @@ function ndfft(dir, x, y) {
 }
 
 module.exports = ndfft
-},{"./lib/fft-matrix.js":265,"ndarray":269,"ndarray-ops":266,"typedarray-pool":300}],265:[function(require,module,exports){
+},{"./lib/fft-matrix.js":289,"ndarray":293,"ndarray-ops":290,"typedarray-pool":324}],289:[function(require,module,exports){
 var bits = require('bit-twiddle')
 
 function fft(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
@@ -42515,7 +44861,7 @@ function fftBluestein(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
   }
 }
 
-},{"bit-twiddle":249}],266:[function(require,module,exports){
+},{"bit-twiddle":273}],290:[function(require,module,exports){
 "use strict"
 
 var compile = require("cwise-compiler")
@@ -42978,7 +45324,7 @@ exports.equals = compile({
 
 
 
-},{"cwise-compiler":253}],267:[function(require,module,exports){
+},{"cwise-compiler":277}],291:[function(require,module,exports){
 "use strict"
 
 var fft = require("ndarray-fft")
@@ -43082,7 +45428,7 @@ function resample(out, inp, clamp_lo, clamp_hi) {
 }
 
 module.exports = resample
-},{"cwise/lib/wrapper":256,"ndarray-fft":264,"ndarray-ops":266,"ndarray-scratch":268}],268:[function(require,module,exports){
+},{"cwise/lib/wrapper":280,"ndarray-fft":288,"ndarray-ops":290,"ndarray-scratch":292}],292:[function(require,module,exports){
 "use strict"
 
 var ndarray = require("ndarray")
@@ -43190,7 +45536,7 @@ function eye(shape, dtype) {
 }
 exports.eye = eye
 
-},{"ndarray":269,"ndarray-ops":266,"typedarray-pool":300}],269:[function(require,module,exports){
+},{"ndarray":293,"ndarray-ops":290,"typedarray-pool":324}],293:[function(require,module,exports){
 var iota = require("iota-array")
 var isBuffer = require("is-buffer")
 
@@ -43535,7 +45881,7 @@ function wrappedNDArrayCtor(data, shape, stride, offset) {
 
 module.exports = wrappedNDArrayCtor
 
-},{"iota-array":261,"is-buffer":262}],270:[function(require,module,exports){
+},{"iota-array":285,"is-buffer":286}],294:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -43721,9 +46067,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],271:[function(require,module,exports){
+},{}],295:[function(require,module,exports){
 arguments[4][50][0].apply(exports,arguments)
-},{"./src/index-minimal":272,"dup":50}],272:[function(require,module,exports){
+},{"./src/index-minimal":296,"dup":50}],296:[function(require,module,exports){
 "use strict";
 var protobuf = exports;
 
@@ -43761,7 +46107,7 @@ function configure() {
 protobuf.Writer._configure(protobuf.BufferWriter);
 configure();
 
-},{"./reader":273,"./reader_buffer":274,"./roots":275,"./rpc":276,"./util/minimal":279,"./writer":280,"./writer_buffer":281}],273:[function(require,module,exports){
+},{"./reader":297,"./reader_buffer":298,"./roots":299,"./rpc":300,"./util/minimal":303,"./writer":304,"./writer_buffer":305}],297:[function(require,module,exports){
 "use strict";
 module.exports = Reader;
 
@@ -44170,17 +46516,17 @@ Reader._configure = function(BufferReader_) {
     });
 };
 
-},{"./util/minimal":279}],274:[function(require,module,exports){
+},{"./util/minimal":303}],298:[function(require,module,exports){
 arguments[4][53][0].apply(exports,arguments)
-},{"./reader":273,"./util/minimal":279,"dup":53}],275:[function(require,module,exports){
+},{"./reader":297,"./util/minimal":303,"dup":53}],299:[function(require,module,exports){
 arguments[4][54][0].apply(exports,arguments)
-},{"dup":54}],276:[function(require,module,exports){
+},{"dup":54}],300:[function(require,module,exports){
 arguments[4][55][0].apply(exports,arguments)
-},{"./rpc/service":277,"dup":55}],277:[function(require,module,exports){
+},{"./rpc/service":301,"dup":55}],301:[function(require,module,exports){
 arguments[4][56][0].apply(exports,arguments)
-},{"../util/minimal":279,"dup":56}],278:[function(require,module,exports){
+},{"../util/minimal":303,"dup":56}],302:[function(require,module,exports){
 arguments[4][57][0].apply(exports,arguments)
-},{"../util/minimal":279,"dup":57}],279:[function(require,module,exports){
+},{"../util/minimal":303,"dup":57}],303:[function(require,module,exports){
 (function (global){
 "use strict";
 var util = exports;
@@ -44589,11 +46935,11 @@ util._configure = function() {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./longbits":278,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],280:[function(require,module,exports){
+},{"./longbits":302,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],304:[function(require,module,exports){
 arguments[4][59][0].apply(exports,arguments)
-},{"./util/minimal":279,"dup":59}],281:[function(require,module,exports){
+},{"./util/minimal":303,"dup":59}],305:[function(require,module,exports){
 arguments[4][60][0].apply(exports,arguments)
-},{"./util/minimal":279,"./writer":280,"dup":60}],282:[function(require,module,exports){
+},{"./util/minimal":303,"./writer":304,"dup":60}],306:[function(require,module,exports){
 // A library of seedable RNGs implemented in Javascript.
 //
 // Usage:
@@ -44655,7 +47001,7 @@ sr.tychei = tychei;
 
 module.exports = sr;
 
-},{"./lib/alea":283,"./lib/tychei":284,"./lib/xor128":285,"./lib/xor4096":286,"./lib/xorshift7":287,"./lib/xorwow":288,"./seedrandom":289}],283:[function(require,module,exports){
+},{"./lib/alea":307,"./lib/tychei":308,"./lib/xor128":309,"./lib/xor4096":310,"./lib/xorshift7":311,"./lib/xorwow":312,"./seedrandom":313}],307:[function(require,module,exports){
 // A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
 // http://baagoe.com/en/RandomMusings/javascript/
 // https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
@@ -44771,7 +47117,7 @@ if (module && module.exports) {
 
 
 
-},{}],284:[function(require,module,exports){
+},{}],308:[function(require,module,exports){
 // A Javascript implementaion of the "Tyche-i" prng algorithm by
 // Samuel Neves and Filipe Araujo.
 // See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
@@ -44876,7 +47222,7 @@ if (module && module.exports) {
 
 
 
-},{}],285:[function(require,module,exports){
+},{}],309:[function(require,module,exports){
 // A Javascript implementaion of the "xor128" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44959,7 +47305,7 @@ if (module && module.exports) {
 
 
 
-},{}],286:[function(require,module,exports){
+},{}],310:[function(require,module,exports){
 // A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
 //
 // This fast non-cryptographic random number generator is designed for
@@ -45107,7 +47453,7 @@ if (module && module.exports) {
   (typeof define) == 'function' && define   // present with an AMD loader
 );
 
-},{}],287:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 // A Javascript implementaion of the "xorshift7" algorithm by
 // François Panneton and Pierre L'ecuyer:
 // "On the Xorgshift Random Number Generators"
@@ -45206,7 +47552,7 @@ if (module && module.exports) {
 );
 
 
-},{}],288:[function(require,module,exports){
+},{}],312:[function(require,module,exports){
 // A Javascript implementaion of the "xorwow" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -45294,7 +47640,7 @@ if (module && module.exports) {
 
 
 
-},{}],289:[function(require,module,exports){
+},{}],313:[function(require,module,exports){
 /*
 Copyright 2014 David Bau.
 
@@ -45543,7 +47889,7 @@ if ((typeof module) == 'object' && module.exports) {
   Math    // math: package containing random, pow, and seedrandom
 );
 
-},{"crypto":250}],290:[function(require,module,exports){
+},{"crypto":274}],314:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45699,7 +48045,7 @@ exports.unique = unique;
 exports.shuffle = shuffle;
 exports.permutations = permutations;
 
-},{"tonal-note":295}],291:[function(require,module,exports){
+},{"tonal-note":319}],315:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45891,7 +48237,7 @@ exports.supersets = supersets;
 exports.subsets = subsets;
 exports.tokenize = tokenize$1;
 
-},{"tonal-dictionary":292,"tonal-distance":293,"tonal-note":295,"tonal-pcset":296}],292:[function(require,module,exports){
+},{"tonal-dictionary":316,"tonal-distance":317,"tonal-note":319,"tonal-pcset":320}],316:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46263,7 +48609,7 @@ exports.scale = scale;
 exports.chord = chord;
 exports.pcset = pcset;
 
-},{"tonal-pcset":296}],293:[function(require,module,exports){
+},{"tonal-pcset":320}],317:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46542,7 +48888,7 @@ exports.subtract = subtract;
 exports.interval = interval;
 exports.semitones = semitones;
 
-},{"tonal-interval":294,"tonal-note":295}],294:[function(require,module,exports){
+},{"tonal-interval":318,"tonal-note":319}],318:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46883,7 +49229,7 @@ exports.simplify = simplify;
 exports.invert = invert;
 exports.fromSemitones = fromSemitones;
 
-},{}],295:[function(require,module,exports){
+},{}],319:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47298,7 +49644,7 @@ exports.fromMidi = fromMidi;
 exports.simplify = simplify;
 exports.enharmonic = enharmonic;
 
-},{}],296:[function(require,module,exports){
+},{}],320:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47527,7 +49873,7 @@ exports.isSupersetOf = isSupersetOf;
 exports.includes = includes;
 exports.filter = filter;
 
-},{"tonal-array":290,"tonal-interval":294,"tonal-note":295}],297:[function(require,module,exports){
+},{"tonal-array":314,"tonal-interval":318,"tonal-note":319}],321:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47764,7 +50110,7 @@ exports.toScale = toScale;
 exports.supersets = supersets;
 exports.subsets = subsets;
 
-},{"tonal-array":290,"tonal-dictionary":292,"tonal-distance":293,"tonal-note":295,"tonal-pcset":296}],298:[function(require,module,exports){
+},{"tonal-array":314,"tonal-dictionary":316,"tonal-distance":317,"tonal-note":319,"tonal-pcset":320}],322:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47902,7 +50248,7 @@ exports.freq = freq$1;
 exports.chord = chord$1;
 exports.scale = scale$1;
 
-},{"tonal-array":290,"tonal-chord":291,"tonal-dictionary":292,"tonal-distance":293,"tonal-interval":294,"tonal-note":295,"tonal-pcset":296,"tonal-scale":297}],299:[function(require,module,exports){
+},{"tonal-array":314,"tonal-chord":315,"tonal-dictionary":316,"tonal-distance":317,"tonal-interval":318,"tonal-note":319,"tonal-pcset":320,"tonal-scale":321}],323:[function(require,module,exports){
 (function(root, factory){
 
 	//UMD
@@ -72285,7 +74631,7 @@ exports.scale = scale$1;
 	
 	return Tone;
 }));
-},{}],300:[function(require,module,exports){
+},{}],324:[function(require,module,exports){
 (function (global,Buffer){
 'use strict'
 
@@ -72502,7 +74848,7 @@ exports.clearCache = function clearCache() {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"bit-twiddle":249,"buffer":251,"dup":257}],301:[function(require,module,exports){
+},{"bit-twiddle":273,"buffer":275,"dup":281}],325:[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -72561,7 +74907,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],302:[function(require,module,exports){
+},{}],326:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72609,7 +74955,7 @@ var BinaryCounter = (function (_super) {
 }(AuxiliaryInput));
 exports.BinaryCounter = BinaryCounter;
 
-},{"@tensorflow/tfjs-core":68}],303:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],327:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72803,7 +75149,7 @@ var PitchChordEncoder = (function (_super) {
 }(ChordEncoder));
 exports.PitchChordEncoder = PitchChordEncoder;
 
-},{"./constants":304,"@tensorflow/tfjs-core":68,"tonal":298}],304:[function(require,module,exports){
+},{"./constants":328,"@tensorflow/tfjs-core":68,"tonal":322}],328:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 null;
@@ -72831,7 +75177,7 @@ exports.HI_CLICK_PITCH = 90;
 exports.LO_CLICK_CLASS = 9;
 exports.HI_CLICK_CLASS = 10;
 
-},{}],305:[function(require,module,exports){
+},{}],329:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73403,7 +75749,7 @@ var MultitrackConverter = (function (_super) {
 }(DataConverter));
 exports.MultitrackConverter = MultitrackConverter;
 
-},{"../protobuf/index":321,"./constants":304,"./performance":309,"./sequences":312,"@tensorflow/tfjs-core":68}],306:[function(require,module,exports){
+},{"../protobuf/index":345,"./constants":328,"./performance":333,"./sequences":336,"@tensorflow/tfjs-core":68}],330:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -73428,7 +75774,7 @@ __export(require("./player"));
 __export(require("./recorder"));
 __export(require("./visualizer"));
 
-},{"./aux_inputs":302,"./chords":303,"./constants":304,"./data":305,"./logging":307,"./midi_io":308,"./performance":309,"./player":310,"./recorder":311,"./sequences":312,"./visualizer":314}],307:[function(require,module,exports){
+},{"./aux_inputs":326,"./chords":327,"./constants":328,"./data":329,"./logging":331,"./midi_io":332,"./performance":333,"./player":334,"./recorder":335,"./sequences":336,"./visualizer":338}],331:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Level;
@@ -73459,7 +75805,7 @@ function logWithDuration(msg, startTime, prefix, level) {
 }
 exports.logWithDuration = logWithDuration;
 
-},{}],308:[function(require,module,exports){
+},{}],332:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73605,7 +75951,7 @@ function sequenceProtoToMidi(ns) {
 }
 exports.sequenceProtoToMidi = sequenceProtoToMidi;
 
-},{"../protobuf":321,"./constants":304,"./sequences":312,"midiconvert":263}],309:[function(require,module,exports){
+},{"../protobuf":345,"./constants":328,"./sequences":336,"midiconvert":287}],333:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var index_1 = require("../protobuf/index");
@@ -73808,7 +76154,7 @@ var Performance = (function () {
 }());
 exports.Performance = Performance;
 
-},{"../protobuf/index":321,"./constants":304,"./sequences":312}],310:[function(require,module,exports){
+},{"../protobuf/index":345,"./constants":328,"./sequences":336}],334:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74220,7 +76566,7 @@ var PlayerWithClick = (function (_super) {
 }(Player));
 exports.PlayerWithClick = PlayerWithClick;
 
-},{".":306,"./constants":304,"./data":305,"./soundfont":313,"tone":299}],311:[function(require,module,exports){
+},{".":330,"./constants":328,"./data":329,"./soundfont":337,"tone":323}],335:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74446,7 +76792,7 @@ var Recorder = (function () {
 }());
 exports.Recorder = Recorder;
 
-},{"../protobuf":321,"./constants":304,"tone":299}],312:[function(require,module,exports){
+},{"../protobuf":345,"./constants":328,"tone":323}],336:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74717,7 +77063,7 @@ function mergeInstruments(ns) {
 }
 exports.mergeInstruments = mergeInstruments;
 
-},{"../protobuf/index":321,"./constants":304}],313:[function(require,module,exports){
+},{"../protobuf/index":345,"./constants":328}],337:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74975,7 +77321,7 @@ var SoundFont = (function () {
 }());
 exports.SoundFont = SoundFont;
 
-},{"./constants":304,"tone":299}],314:[function(require,module,exports){
+},{"./constants":328,"tone":323}],338:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require(".");
@@ -75067,7 +77413,7 @@ var Visualizer = (function () {
 }());
 exports.Visualizer = Visualizer;
 
-},{".":306,"./constants":304}],315:[function(require,module,exports){
+},{".":330,"./constants":328}],339:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -75081,7 +77427,7 @@ __export(require("./music_vae"));
 __export(require("./protobuf"));
 __export(require("./transcription"));
 
-},{"./core":306,"./music_rnn":317,"./music_vae":319,"./protobuf":321,"./transcription":325,"@tensorflow/tfjs":246}],316:[function(require,module,exports){
+},{"./core":330,"./music_rnn":341,"./music_vae":343,"./protobuf":345,"./transcription":349,"@tensorflow/tfjs":270}],340:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tf = require("@tensorflow/tfjs-core");
@@ -75145,13 +77491,13 @@ var AttentionWrapper = (function () {
 }());
 exports.AttentionWrapper = AttentionWrapper;
 
-},{"@tensorflow/tfjs-core":68}],317:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],341:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.MusicRNN = model_1.MusicRNN;
 
-},{"./model":318}],318:[function(require,module,exports){
+},{"./model":342}],342:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -75450,7 +77796,7 @@ var MusicRNN = (function () {
 }());
 exports.MusicRNN = MusicRNN;
 
-},{"../core/aux_inputs":302,"../core/chords":303,"../core/data":305,"../core/logging":307,"../core/sequences":312,"./attention":316,"@tensorflow/tfjs-core":68}],319:[function(require,module,exports){
+},{"../core/aux_inputs":326,"../core/chords":327,"../core/data":329,"../core/logging":331,"../core/sequences":336,"./attention":340,"@tensorflow/tfjs-core":68}],343:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
@@ -75458,7 +77804,7 @@ exports.Decoder = model_1.Decoder;
 exports.Encoder = model_1.Encoder;
 exports.MusicVAE = model_1.MusicVAE;
 
-},{"./model":320}],320:[function(require,module,exports){
+},{"./model":344}],344:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -76202,14 +78548,14 @@ var MusicVAE = (function () {
 }());
 exports.MusicVAE = MusicVAE;
 
-},{"../core/chords":303,"../core/constants":304,"../core/data":305,"../core/logging":307,"@tensorflow/tfjs-core":68}],321:[function(require,module,exports){
+},{"../core/chords":327,"../core/constants":328,"../core/data":329,"../core/logging":331,"@tensorflow/tfjs-core":68}],345:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var proto_1 = require("./proto");
 var NoteSequence = proto_1.tensorflow.magenta.NoteSequence;
 exports.NoteSequence = NoteSequence;
 
-},{"./proto":322}],322:[function(require,module,exports){
+},{"./proto":346}],346:[function(require,module,exports){
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
@@ -81920,7 +84266,7 @@ $root.tensorflow = (function() {
 
 module.exports = $root;
 
-},{"protobufjs/minimal":271}],323:[function(require,module,exports){
+},{"protobufjs/minimal":295}],347:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82299,7 +84645,7 @@ function max(arr) {
     return arr.reduce(function (a, b) { return Math.max(a, b); });
 }
 
-},{"../core/logging":307,"./constants":324,"fft.js":258,"ndarray":269,"ndarray-resample":267}],324:[function(require,module,exports){
+},{"../core/logging":331,"./constants":348,"fft.js":282,"ndarray":293,"ndarray-resample":291}],348:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SAMPLE_RATE = 16000;
@@ -82310,13 +84656,13 @@ exports.MIN_MIDI_PITCH = 21;
 exports.MAX_MIDI_PITCH = 108;
 exports.MIDI_PITCHES = exports.MAX_MIDI_PITCH - exports.MIN_MIDI_PITCH + 1;
 
-},{}],325:[function(require,module,exports){
+},{}],349:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.OnsetsAndFrames = model_1.OnsetsAndFrames;
 
-},{"./model":326}],326:[function(require,module,exports){
+},{"./model":350}],350:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82682,7 +85028,7 @@ var Lstm = (function () {
     return Lstm;
 }());
 
-},{"../core/logging":307,"./audio_utils":323,"./constants":324,"./transcription_utils":327,"@tensorflow/tfjs":246}],327:[function(require,module,exports){
+},{"../core/logging":331,"./audio_utils":347,"./constants":348,"./transcription_utils":351,"@tensorflow/tfjs":270}],351:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82852,4 +85198,4 @@ function pianorollToNoteSequence(frameProbs, onsetProbs, velocityValues, onsetTh
 }
 exports.pianorollToNoteSequence = pianorollToNoteSequence;
 
-},{"../protobuf":321,"./constants":324,"@tensorflow/tfjs":246}]},{},[2]);
+},{"../protobuf":345,"./constants":348,"@tensorflow/tfjs":270}]},{},[2]);

--- a/docs/music/demos/player_bundle.js
+++ b/docs/music/demos/player_bundle.js
@@ -418,7 +418,7 @@ function notesMatch(aNotes, bNotes) {
 }
 exports.notesMatch = notesMatch;
 
-},{"../src/index":314,"file-saver":258}],2:[function(require,module,exports){
+},{"../src/index":338,"file-saver":282}],2:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var mm = require("../src/index");
@@ -468,7 +468,7 @@ catch (err) {
     console.error(err);
 }
 
-},{"../src/index":314,"./common":1}],3:[function(require,module,exports){
+},{"../src/index":338,"./common":1}],3:[function(require,module,exports){
 "use strict";
 module.exports = asPromise;
 
@@ -3218,7 +3218,7 @@ var FrozenModel = (function () {
         });
     };
     FrozenModel.prototype.predict = function (inputs, config) {
-        return this.execute(inputs, this.outputNodes);
+        return this.execute_(inputs, true, this.outputNodes);
     };
     FrozenModel.prototype.constructTensorMap = function (inputs) {
         var inputArray = inputs instanceof tfc.Tensor ? [inputs] : inputs;
@@ -3233,6 +3233,10 @@ var FrozenModel = (function () {
         }, {});
     };
     FrozenModel.prototype.execute = function (inputs, outputs) {
+        return this.execute_(inputs, false, outputs);
+    };
+    FrozenModel.prototype.execute_ = function (inputs, strictInputCheck, outputs) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         outputs = outputs || this.outputNodes;
         if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
             inputs = this.constructTensorMap(inputs);
@@ -3241,7 +3245,7 @@ var FrozenModel = (function () {
             throw new Error('The model contains control flow or dynamic shape ops, ' +
                 'please use executeAsync method');
         }
-        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), outputs);
+        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
         var keys = Object.keys(result);
         return (Array.isArray(outputs) && outputs.length > 1) ?
             outputs.map(function (node) { return result[node]; }) :
@@ -3355,8 +3359,9 @@ var execution_context_1 = require("./execution_context");
 var GraphExecutor = (function () {
     function GraphExecutor(graph) {
         this.graph = graph;
-        this.compiledOrder = [];
+        this.compiledMap = new Map();
         this._weightMap = {};
+        this.SEPERATOR = ',';
         this.placeholders = graph.placeholders;
         this._outputs = graph.outputs;
         this.compile();
@@ -3431,16 +3436,23 @@ var GraphExecutor = (function () {
         enumerable: true,
         configurable: true
     });
-    GraphExecutor.prototype.compile = function () {
+    GraphExecutor.prototype.compile = function (startNodes) {
         if (this.graph.withControlFlow || this.graph.withDynamicShape) {
             return;
         }
-        var stack = this.graph.inputs.slice();
+        var compiledOrder = [];
+        var inputs = startNodes || this.graph.placeholders;
+        var sortedNodeNames = inputs.map(function (node) { return node.name; }).sort();
+        var nameKey = sortedNodeNames.join(this.SEPERATOR);
+        if (this.compiledMap.get(nameKey)) {
+            return;
+        }
+        var stack = inputs.concat(this.graph.weights);
         var visited = {};
         while (stack.length > 0) {
             var node = stack.pop();
             visited[node.name] = true;
-            this.compiledOrder.push(node);
+            compiledOrder.push(node);
             node.children.forEach(function (childNode) {
                 if (!visited[childNode.name] && childNode.inputNames.every(function (name) {
                     var nodeName = utils_1.getNodeNameAndIndex(name)[0];
@@ -3450,19 +3462,33 @@ var GraphExecutor = (function () {
                 }
             });
         }
+        this.compiledMap.set(nameKey, compiledOrder);
     };
-    GraphExecutor.prototype.execute = function (inputs, outputs) {
+    GraphExecutor.prototype.execute = function (inputs, strictInputCheck, outputs) {
         var _this = this;
-        this.checkInput(inputs);
-        this.checkInputShapeAndType(inputs);
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
+        var names = Object.keys(inputs).sort();
+        this.checkInput(inputs, strictInputCheck);
+        this.checkInputShapeAndType(inputs, strictInputCheck);
+        this.compile(names.map(function (name) { return _this.graph.nodes[name]; }));
+        var outputNames = this.calculateOutputs(outputs);
+        this.checkOutput(this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
         var tensorArrayMap = {};
         var result = tfjs_core_1.tidy(function () {
             var context = new execution_context_1.ExecutionContext(_this._weightMap, tensorArrayMap);
-            var tensors = _this.compiledOrder.reduce(function (map, node) {
-                map[node.name] = operation_executor_1.executeOp(node, map, context);
-                return map;
-            }, __assign({}, _this.weightMap, inputs));
-            return _this.findOutputs(tensors, context, outputs);
+            var tensorMap = __assign({}, _this.weightMap, inputs);
+            var compiledNodes = _this.compiledMap.get(names.join(_this.SEPERATOR));
+            for (var i = 0; i < compiledNodes.length; i++) {
+                var node = compiledNodes[i];
+                if (!tensorMap[node.name]) {
+                    tensorMap[node.name] =
+                        operation_executor_1.executeOp(node, tensorMap, context);
+                }
+                if (outputNames.every(function (name) { return !!tensorMap[name]; })) {
+                    break;
+                }
+            }
+            return _this.findOutputs(tensorMap, context, outputNames);
         });
         return result;
     };
@@ -3473,8 +3499,8 @@ var GraphExecutor = (function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        this.checkInput(inputs);
-                        this.checkInputShapeAndType(inputs);
+                        this.checkInput(inputs, false);
+                        this.checkInputShapeAndType(inputs, false);
                         tensorArrayMap = {};
                         context = new execution_context_1.ExecutionContext(this._weightMap, tensorArrayMap);
                         return [4, this.executeWithControlFlow(inputs, context)];
@@ -3501,11 +3527,14 @@ var GraphExecutor = (function () {
     };
     GraphExecutor.prototype.executeWithControlFlow = function (inputs, context) {
         return __awaiter(this, void 0, void 0, function () {
-            var stack, tensorMap, added, promises;
+            var _this = this;
+            var names, inputNodes, stack, tensorMap, added, promises;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        stack = this.graph.inputs.map(function (node) {
+                        names = Object.keys(inputs);
+                        inputNodes = names.map(function (name) { return _this.graph.nodes[name]; });
+                        stack = inputNodes.concat(this.graph.weights).map(function (node) {
                             return { node: node, contexts: context.currentContext };
                         });
                         tensorMap = __assign({}, this.weightMap, inputs);
@@ -3513,7 +3542,7 @@ var GraphExecutor = (function () {
                         _a.label = 1;
                     case 1:
                         if (!(stack.length > 0)) return [3, 3];
-                        promises = this.processStack(stack, context, tensorMap, added);
+                        promises = this.processStack(inputNodes, stack, context, tensorMap, added);
                         return [4, Promise.all(promises)];
                     case 2:
                         _a.sent();
@@ -3523,7 +3552,7 @@ var GraphExecutor = (function () {
             });
         });
     };
-    GraphExecutor.prototype.processStack = function (stack, context, tensorMap, added) {
+    GraphExecutor.prototype.processStack = function (inputNodes, stack, context, tensorMap, added) {
         var _this = this;
         var promises = [];
         var _loop_1 = function () {
@@ -3534,21 +3563,26 @@ var GraphExecutor = (function () {
                 utils_1.getParamValue('isConstant', item.node, tensorMap, context)) {
                 nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
             }
-            var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
-            if (!nodeName) {
-                nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
-            }
-            var currentContext = context.currentContext;
-            if (tensors instanceof Promise) {
-                promises.push(tensors.then(function (t) {
-                    tensorMap[nodeName] = t;
-                    context.currentContext = currentContext;
-                    _this.processChildNodes(item.node, stack, context, tensorMap, added);
-                    return t;
-                }));
+            if (inputNodes.indexOf(item.node) === -1) {
+                var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
+                if (!nodeName) {
+                    nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
+                }
+                var currentContext_1 = context.currentContext;
+                if (tensors instanceof Promise) {
+                    promises.push(tensors.then(function (t) {
+                        tensorMap[nodeName] = t;
+                        context.currentContext = currentContext_1;
+                        _this.processChildNodes(item.node, stack, context, tensorMap, added);
+                        return t;
+                    }));
+                }
+                else {
+                    tensorMap[nodeName] = tensors;
+                    this_1.processChildNodes(item.node, stack, context, tensorMap, added);
+                }
             }
             else {
-                tensorMap[nodeName] = tensors;
                 this_1.processChildNodes(item.node, stack, context, tensorMap, added);
             }
         };
@@ -3579,11 +3613,14 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+    GraphExecutor.prototype.calculateOutputs = function (outputs) {
         if (outputs && !(outputs instanceof Array)) {
             outputs = [outputs];
         }
-        var requestedOutputs = (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+        return (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+    };
+    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+        var requestedOutputs = this.calculateOutputs(outputs);
         return requestedOutputs.reduce(function (map, name) {
             map[name] = utils_1.getTensor(name, tensorMap, context);
             return map;
@@ -3594,9 +3631,14 @@ var GraphExecutor = (function () {
         Object.keys(this.weightMap)
             .forEach(function (key) { return _this.weightMap[key].forEach(function (tensor) { return tensor.dispose(); }); });
     };
-    GraphExecutor.prototype.checkInputShapeAndType = function (inputs) {
+    GraphExecutor.prototype.checkInputShapeAndType = function (inputs, strictInputCheck) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         this.placeholders.forEach(function (node) {
-            var input = inputs[node.name][0];
+            var inputTensors = inputs[node.name];
+            if (!strictInputCheck && !inputTensors) {
+                return;
+            }
+            var input = inputTensors[0];
             if (node.params['shape'] && node.params['shape'].value) {
                 var shape_1 = node.params['shape'].value;
                 var match = shape_1.length === input.shape.length &&
@@ -3608,8 +3650,9 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.checkInput = function (inputs) {
+    GraphExecutor.prototype.checkInput = function (inputs, strictInputCheck) {
         var _this = this;
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         var inputKeys = Object.keys(inputs);
         var missing = [];
         var extra = [];
@@ -3621,14 +3664,31 @@ var GraphExecutor = (function () {
             if (_this.inputNodes.indexOf(name) === -1)
                 extra.push(name);
         });
-        if (missing.length > 0) {
+        var notInGraph = extra.filter(function (name) { return !_this.graph.nodes[name]; });
+        if (missing.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has the keys " +
                 ("[" + inputKeys + "], but is missing the required keys: [" + missing + "]."));
         }
-        if (extra.length > 0) {
+        if (extra.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has " +
                 ("unused keys: [" + extra + "]. Please provide only the following keys: ") +
                 ("[" + this.inputNodes + "]."));
+        }
+        if (notInGraph.length > 0) {
+            throw new Error("The dict provided in model.execute(dict) has " +
+                ("keys: [" + notInGraph + "] not part of model graph."));
+        }
+    };
+    GraphExecutor.prototype.checkOutput = function (compiledNodes, outputs) {
+        var compiledNodeNames = compiledNodes.map(function (node) { return node.name; });
+        var extra = [];
+        outputs.forEach(function (name) {
+            if (compiledNodeNames.indexOf(name) === -1)
+                extra.push(name);
+        });
+        if (extra.length > 0) {
+            throw new Error("The following outputs are not be generated by the execution: " +
+                ("[" + extra + "]."));
         }
     };
     return GraphExecutor;
@@ -4344,6 +4404,9 @@ exports.executeOp = function (node, tensorMap, context) {
             return [snapshot.clone()];
         case 'shape':
             return [tfc.tensor1d(utils_1.getParamValue('x', node, tensorMap, context).shape, 'int32')];
+        case 'shapeN':
+            return utils_1.getParamValue('x', node, tensorMap, context)
+                .map(function (t) { return tfc.tensor1d(t.shape); });
         case 'size':
             return [tfc.scalar(utils_1.getParamValue('x', node, tensorMap, context).size, 'int32')];
         case 'rank':
@@ -4386,6 +4449,15 @@ exports.executeOp = function (node, tensorMap, context) {
             var size = utils_1.getParamValue('size', node, tensorMap, context);
             var alignCorners = utils_1.getParamValue('alignCorners', node, tensorMap, context);
             return [tfc.image.resizeNearestNeighbor(images, [size[0], size[1]], alignCorners)];
+        }
+        case 'cropAndResize': {
+            var image = utils_1.getParamValue('image', node, tensorMap, context);
+            var boxes = utils_1.getParamValue('boxes', node, tensorMap, context);
+            var boxInd = utils_1.getParamValue('boxInd', node, tensorMap, context);
+            var cropSize = utils_1.getParamValue('cropSize', node, tensorMap, context);
+            var method = utils_1.getParamValue('method', node, tensorMap, context);
+            var extrapolationValue = utils_1.getParamValue('extrapolationValue', node, tensorMap, context);
+            return [tfc.image.cropAndResize(image, boxes, boxInd, cropSize, method, extrapolationValue)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4519,6 +4591,11 @@ exports.executeOp = function (node, tensorMap, context) {
         case 'argMin': {
             var axis = utils_1.getParamValue('axis', node, tensorMap, context);
             return [tfc.argMin(utils_1.getParamValue('x', node, tensorMap, context), axis)];
+        }
+        case 'prod': {
+            var axis = utils_1.getParamValue('axis', node, tensorMap, context);
+            var keepDims = utils_1.getParamValue('keepDims', node, tensorMap, context);
+            return [tfc.prod(utils_1.getParamValue('x', node, tensorMap, context), axis, keepDims)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4875,6 +4952,20 @@ exports.json = [
     },
     {
         'tfOpName': 'Mod',
+        'dlOpName': 'mod',
+        'category': 'arithmetic',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'FloorMod',
         'dlOpName': 'mod',
         'category': 'arithmetic',
         'params': [
@@ -6034,6 +6125,17 @@ exports.json = [
         'params': [{ 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' }]
     },
     {
+        'tfOpName': 'ShapeN',
+        'dlOpName': 'shapeN',
+        'category': 'graph',
+        'params': [{
+                'tfInputIndex': 0,
+                'tfInputParamLength': 0,
+                'dlParamName': 'x',
+                'type': 'tensors'
+            }]
+    },
+    {
         'tfOpName': 'Print',
         'dlOpName': 'print',
         'category': 'graph',
@@ -6115,6 +6217,22 @@ exports.json = [
                 'dlParamName': 'dtype',
                 'type': 'dtype',
                 'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'CropAndResize',
+        'dlOpName': 'cropAndResize',
+        'category': 'image',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'image', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'boxes', 'type': 'tensor' },
+            { 'tfInputIndex': 2, 'dlParamName': 'boxInd', 'type': 'tensor' },
+            { 'tfInputIndex': 3, 'dlParamName': 'cropSize', 'type': 'number[]' },
+            { 'tfParamName': 'method', 'dlParamName': 'method', 'type': 'string' }, {
+                'tfParamName': 'extrapolation_value',
+                'dlParamName': 'extrapolationValue',
+                'type': 'number'
             }
         ]
     }
@@ -6284,6 +6402,32 @@ exports.json = [
             },
             {
                 'tfParamName': 'transpose_b',
+                'dlParamName': 'transposeB',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'BatchMatMul',
+        'dlOpName': 'matMul',
+        'category': 'matrices',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'adj_x',
+                'dlParamName': 'transposeA',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'adj_y',
                 'dlParamName': 'transposeB',
                 'type': 'bool',
                 'defaultValue': false
@@ -6481,6 +6625,19 @@ exports.json = [
         'params': [
             { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
             { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number' }
+        ]
+    },
+    {
+        'tfOpName': 'Prod',
+        'dlOpName': 'prod',
+        'category': 'reduction',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number[]' }, {
+                'tfParamName': 'keep_dims',
+                'dlParamName': 'keepDims',
+                'type': 'bool'
+            }
         ]
     }
 ];
@@ -6689,6 +6846,21 @@ exports.json = [
                 'dlParamName': 'numOrSizeSplits',
                 'type': 'number',
                 'defaultValue': 1
+            }
+        ]
+    },
+    {
+        'tfOpName': 'SplitV',
+        'dlOpName': 'split',
+        'category': 'slice_join',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'numOrSizeSplits', 'type': 'number[]' },
+            {
+                'tfInputIndex': 2,
+                'dlParamName': 'axis',
+                'type': 'number',
+                'defaultValue': 0
             }
         ]
     }
@@ -6907,6 +7079,7 @@ var OperationMapper = (function () {
         var withControlFlow = false;
         var withDynamicShape = false;
         var placeholders = [];
+        var weights = [];
         var nodes = tfNodes.reduce(function (map, node) {
             map[node.name] = _this.mapNode(node);
             if (_this.isControlFlow(node))
@@ -6915,6 +7088,8 @@ var OperationMapper = (function () {
                 withDynamicShape = true;
             if (node.op === 'Placeholder')
                 placeholders.push(map[node.name]);
+            if (node.op === 'Const')
+                weights.push(map[node.name]);
             return map;
         }, {});
         var inputs = [];
@@ -6938,6 +7113,7 @@ var OperationMapper = (function () {
             nodes: nodes,
             inputs: inputs,
             outputs: outputs,
+            weights: weights,
             placeholders: placeholders,
             withControlFlow: withControlFlow,
             withDynamicShape: withDynamicShape
@@ -7075,7 +7251,7 @@ exports.OperationMapper = OperationMapper;
 },{"../data/compiled_api":10,"./executors/utils":31,"./op_list/arithmetic":32,"./op_list/basic_math":33,"./op_list/control":34,"./op_list/convolution":35,"./op_list/creation":36,"./op_list/dynamic":37,"./op_list/evaluation":38,"./op_list/graph":39,"./op_list/image":40,"./op_list/logical":41,"./op_list/matrices":42,"./op_list/normalization":43,"./op_list/reduction":44,"./op_list/slice_join":45,"./op_list/transformation":46}],49:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.5.9';
+var version = '0.6.5';
 exports.version = version;
 
 },{}],50:[function(require,module,exports){
@@ -9014,18 +9190,24 @@ var Engine = (function () {
         this.safeMode = safeMode;
         this.debugMode = debugMode;
         this.registeredVariables = {};
-        this.refCounter = new WeakMap();
         this.nextTapeNodeId = 0;
         this.numBytes = 0;
         this.numTensors = 0;
         this.numDataBuffers = 0;
+        this.profiling = false;
         this.gradientScopeCount = 0;
         this.customGradientDepth = 0;
         this.keepTensors = new Set();
+        this.tensorInfo = new WeakMap();
         this.activeScope = { track: [], name: 'default scope' };
         this.scopeStack = [this.activeScope];
         this.profiler = new profiler_1.Profiler(backend);
+        this.activeProfile =
+            { newBytes: 0, newTensors: 0, peakBytes: 0, kernels: [], result: null };
     }
+    Engine.prototype.moveData = function (dataId) {
+        this.write(dataId, this.readSync(dataId));
+    };
     Engine.prototype.tidy = function (nameOrFn, fn, gradMode) {
         var _this = this;
         if (gradMode === void 0) { gradMode = false; }
@@ -9077,6 +9259,8 @@ var Engine = (function () {
             return x;
         };
         var scopeName = this.activeScope.name;
+        var startingBytecount = this.numBytes;
+        var startingNumTensors = this.numTensors;
         this.scopedRun(function () { return _this.customGradientDepth++; }, function () { return _this.customGradientDepth--; }, function () {
             if (!_this.debugMode()) {
                 result = forwardFunc(_this.backend, saveFunc);
@@ -9098,10 +9282,25 @@ var Engine = (function () {
             }
             this.activeTape.push(tapeNode);
         }
+        if (this.profiling) {
+            this.activeProfile.kernels.push({
+                name: scopeName,
+                bytesAdded: this.numBytes - startingBytecount,
+                totalBytesSnapshot: this.numBytes,
+                tensorsAdded: this.numTensors - startingNumTensors,
+                totalTensorsSnapshot: this.numTensors,
+                inputShapes: Object.keys(inputs).map(function (key) { return inputs[key].shape; }),
+                outputShape: Array.isArray(result) ?
+                    result.map(function (item) { return item.shape; }) :
+                    result.shape
+            });
+        }
         return result;
     };
     Engine.prototype.registerTensor = function (a) {
-        var refCount = this.refCounter.has(a.dataId) ? this.refCounter.get(a.dataId) : 0;
+        var refCount = this.tensorInfo.has(a.dataId) ?
+            this.tensorInfo.get(a.dataId).refCount :
+            0;
         this.numTensors++;
         if (refCount === 0) {
             this.numDataBuffers++;
@@ -9109,9 +9308,10 @@ var Engine = (function () {
                 this.numBytes +=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.set(a.dataId, { backend: this.backend, dtype: a.dtype, shape: a.shape, refCount: 0 });
             this.backend.register(a.dataId, a.shape, a.dtype);
         }
-        this.refCounter.set(a.dataId, refCount + 1);
+        this.tensorInfo.get(a.dataId).refCount++;
         if (!(a instanceof tensor_1.Variable)) {
             this.track(a);
         }
@@ -9123,25 +9323,26 @@ var Engine = (function () {
         this.registeredVariables[v.name] = v;
     };
     Engine.prototype.disposeTensor = function (a) {
-        if (!this.refCounter.has(a.dataId)) {
+        if (!this.tensorInfo.has(a.dataId)) {
             return;
         }
         if (this.keepTensors.has(a.id)) {
             this.keepTensors.delete(a.id);
         }
         this.numTensors--;
-        var refCount = this.refCounter.get(a.dataId);
+        var refCount = this.tensorInfo.get(a.dataId).refCount;
         if (refCount <= 1) {
-            this.refCounter.delete(a.dataId);
-            this.backend.disposeData(a.dataId);
+            var info = this.tensorInfo.get(a.dataId);
+            info.backend.disposeData(a.dataId);
             this.numDataBuffers--;
             if (a.dtype !== 'complex64') {
                 this.numBytes -=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.delete(a.dataId);
         }
         else {
-            this.refCounter.set(a.dataId, refCount - 1);
+            this.tensorInfo.get(a.dataId).refCount--;
         }
     };
     Engine.prototype.disposeVariables = function () {
@@ -9157,6 +9358,23 @@ var Engine = (function () {
         info.numDataBuffers = this.numDataBuffers;
         info.numBytes = this.numBytes;
         return info;
+    };
+    Engine.prototype.profile = function (query) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startBytes, startNumTensors;
+            return __generator(this, function (_a) {
+                this.profiling = true;
+                startBytes = this.numBytes;
+                startNumTensors = this.numTensors;
+                this.activeProfile.kernels = [];
+                this.activeProfile.result = query();
+                this.profiling = false;
+                this.activeProfile.peakBytes = Math.max.apply(Math, this.activeProfile.kernels.map(function (d) { return d.totalBytesSnapshot; }));
+                this.activeProfile.newBytes = this.numBytes - startBytes;
+                this.activeProfile.newTensors = this.numTensors - startNumTensors;
+                return [2, this.activeProfile];
+            });
+        });
     };
     Engine.prototype.shouldRecord = function () {
         return this.activeTape != null && this.customGradientDepth === 0;
@@ -9302,13 +9520,21 @@ var Engine = (function () {
         };
     };
     Engine.prototype.write = function (dataId, values) {
+        var info = this.tensorInfo.get(dataId);
+        if (this.backend !== info.backend) {
+            info.backend.disposeData(dataId);
+            info.backend = this.backend;
+            this.backend.register(dataId, info.shape, info.dtype);
+        }
         this.backend.write(dataId, values);
     };
     Engine.prototype.readSync = function (dataId) {
-        return this.backend.readSync(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.readSync(dataId);
     };
     Engine.prototype.read = function (dataId) {
-        return this.backend.read(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.read(dataId);
     };
     Engine.prototype.fromPixels = function (pixels, numChannels) {
         return this.backend.fromPixels(pixels, numChannels);
@@ -9345,7 +9571,7 @@ function ones(shape) {
     return tensor_1.Tensor.make(shape, { values: values });
 }
 
-},{"./profiler":184,"./tape":186,"./tensor":187,"./tensor_util":189,"./util":194}],64:[function(require,module,exports){
+},{"./profiler":204,"./tape":206,"./tensor":207,"./tensor_util":209,"./util":214}],64:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -9361,7 +9587,6 @@ var TEST_EPSILON_FLOAT32 = 1e-3;
 var Environment = (function () {
     function Environment(features) {
         this.features = {};
-        this.engines = {};
         this.registry = {};
         if (features != null) {
             this.features = features;
@@ -9377,10 +9602,11 @@ var Environment = (function () {
         if (!(backendName in exports.ENV.registry)) {
             throw new Error("Backend name '" + backendName + "' not found in registry");
         }
-        exports.ENV.initBackend(backendName, safeMode);
+        exports.ENV.engine.backend = exports.ENV.findBackend(backendName);
+        exports.ENV.backendName = backendName;
     };
     Environment.getBackend = function () {
-        exports.ENV.initDefaultBackend();
+        exports.ENV.initEngine();
         return exports.ENV.backendName;
     };
     Environment.disposeVariables = function () {
@@ -9388,6 +9614,9 @@ var Environment = (function () {
     };
     Environment.memory = function () {
         return exports.ENV.engine.memory();
+    };
+    Environment.profile = function (f) {
+        return exports.ENV.engine.profile(f);
     };
     Environment.tidy = function (nameOrFn, fn, gradMode) {
         if (gradMode === void 0) { gradMode = false; }
@@ -9444,6 +9673,18 @@ var Environment = (function () {
         else if (feature === 'IS_CHROME') {
             return environment_util_1.isChrome();
         }
+        else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+            return false;
+        }
+        else if (feature === 'WEBGL_CONV_IM2COL') {
+            return false;
+        }
+        else if (feature === 'WEBGL_PAGING_ENABLED') {
+            return this.get('IS_BROWSER') && !this.get('PROD');
+        }
+        else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
+            return environment_util_1.getWebGLMaxTextureSize(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+        }
         else if (feature === 'IS_TEST') {
             return false;
         }
@@ -9453,9 +9694,6 @@ var Environment = (function () {
         else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
             var webGLVersion = this.get('WEBGL_VERSION');
             if (webGLVersion === 0) {
-                return 0;
-            }
-            if (webGLVersion > 0) {
                 return 0;
             }
             return environment_util_1.getWebGLDisjointQueryTimerVersion(webGLVersion, this.get('IS_BROWSER'));
@@ -9485,6 +9723,10 @@ var Environment = (function () {
         else if (feature === 'WEBGL_FENCE_API_ENABLED') {
             return environment_util_1.isWebGLFenceEnabled(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
         }
+        else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
+            var useUniforms = this.get('WEBGL_RENDER_FLOAT32_ENABLED');
+            return useUniforms ? 4 : 0;
+        }
         else if (feature === 'TEST_EPSILON') {
             return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
                 TEST_EPSILON_FLOAT16;
@@ -9492,6 +9734,12 @@ var Environment = (function () {
         else if (feature === 'EPSILON') {
             return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
                 EPSILON_FLOAT16;
+        }
+        else if (feature === 'PROD') {
+            return false;
+        }
+        else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
+            return !this.get('PROD');
         }
         throw new Error("Unknown feature " + feature + ".");
     };
@@ -9502,20 +9750,6 @@ var Environment = (function () {
         this.features = environment_util_1.getFeaturesFromURL();
         if (this.globalEngine != null) {
             this.globalEngine = null;
-        }
-    };
-    Environment.prototype.initBackend = function (backendName, safeMode) {
-        var _this = this;
-        if (safeMode === void 0) { safeMode = false; }
-        this.backendName = backendName;
-        if (this.engines[backendName]) {
-            this.globalEngine = this.engines[backendName];
-        }
-        else {
-            var backend = this.findBackend(backendName);
-            this.globalEngine =
-                new engine_1.Engine(backend, safeMode, function () { return _this.get('DEBUG'); });
-            this.engines[backendName] = this.globalEngine;
         }
     };
     Object.defineProperty(Environment.prototype, "backend", {
@@ -9543,6 +9777,7 @@ var Environment = (function () {
         }
         try {
             var backend = factory();
+            backend.setDataMover({ moveData: function (dataId) { return _this.engine.moveData(dataId); } });
             this.registry[name] = { backend: backend, priority: priority };
             return true;
         }
@@ -9558,21 +9793,22 @@ var Environment = (function () {
         }
         this.registry[name].backend.dispose();
         delete this.registry[name];
-        if (name in this.engines) {
-            delete this.engines[name];
-        }
     };
     Object.defineProperty(Environment.prototype, "engine", {
         get: function () {
-            this.initDefaultBackend();
+            this.initEngine();
             return this.globalEngine;
         },
         enumerable: true,
         configurable: true
     });
-    Environment.prototype.initDefaultBackend = function () {
+    Environment.prototype.initEngine = function () {
+        var _this = this;
         if (this.globalEngine == null) {
-            this.initBackend(this.get('BACKEND'), false);
+            this.backendName = this.get('BACKEND');
+            var backend = this.findBackend(this.backendName);
+            this.globalEngine =
+                new engine_1.Engine(backend, false, function () { return _this.get('DEBUG'); });
         }
     };
     return Environment;
@@ -9602,7 +9838,7 @@ function getOrMakeEnvironment() {
 exports.ENV = getOrMakeEnvironment();
 
 }).call(this,require('_process'))
-},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":187,"./tensor_util":189,"_process":269}],65:[function(require,module,exports){
+},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":207,"./tensor_util":209,"_process":293}],65:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Type;
@@ -9612,14 +9848,23 @@ var Type;
     Type[Type["STRING"] = 2] = "STRING";
 })(Type = exports.Type || (exports.Type = {}));
 exports.URL_PROPERTIES = [
-    { name: 'DEBUG', type: Type.BOOLEAN }, { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'DEBUG', type: Type.BOOLEAN },
+    { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN },
+    { name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN },
+    { name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER },
+    { name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN },
     { name: 'WEBGL_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_RENDER_FLOAT32_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DOWNLOAD_FLOAT_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_FENCE_API_ENABLED', type: Type.BOOLEAN },
-    { name: 'BACKEND', type: Type.STRING }, { name: 'EPSILON', type: Type.NUMBER }
+    { name: 'WEBGL_SIZE_UPLOAD_UNIFORM', type: Type.NUMBER },
+    { name: 'BACKEND', type: Type.STRING },
+    { name: 'EPSILON', type: Type.NUMBER },
+    { name: 'PROD', type: Type.BOOLEAN },
+    { name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN },
 ];
 function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     var gl;
@@ -9636,6 +9881,15 @@ function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     return false;
 }
 exports.isWebGLVersionEnabled = isWebGLVersionEnabled;
+var MAX_TEXTURE_SIZE;
+function getWebGLMaxTextureSize(webGLVersion, isBrowser) {
+    if (MAX_TEXTURE_SIZE == null) {
+        var gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+        MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    }
+    return MAX_TEXTURE_SIZE;
+}
+exports.getWebGLMaxTextureSize = getWebGLMaxTextureSize;
 function getWebGLDisjointQueryTimerVersion(webGLVersion, isBrowser) {
     if (webGLVersion === 0) {
         return 0;
@@ -9824,6 +10078,7 @@ exports.tidy = environment_1.Environment.tidy;
 exports.keep = environment_1.Environment.keep;
 exports.dispose = environment_1.Environment.dispose;
 exports.time = environment_1.Environment.time;
+exports.profile = environment_1.Environment.profile;
 
 },{"./environment":64,"./gradients":67}],67:[function(require,module,exports){
 "use strict";
@@ -9938,7 +10193,7 @@ function checkGrads(grads) {
     }
 }
 
-},{"./environment":64,"./tensor":187,"./util":194}],68:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],68:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -9953,6 +10208,8 @@ exports.environment = environment;
 var environment_1 = require("./environment");
 var io = require("./io/io");
 exports.io = io;
+var math = require("./math");
+exports.math = math;
 var serialization = require("./serialization");
 exports.serialization = serialization;
 var tensor_1 = require("./tensor");
@@ -9999,10 +10256,12 @@ exports.setBackend = environment_1.Environment.setBackend;
 exports.getBackend = environment_1.Environment.getBackend;
 exports.disposeVariables = environment_1.Environment.disposeVariables;
 exports.memory = environment_1.Environment.memory;
+var backend_1 = require("./kernels/backend");
+exports.DataStorage = backend_1.DataStorage;
 var ops = require("./ops/ops");
 tensor_1.setOpHandler(ops);
 
-},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend_cpu":80,"./kernels/backend_webgl":82,"./ops/loss_ops":150,"./ops/ops":157,"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer":180,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183,"./serialization":185,"./tensor":187,"./test_util":191,"./train":192,"./types":193,"./util":194,"./version":195,"./webgl":196}],69:[function(require,module,exports){
+},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend":80,"./kernels/backend_cpu":81,"./kernels/backend_webgl":83,"./math":145,"./ops/loss_ops":165,"./ops/ops":172,"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer":200,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203,"./serialization":205,"./tensor":207,"./test_util":211,"./train":212,"./types":213,"./util":214,"./version":215,"./webgl":216}],69:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10494,7 +10753,7 @@ function browserHTTPRequest(path, requestInit) {
 }
 exports.browserHTTPRequest = browserHTTPRequest;
 
-},{"../util":194,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11075,7 +11334,7 @@ function getModelArtifactsInfoForJSON(modelArtifacts) {
 exports.getModelArtifactsInfoForJSON = getModelArtifactsInfoForJSON;
 
 }).call(this,require("buffer").Buffer)
-},{"../ops/tensor_ops":171,"../util":194,"./types":78,"buffer":251}],74:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214,"./types":78,"buffer":275}],74:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11323,7 +11582,7 @@ if (environment_1.ENV.get('IS_BROWSER')) {
     }
 }
 
-},{"../environment":64,"../util":194,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
+},{"../environment":64,"../util":214,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11527,7 +11786,7 @@ function moveModel(sourceURL, destURL) {
 }
 exports.moveModel = moveModel;
 
-},{"../util":194,"./router_registry":77}],76:[function(require,module,exports){
+},{"../util":214,"./router_registry":77}],76:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -11836,7 +12095,34 @@ function loadWeights(manifest, filePathPrefix, weightNames, requestOptions) {
 }
 exports.loadWeights = loadWeights;
 
-},{"../util":194,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var DataStorage = (function () {
+    function DataStorage(dataMover) {
+        this.dataMover = dataMover;
+        this.data = new WeakMap();
+    }
+    DataStorage.prototype.get = function (dataId) {
+        if (!this.data.has(dataId)) {
+            this.dataMover.moveData(dataId);
+        }
+        return this.data.get(dataId);
+    };
+    DataStorage.prototype.set = function (dataId, value) {
+        this.data.set(dataId, value);
+    };
+    DataStorage.prototype.has = function (dataId) {
+        return this.data.has(dataId);
+    };
+    DataStorage.prototype.delete = function (dataId) {
+        return this.data.delete(dataId);
+    };
+    return DataStorage;
+}());
+exports.DataStorage = DataStorage;
+
+},{}],81:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11882,14 +12168,17 @@ var axis_util = require("../ops/axis_util");
 var broadcast_util = require("../ops/broadcast_util");
 var concat_util = require("../ops/concat_util");
 var erf_util = require("../ops/erf_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var ops = require("../ops/ops");
 var ops_1 = require("../ops/ops");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var selu_util = require("../ops/selu_util");
 var slice_util_1 = require("../ops/slice_util");
 var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -11899,12 +12188,14 @@ var where_impl_1 = require("./where_impl");
 var MathBackendCPU = (function () {
     function MathBackendCPU() {
         this.blockSize = 48;
-        this.data = new WeakMap();
         this.firstUse = true;
         if (environment_1.ENV.get('IS_BROWSER')) {
             this.canvas = document.createElement('canvas');
         }
     }
+    MathBackendCPU.prototype.setDataMover = function (dataMover) {
+        this.data = new backend_1.DataStorage(dataMover);
+    };
     MathBackendCPU.prototype.register = function (dataId, shape, dtype) {
         if (this.firstUse) {
             this.firstUse = false;
@@ -11930,7 +12221,6 @@ var MathBackendCPU = (function () {
         if (values == null) {
             throw new Error('MathBackendCPU.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         this.data.get(dataId).values = values;
     };
     MathBackendCPU.prototype.fromPixels = function (pixels, numChannels) {
@@ -11993,7 +12283,6 @@ var MathBackendCPU = (function () {
         });
     };
     MathBackendCPU.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var _a = this.data.get(dataId), dtype = _a.dtype, complexTensors = _a.complexTensors;
         if (dtype === 'complex64') {
             var realValues = complexTensors.real.dataSync();
@@ -12027,13 +12316,6 @@ var MathBackendCPU = (function () {
         return {
             unreliable: true
         };
-    };
-    MathBackendCPU.prototype.throwIfNoData = function (dataId) {
-        if (!this.data.has(dataId)) {
-            throw new Error("CPU backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
     };
     MathBackendCPU.prototype.complex = function (real, imag) {
         var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
@@ -12254,6 +12536,24 @@ var MathBackendCPU = (function () {
                 sum += aVals[offset + j];
             }
             vals[i] = sum;
+        }
+        return result;
+    };
+    MathBackendCPU.prototype.prod = function (x, axes) {
+        this.assertNotComplex(x, 'sum');
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var resultDtype = types_1.upcastType(x.dtype, 'int32');
+        var result = ops.zeros(outShape, resultDtype);
+        var reduceSize = util.sizeFromShape(reduceShape);
+        var vals = result.dataSync();
+        var aVals = x.dataSync();
+        for (var i = 0; i < vals.length; ++i) {
+            var offset = i * reduceSize;
+            var prod = 1;
+            for (var j = 0; j < reduceSize; ++j) {
+                prod *= aVals[offset + j];
+            }
+            vals[i] = prod;
         }
         return result;
     };
@@ -12750,11 +13050,19 @@ var MathBackendCPU = (function () {
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
     MathBackendCPU.prototype.abs = function (x) {
-        this.assertNotComplex(x, 'abs');
         var resultValues = new Float32Array(x.size);
         var values = x.dataSync();
-        for (var i = 0; i < values.length; ++i) {
-            resultValues[i] = Math.abs(values[i]);
+        if (x.dtype === 'complex64') {
+            for (var i = 0; i < x.size; ++i) {
+                var real = values[i * 2];
+                var imag = values[i * 2 + 1];
+                resultValues[i] = Math.sqrt(real * real + imag * imag);
+            }
+        }
+        else {
+            for (var i = 0; i < values.length; ++i) {
+                resultValues[i] = Math.abs(values[i]);
+            }
         }
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
@@ -13313,8 +13621,10 @@ var MathBackendCPU = (function () {
         this.assertNotComplex(x, 'pool');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var y = ops.buffer(convInfo.outShape, 'float32');
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
@@ -13325,16 +13635,16 @@ var MathBackendCPU = (function () {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
                     var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
                         var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var minMaxValue = initialValue;
                         var avgValue = 0;
                         var count = 0;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var pixel = x.get(b, xR, xC, d);
                                 if ((poolType === 'max' && pixel > minMaxValue)) {
                                     minMaxValue = pixel;
@@ -13362,30 +13672,38 @@ var MathBackendCPU = (function () {
         var maxPositions = ops.buffer(convInfo.outShape, 'int32');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
-                    var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMin = xRCorner;
+                    while (xRMin < 0) {
+                        xRMin += dilationHeight;
+                    }
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
-                        var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMin = xCCorner;
+                        while (xCMin < 0) {
+                            xCMin += dilationWidth;
+                        }
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var maxValue = Number.NEGATIVE_INFINITY;
                         var maxPosition = -1;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
                             var wR = xR - xRCorner;
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var wC = xC - xCCorner;
                                 var pixel = x.get(b, xR, xC, d);
                                 if (pixel > maxValue) {
                                     maxValue = pixel;
-                                    maxPosition = wR * filterWidth + wC;
+                                    maxPosition = wR * effectiveFilterWidth + wC;
                                 }
                             }
                         }
@@ -13401,10 +13719,12 @@ var MathBackendCPU = (function () {
         var maxPositions = this.maxPoolPositions(x, convInfo);
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
@@ -13413,21 +13733,21 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
                                     continue;
                                 }
-                                var maxPos = filterHeight * filterWidth - 1 -
-                                    maxPositions.get(b, dyR, dyC, d);
-                                var curPos = wR * filterWidth + wC;
+                                var maxPos = effectiveFilterHeight * effectiveFilterWidth -
+                                    1 - maxPositions.get(b, dyR, dyC, d);
+                                var curPos = wR * effectiveFilterWidth + wC;
                                 var mask = maxPos === curPos ? 1 : 0;
                                 if (mask === 0) {
                                     continue;
@@ -13449,8 +13769,12 @@ var MathBackendCPU = (function () {
         var strideWidth = convInfo.strideWidth;
         var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         var avgMultiplier = 1 / (filterHeight * filterWidth);
         for (var b = 0; b < convInfo.batchSize; ++b) {
@@ -13460,13 +13784,13 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
@@ -13496,7 +13820,8 @@ var MathBackendCPU = (function () {
     MathBackendCPU.prototype.resizeBilinear = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeBilinear');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var result = new Float32Array(util.sizeFromShape([batch, newHeight, newWidth, numChannels]));
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13505,37 +13830,46 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var outputIdx = 0;
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
         for (var b = 0; b < batch; b++) {
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceRowFloor = Math.floor(sourceFracRow);
+                var rowFrac = sourceFracRow - sourceRowFloor;
+                var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
+                var topRowOffset = b * x.strides[0] + sourceRowFloor * x.strides[1];
+                var botRowOffset = b * x.strides[0] + sourceRowCeil * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceColFloor = Math.floor(sourceFracCol);
+                    var colFrac = sourceFracCol - sourceColFloor;
+                    var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
+                    var topLeftOffest = topRowOffset + sourceColFloor * x.strides[2];
+                    var botLeftOffset = botRowOffset + sourceColFloor * x.strides[2];
+                    var topRightOffset = topRowOffset + +sourceColCeil * x.strides[2];
+                    var botRightOffest = botRowOffset + sourceColCeil * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceRowFloor = Math.floor(sourceFracRow);
-                        var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
-                        var sourceColFloor = Math.floor(sourceFracCol);
-                        var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
-                        var topLeft = x.get(b, sourceRowFloor, sourceColFloor, d);
-                        var bottomLeft = x.get(b, sourceRowCeil, sourceColFloor, d);
-                        var topRight = x.get(b, sourceRowFloor, sourceColCeil, d);
-                        var bottomRight = x.get(b, sourceRowCeil, sourceColCeil, d);
-                        var rowFrac = sourceFracRow - sourceRowFloor;
-                        var colFrac = sourceFracCol - sourceColFloor;
+                        var topLeft = xValues[topLeftOffest + d];
+                        var bottomLeft = xValues[botLeftOffset + d];
+                        var topRight = xValues[topRightOffset + d];
+                        var bottomRight = xValues[botRightOffest + d];
                         var top_1 = topLeft + (topRight - topLeft) * colFrac;
                         var bottom = bottomLeft + (bottomRight - bottomLeft) * colFrac;
                         var newValue = top_1 + (bottom - top_1) * rowFrac;
-                        output.set(newValue, b, r, c, d);
+                        result[outputIdx++] = newValue;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(result, [batch, newHeight, newWidth, numChannels]);
     };
     MathBackendCPU.prototype.resizeBilinearBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeBilinearBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13546,11 +13880,16 @@ var MathBackendCPU = (function () {
         ];
         var heightScale = effectiveXSize[0] / effectiveYSize[0];
         var widthScale = effectiveXSize[1] / effectiveYSize[1];
+        var dyValues = dy.dataSync();
+        var offset = 0;
         for (var b = 0; b < batch; b++) {
+            var bOffset = b * x.strides[0];
             for (var r = 0; r < yHeight; r++) {
                 var dxR = r * heightScale;
                 var topDxRIndex = Math.floor(dxR);
                 var bottomDxRIndex = Math.min(Math.ceil(dxR), xHeight - 1);
+                var topDxROffset = bOffset + topDxRIndex * x.strides[1];
+                var bottomDxROffset = bOffset + bottomDxRIndex * x.strides[1];
                 var dxRLerp = dxR - topDxRIndex;
                 var inverseDxRLerp = 1.0 - dxRLerp;
                 for (var c = 0; c < yWidth; c++) {
@@ -13559,30 +13898,33 @@ var MathBackendCPU = (function () {
                     var rightDxCIndex = Math.min(Math.ceil(dxC), xWidth - 1);
                     var dxCLerp = dxC - leftDxCIndex;
                     var inverseDxCLerp = 1.0 - dxCLerp;
+                    var topLeftRCOffset = topDxROffset + leftDxCIndex * x.strides[2];
+                    var topRightRCOffset = topDxROffset + rightDxCIndex * x.strides[2];
+                    var bottomLeftRCOffset = bottomDxROffset + leftDxCIndex * x.strides[2];
+                    var bottomRightRCOffset = bottomDxROffset + rightDxCIndex * x.strides[2];
+                    var inverseDxRLerpTimesInverseDxCLerp = inverseDxRLerp * inverseDxCLerp;
+                    var inverseDxRLerpTimesDxCLerp = inverseDxRLerp * dxCLerp;
+                    var dxRLerpTimesInverseDxCLerp = dxRLerp * inverseDxCLerp;
+                    var dxRLerpTimesDxCLerp = dxRLerp * dxCLerp;
                     for (var d = 0; d < depth; d++) {
-                        var dyVal = dy.get(b, r, c, d);
-                        var topLeft = output.get(b, topDxRIndex, leftDxCIndex, d);
-                        topLeft += dyVal * inverseDxRLerp * inverseDxCLerp;
-                        output.set(topLeft, b, topDxRIndex, leftDxCIndex, d);
-                        var topRight = output.get(b, topDxRIndex, rightDxCIndex, d);
-                        topRight += dyVal * inverseDxRLerp * dxCLerp;
-                        output.set(topRight, b, topDxRIndex, rightDxCIndex, d);
-                        var bottomLeft = output.get(b, bottomDxRIndex, leftDxCIndex, d);
-                        bottomLeft += dyVal * dxRLerp * inverseDxCLerp;
-                        output.set(bottomLeft, b, bottomDxRIndex, leftDxCIndex, d);
-                        var bottomRight = output.get(b, bottomDxRIndex, rightDxCIndex, d);
-                        bottomRight += dyVal * dxRLerp * dxCLerp;
-                        output.set(bottomRight, b, bottomDxRIndex, rightDxCIndex, d);
+                        var dyVal = dyValues[offset++];
+                        output[topLeftRCOffset + d] +=
+                            dyVal * inverseDxRLerpTimesInverseDxCLerp;
+                        output[topRightRCOffset + d] += dyVal * inverseDxRLerpTimesDxCLerp;
+                        output[bottomLeftRCOffset + d] +=
+                            dyVal * dxRLerpTimesInverseDxCLerp;
+                        output[bottomRightRCOffset + d] += dyVal * dxRLerpTimesDxCLerp;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, [batch, xWidth, xHeight, depth], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighbor = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeNearestNeighbor');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var output = new Float32Array(batch * newHeight * newWidth * numChannels);
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13591,29 +13933,36 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
+        var outputOffset = 0;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                    Math.floor(sourceFracRow));
+                var rowOffset = batchOffset + sourceNearestRow * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
+                        Math.floor(sourceFracCol));
+                    var colOffset = rowOffset + sourceNearestCol * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                            Math.floor(sourceFracRow));
-                        var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
-                            Math.floor(sourceFracCol));
-                        var newValue = x.get(b, sourceNearestRow, sourceNearestCol, d);
-                        output.set(newValue, b, r, c, d);
+                        var newVal = xValues[colOffset + d];
+                        output[outputOffset++] = newVal;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(output, [batch, newHeight, newWidth, numChannels], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighborBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeNearestNeighborBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
+        var dyValues = dy.dataSync();
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13629,41 +13978,49 @@ var MathBackendCPU = (function () {
         var winHeight = (Math.ceil(invHeightScale) * 2) + 2;
         var winWidth = (Math.ceil(invWidthScale) * 2) + 2;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < xHeight; r++) {
+                var rowOffset = batchOffset + r * x.strides[1];
+                var startRLerp = Math.floor(r * invHeightScale);
+                var startDyR = Math.floor(startRLerp - (winHeight / 2));
                 for (var c = 0; c < xWidth; c++) {
-                    var startRLerp = Math.floor(r * invHeightScale);
-                    var startDyR = Math.floor(startRLerp - (winHeight / 2));
+                    var colOffset = rowOffset + c * x.strides[2];
                     var startCLerp = Math.floor(c * invWidthScale);
                     var startDyC = Math.floor(startCLerp - (winWidth / 2));
                     for (var d = 0; d < depth; d++) {
                         var accum = 0;
-                        for (var dyROffset = 0; dyROffset < winHeight; dyROffset++) {
-                            var dyR = dyROffset + startDyR;
+                        for (var dyRIndex = 0; dyRIndex < winHeight; dyRIndex++) {
+                            var dyR = dyRIndex + startDyR;
                             if (dyR < 0 || dyR >= yHeight) {
                                 continue;
                             }
-                            for (var dyCOffSet = 0; dyCOffSet < winWidth; dyCOffSet++) {
-                                var dyC = dyCOffSet + startDyC;
+                            var dyROffset = batchOffset + dyR * dy.strides[1];
+                            var sourceFracRow = dyR * heightScale;
+                            var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                                Math.floor(sourceFracRow));
+                            if (r !== sourceNearestRow) {
+                                continue;
+                            }
+                            for (var dyCIndex = 0; dyCIndex < winWidth; dyCIndex++) {
+                                var dyC = dyCIndex + startDyC;
                                 if (dyC < 0 || dyC >= yWidth) {
                                     continue;
                                 }
-                                var sourceFracRow = effectiveXSize[0] * (dyR / effectiveYSize[0]);
-                                var sourceFracCol = effectiveXSize[1] * (dyC / effectiveYSize[1]);
-                                var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                                    Math.floor(sourceFracRow));
+                                var dyCOffset = dyROffset + dyC * dy.strides[2];
+                                var sourceFracCol = dyC * widthScale;
                                 var sourceNearestCol = Math.min(xWidth - 1, alignCorners ? Math.round(sourceFracCol) :
                                     Math.floor(sourceFracCol));
-                                if (r === sourceNearestRow && c === sourceNearestCol) {
-                                    accum += dy.get(b, dyR, dyC, d);
+                                if (c === sourceNearestCol) {
+                                    accum += dyValues[dyCOffset + d];
                                 }
                             }
                         }
-                        output.set(accum, b, r, c, d);
+                        output[colOffset + d] = accum;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, x.shape, x.dtype);
     };
     MathBackendCPU.prototype.batchNormalization = function (x, mean, variance, varianceEpsilon, scale, offset) {
         this.assertNotComplex([x, mean, variance, scale, offset], 'batchNormalization');
@@ -13803,6 +14160,61 @@ var MathBackendCPU = (function () {
         var scoresVals = scores.dataSync();
         return non_max_suppression_impl_1.nonMaxSuppressionImpl(boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
     };
+    MathBackendCPU.prototype.fft = function (input) {
+        if (input.shape[0] !== 1) {
+            throw new Error("tf.fft() on CPU only supports vectors.");
+        }
+        var input1D = input.as1D();
+        var n = input1D.size;
+        if (this.isExponentOf2(n)) {
+            return this.fftRadix2(input1D, n).as2D(input.shape[0], input.shape[1]);
+        }
+        else {
+            var data = input.dataSync();
+            var rawOutput = this.fourierTransformByMatmul(data, n);
+            var output = complex_util.splitRealAndImagArrays(rawOutput);
+            return ops.complex(output.real, output.imag)
+                .as2D(input.shape[0], input.shape[1]);
+        }
+    };
+    MathBackendCPU.prototype.isExponentOf2 = function (size) {
+        return (size & size - 1) === 0;
+    };
+    MathBackendCPU.prototype.fftRadix2 = function (input, size) {
+        if (size === 1) {
+            return input;
+        }
+        var data = input.dataSync();
+        var half = size / 2;
+        var evenComplex = complex_util.complexWithEvenIndex(data);
+        var evenTensor = ops.complex(evenComplex.real, evenComplex.imag).as1D();
+        var oddComplex = complex_util.complexWithOddIndex(data);
+        var oddTensor = ops.complex(oddComplex.real, oddComplex.imag).as1D();
+        evenTensor = this.fftRadix2(evenTensor, half);
+        oddTensor = this.fftRadix2(oddTensor, half);
+        var e = complex_util.exponents(size);
+        var exponent = ops.complex(e.real, e.imag).mul(oddTensor);
+        var addPart = evenTensor.add(exponent);
+        var subPart = evenTensor.sub(exponent);
+        var realTensor = ops.real(addPart).concat(ops.real(subPart));
+        var imagTensor = ops.imag(addPart).concat(ops.imag(subPart));
+        return ops.complex(realTensor, imagTensor).as1D();
+    };
+    MathBackendCPU.prototype.fourierTransformByMatmul = function (data, size) {
+        var ret = new Float32Array(size * 2);
+        for (var r = 0; r < size; r++) {
+            var real = 0.0;
+            var imag = 0.0;
+            for (var c = 0; c < size; c++) {
+                var e = complex_util.exponent(r * c, size);
+                var term = complex_util.getComplexWithIndex(data, c);
+                real += term.real * e.real - term.imag * e.imag;
+                imag += term.real * e.imag + term.imag * e.real;
+            }
+            complex_util.assignToTypedArray(ret, real, imag, r);
+        }
+        return ret;
+    };
     MathBackendCPU.prototype.depthToSpace = function (x, blockSize, dataFormat) {
         util.assert(dataFormat === 'NHWC', "Only NHWC dataFormat supported on CPU for depthToSpace. Got " + dataFormat);
         util.assert(blockSize > 1, "blockSize should be > 1 for depthToSpace, but was: " + blockSize);
@@ -13936,9 +14348,7 @@ var MathBackendCPU = (function () {
             var heightScale = (cropHeight > 1) ?
                 (y2 - y1) * (imageHeight - 1) / (cropHeight - 1) :
                 0;
-            var widthScale = (cropWidth > 1) ?
-                (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) :
-                0;
+            var widthScale = (cropWidth > 1) ? (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) : 0;
             for (var y = 0; y < cropHeight; y++) {
                 var yInd = (cropHeight > 1) ?
                     y1 * (imageHeight - 1) + y * (heightScale) :
@@ -13946,8 +14356,7 @@ var MathBackendCPU = (function () {
                 if (yInd < 0 || yInd > imageHeight - 1) {
                     for (var x = 0; x < cropWidth; x++) {
                         for (var c = 0; c < numChannels; c++) {
-                            var ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = extrapolationValue;
                         }
                     }
@@ -13963,8 +14372,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -13987,8 +14395,7 @@ var MathBackendCPU = (function () {
                             var bottomRight = imageVals[ind];
                             var top_2 = topLeft + (topRight - topLeft) * xLerp;
                             var bottom = bottomLeft + (bottomRight - bottomLeft) * xLerp;
-                            ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = top_2 + ((bottom - top_2) * yLerp);
                         }
                     }
@@ -14000,8 +14407,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14009,10 +14415,9 @@ var MathBackendCPU = (function () {
                         var closestX = Math.round(xInd);
                         var closestY = Math.round(yInd);
                         for (var c = 0; c < numChannels; c++) {
-                            var inInd = c + closestX * inStride[2]
-                                + closestY * inStride[1] + bInd * inStride[0];
-                            var outInd = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var inInd = c + closestX * inStride[2] +
+                                closestY * inStride[1] + bInd * inStride[0];
+                            var outInd = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[outInd] = imageVals[inInd];
                         }
                     }
@@ -14021,12 +14426,84 @@ var MathBackendCPU = (function () {
         }
         return output.toTensor();
     };
+    MathBackendCPU.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        return this.scatter(sparseIndices, sparseValues, outputShape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        if (numSlices === 0) {
+            return ops_1.tensor([], resultShape, x.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer([numSlices, sliceSize], x.dtype);
+        var indicesData = indices.dataSync();
+        var xData = x.dataSync();
+        for (var i = 0; i < numSlices; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                flattenIndex += dim * strides[j];
+                index.push(dim);
+            }
+            if (flattenIndex < 0 || flattenIndex >= x.size / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + x.shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                buffer.values[i * sliceSize + k] = xData[flattenIndex * sliceSize + k];
+            }
+        }
+        return buffer.toTensor().reshape(resultShape);
+    };
+    MathBackendCPU.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var defaultValue = ops_1.scalar(0);
+        var sumDupeIndices = true;
+        return this.scatter(indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.scatter = function (indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices) {
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var indicesData = indices.dataSync();
+        var updatesData = updates.dataSync();
+        if (outputSize === 0) {
+            return ops_1.tensor([], shape, updates.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer(flattenShape, updates.dtype);
+        buffer.values.fill(defaultValue.dataSync()[0]);
+        for (var i = 0; i < numUpdates; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                index.push(dim);
+                flattenIndex += dim * strides[j];
+            }
+            if (flattenIndex < 0 || flattenIndex >= outputSize / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                if (sumDupeIndices) {
+                    buffer.values[flattenIndex * sliceSize + k] +=
+                        updatesData[i * sliceSize + k];
+                }
+                else {
+                    buffer.values[flattenIndex * sliceSize + k] = updates.rank === 0 ?
+                        updatesData[0] :
+                        updatesData[i * sliceSize + k];
+                }
+            }
+        }
+        return buffer.toTensor().reshape(shape);
+    };
     return MathBackendCPU;
 }());
 exports.MathBackendCPU = MathBackendCPU;
 environment_1.ENV.registerBackend('cpu', function () { return new MathBackendCPU(); }, 1, tensor_1.setTensorTracker);
 
-},{"../environment":64,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/broadcast_util":139,"../ops/concat_util":143,"../ops/erf_util":146,"../ops/ops":157,"../ops/selu_util":166,"../ops/slice_util":168,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./where_impl":132,"seedrandom":281}],81:[function(require,module,exports){
+},{"../environment":64,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/broadcast_util":151,"../ops/concat_util":155,"../ops/erf_util":159,"../ops/gather_nd_util":161,"../ops/ops":172,"../ops/scatter_nd_util":180,"../ops/selu_util":183,"../ops/slice_util":185,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./where_impl":143,"seedrandom":305}],82:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -14072,7 +14549,7 @@ function reshapeTensor(x, shape) {
 }
 exports.reshapeTensor = reshapeTensor;
 
-},{"../ops/tensor_ops":171,"../tensor":187,"../util":194}],82:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../tensor":207,"../util":214}],83:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14116,7 +14593,9 @@ var log_1 = require("../log");
 var array_ops_util = require("../ops/array_ops_util");
 var axis_util = require("../ops/axis_util");
 var concat_util_1 = require("../ops/concat_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var reduce_util = require("../ops/reduce_util");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var segment_util = require("../ops/segment_util");
 var slice_util_1 = require("../ops/slice_util");
 var softmax_1 = require("../ops/softmax");
@@ -14125,6 +14604,7 @@ var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util_1 = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -14133,31 +14613,39 @@ var topk_impl_1 = require("./topk_impl");
 var argminmax_gpu_1 = require("./webgl/argminmax_gpu");
 var avg_pool_backprop_gpu_1 = require("./webgl/avg_pool_backprop_gpu");
 var batchnorm_gpu_1 = require("./webgl/batchnorm_gpu");
+var batchnorm_packed_gpu_1 = require("./webgl/batchnorm_packed_gpu");
 var binaryop_complex_gpu = require("./webgl/binaryop_complex_gpu");
 var binaryop_complex_gpu_1 = require("./webgl/binaryop_complex_gpu");
 var binaryop_gpu = require("./webgl/binaryop_gpu");
 var binaryop_gpu_1 = require("./webgl/binaryop_gpu");
 var clip_gpu_1 = require("./webgl/clip_gpu");
+var complex_abs_gpu_1 = require("./webgl/complex_abs_gpu");
 var concat_gpu_1 = require("./webgl/concat_gpu");
 var conv_backprop_gpu_1 = require("./webgl/conv_backprop_gpu");
 var conv_backprop_gpu_depthwise_1 = require("./webgl/conv_backprop_gpu_depthwise");
 var conv_gpu_1 = require("./webgl/conv_gpu");
-var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var conv_gpu_depthwise_1 = require("./webgl/conv_gpu_depthwise");
+var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var cumsum_gpu_1 = require("./webgl/cumsum_gpu");
 var depth_to_space_gpu_1 = require("./webgl/depth_to_space_gpu");
 var encode_float_gpu_1 = require("./webgl/encode_float_gpu");
+var fft_gpu = require("./webgl/fft_gpu");
+var fft_gpu_1 = require("./webgl/fft_gpu");
 var from_pixels_gpu_1 = require("./webgl/from_pixels_gpu");
 var gather_gpu_1 = require("./webgl/gather_gpu");
+var gather_nd_gpu_1 = require("./webgl/gather_nd_gpu");
 var gpgpu_context_1 = require("./webgl/gpgpu_context");
 var gpgpu_math = require("./webgl/gpgpu_math");
 var gpgpu_util = require("./webgl/gpgpu_util");
+var im2col_gpu_1 = require("./webgl/im2col_gpu");
 var lrn_gpu_1 = require("./webgl/lrn_gpu");
 var lrn_grad_gpu_1 = require("./webgl/lrn_grad_gpu");
 var max_pool_backprop_gpu_1 = require("./webgl/max_pool_backprop_gpu");
 var mulmat_gpu_1 = require("./webgl/mulmat_gpu");
+var mulmat_packed_gpu_1 = require("./webgl/mulmat_packed_gpu");
 var multinomial_gpu_1 = require("./webgl/multinomial_gpu");
 var onehot_gpu_1 = require("./webgl/onehot_gpu");
+var pack_gpu_1 = require("./webgl/pack_gpu");
 var pad_gpu_1 = require("./webgl/pad_gpu");
 var pool_gpu_1 = require("./webgl/pool_gpu");
 var reduce_gpu_1 = require("./webgl/reduce_gpu");
@@ -14166,6 +14654,7 @@ var resize_bilinear_gpu_1 = require("./webgl/resize_bilinear_gpu");
 var resize_nearest_neighbor_backprop_gpu_1 = require("./webgl/resize_nearest_neighbor_backprop_gpu");
 var resize_nearest_neighbor_gpu_1 = require("./webgl/resize_nearest_neighbor_gpu");
 var reverse_gpu_1 = require("./webgl/reverse_gpu");
+var scatter_gpu_1 = require("./webgl/scatter_gpu");
 var segment_gpu_1 = require("./webgl/segment_gpu");
 var select_gpu_1 = require("./webgl/select_gpu");
 var slice_gpu_1 = require("./webgl/slice_gpu");
@@ -14176,16 +14665,16 @@ var tile_gpu_1 = require("./webgl/tile_gpu");
 var transpose_gpu_1 = require("./webgl/transpose_gpu");
 var unary_op = require("./webgl/unaryop_gpu");
 var unaryop_gpu_1 = require("./webgl/unaryop_gpu");
+var unpack_gpu_1 = require("./webgl/unpack_gpu");
 var webgl_util = require("./webgl/webgl_util");
 var where_impl_1 = require("./where_impl");
 var BEFORE_PAGING_CONSTANT = 300;
-exports.SIZE_UPLOAD_UNIFORM = 32;
+exports.SIZE_UPLOAD_UNIFORM = 4;
 var MathBackendWebGL = (function () {
     function MathBackendWebGL(gpgpu, delayedStorage) {
         if (delayedStorage === void 0) { delayedStorage = true; }
         this.gpgpu = gpgpu;
         this.delayedStorage = delayedStorage;
-        this.texData = new WeakMap();
         this.pendingRead = new WeakMap();
         this.pendingDisposal = new WeakSet();
         this.lruDataGPU = [];
@@ -14207,9 +14696,12 @@ var MathBackendWebGL = (function () {
         else {
             this.gpgpuCreatedLocally = false;
         }
-        this.NUM_BYTES_BEFORE_PAGING =
-            (window.screen.height * window.screen.width * window.devicePixelRatio) *
-                BEFORE_PAGING_CONSTANT;
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.NUM_BYTES_BEFORE_PAGING =
+                (window.screen.height * window.screen.width *
+                    window.devicePixelRatio) *
+                    BEFORE_PAGING_CONSTANT;
+        }
         this.textureManager = new texture_manager_1.TextureManager(this.gpgpu);
     }
     MathBackendWebGL.prototype.register = function (dataId, shape, dtype) {
@@ -14223,8 +14715,12 @@ var MathBackendWebGL = (function () {
             texture: null,
             complexTensors: null,
             texShape: null,
-            usage: tex_util_1.TextureUsage.RENDER
+            usage: tex_util_1.TextureUsage.RENDER,
+            isPacked: false
         });
+    };
+    MathBackendWebGL.prototype.setDataMover = function (dataMover) {
+        this.texData = new backend_1.DataStorage(dataMover);
     };
     MathBackendWebGL.prototype.fromPixels = function (pixels, numChannels) {
         if (pixels == null) {
@@ -14257,27 +14753,31 @@ var MathBackendWebGL = (function () {
             this.fromPixelsCanvas.getContext('2d').drawImage(pixels, 0, 0, pixels.width, pixels.height);
             pixels = this.fromPixelsCanvas;
         }
-        var tempPixelArray = tensor_1.Tensor.make(texShape, {}, 'int32');
-        this.texData.get(tempPixelArray.dataId).usage = tex_util_1.TextureUsage.PIXELS;
-        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelArray.dataId), pixels);
+        var tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
+        this.texData.get(tempPixelHandle.dataId).usage = tex_util_1.TextureUsage.PIXELS;
+        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelHandle.dataId), pixels);
         var program = new from_pixels_gpu_1.FromPixelsProgram(outShape);
-        var res = this.compileAndRun(program, [tempPixelArray]);
-        tempPixelArray.dispose();
+        var res = this.compileAndRun(program, [tempPixelHandle]);
+        this.disposeData(tempPixelHandle.dataId);
         return res;
+    };
+    MathBackendWebGL.prototype.makeTensorHandle = function (shape, dtype) {
+        var dataId = {};
+        this.register(dataId, shape, dtype);
+        return { dataId: dataId, shape: shape, dtype: dtype };
     };
     MathBackendWebGL.prototype.write = function (dataId, values) {
         if (values == null) {
             throw new Error('MathBackendWebGL.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype;
+        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype, isPacked = texData.isPacked;
         if (dtype === 'complex64') {
             throw new Error("Cannot write to a complex64 dtype. " +
                 "Please use tf.complex(real, imag).");
         }
         if (texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -14288,9 +14788,8 @@ var MathBackendWebGL = (function () {
         }
     };
     MathBackendWebGL.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype, complexTensors = texData.complexTensors;
+        var values = texData.values, dtype = texData.dtype, complexTensors = texData.complexTensors;
         if (values != null) {
             this.cacheOnCPU(dataId);
             return values;
@@ -14307,8 +14806,7 @@ var MathBackendWebGL = (function () {
             result = complex_util_1.mergeRealAndImagArrays(realValues, imagValues);
         }
         else {
-            result =
-                this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+            result = this.getValuesFromTexture(dataId);
         }
         if (shouldTimeProgram) {
             this.downloadWaitMs += performance.now() - start;
@@ -14318,7 +14816,7 @@ var MathBackendWebGL = (function () {
     };
     MathBackendWebGL.prototype.read = function (dataId) {
         return __awaiter(this, void 0, void 0, function () {
-            var subscribers_1, texData, shape, texture, values, texShape, dtype, bufferOrTexture, vals, subscribers;
+            var subscribers_1, texData, texture, values, texShape, bufferOrTexture, vals, subscribers;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14326,9 +14824,8 @@ var MathBackendWebGL = (function () {
                             subscribers_1 = this.pendingRead.get(dataId);
                             return [2, new Promise(function (resolve) { return subscribers_1.push(resolve); })];
                         }
-                        this.throwIfNoData(dataId);
                         texData = this.texData.get(dataId);
-                        shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype;
+                        texture = texData.texture, values = texData.values, texShape = texData.texShape;
                         if (values != null) {
                             this.cacheOnCPU(dataId);
                             return [2, values];
@@ -14344,7 +14841,7 @@ var MathBackendWebGL = (function () {
                     case 1:
                         _a.sent();
                         if (bufferOrTexture instanceof WebGLTexture) {
-                            vals = this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+                            vals = this.getValuesFromTexture(dataId);
                         }
                         else {
                             vals = this.gpgpu.downloadFloat32MatrixFromBuffer(bufferOrTexture, texShape[0], texShape[1]);
@@ -14362,25 +14859,33 @@ var MathBackendWebGL = (function () {
             });
         });
     };
-    MathBackendWebGL.prototype.getValuesFromTexture = function (texture, dataId, dtype, texShape, shape) {
+    MathBackendWebGL.prototype.getValuesFromTexture = function (dataId) {
+        var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype, texture = _a.texture, texShape = _a.texShape;
         if (environment_1.ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
-            return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            if (this.texData.get(dataId).isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                return this.gpgpu.downloadMatrixFromPackedTexture(texture, batch, rows, cols, texShape[0], texShape[1]);
+            }
+            else {
+                return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            }
         }
-        var tmpTarget = tensor_1.Tensor.make(shape, {});
+        var tmpTarget = this.makeTensorHandle(shape, 'float32');
+        tmpTarget.size = util_1.sizeFromShape(shape);
         this.texData.get(tmpTarget.dataId).usage = tex_util_1.TextureUsage.DOWNLOAD;
-        var tmpInput = tensor_1.Tensor.make(shape, { dataId: dataId }, dtype);
         var program = new encode_float_gpu_1.EncodeFloatProgram(shape);
         var pageToCpu = false;
-        this.compileAndRun(program, [tmpInput], tmpTarget, null, pageToCpu);
+        this.compileAndRun(program, [{ shape: shape, dtype: dtype, dataId: dataId }], tmpTarget, null, pageToCpu);
         var tmpData = this.texData.get(tmpTarget.dataId);
         var vals = this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
-        tmpInput.dispose();
-        tmpTarget.dispose();
+        this.disposeData(tmpTarget.dataId);
         return vals;
     };
     MathBackendWebGL.prototype.time = function (f) {
         return __awaiter(this, void 0, void 0, function () {
-            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimers, kernelMs, res;
+            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimerQueries, flattenedActiveTimerNames, kernelMs, res;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14396,22 +14901,26 @@ var MathBackendWebGL = (function () {
                         }
                         this.activeTimers = newActiveTimers;
                         f();
-                        flattenedActiveTimers = util.flatten(this.activeTimers);
+                        flattenedActiveTimerQueries = util.flatten(this.activeTimers.map(function (d) { return d.query; }))
+                            .filter(function (d) { return d != null; });
+                        flattenedActiveTimerNames = util.flatten(this.activeTimers.map(function (d) { return d.name; }))
+                            .filter(function (d) { return d != null; });
                         this.activeTimers = oldActiveTimers;
                         if (outerMostTime) {
                             this.programTimersStack = null;
                         }
-                        return [4, Promise.all(flattenedActiveTimers).then(function (results) {
-                                var sum = 0;
-                                results.forEach(function (result) { return sum += result; });
-                                return sum;
-                            })];
+                        return [4, Promise.all(flattenedActiveTimerQueries)];
                     case 1:
                         kernelMs = _a.sent();
                         res = {
                             uploadWaitMs: this.uploadWaitMs,
                             downloadWaitMs: this.downloadWaitMs,
-                            kernelMs: kernelMs,
+                            kernelMs: util.sum(kernelMs),
+                            getExtraProfileInfo: function () {
+                                return kernelMs.map(function (d, i) { return ({ name: flattenedActiveTimerNames[i], ms: d }); })
+                                    .map(function (d) { return d.name + ": " + d.ms; })
+                                    .join(', ');
+                            },
                             wallMs: null
                         };
                         this.uploadWaitMs = 0;
@@ -14459,9 +14968,9 @@ var MathBackendWebGL = (function () {
             return;
         }
         if (this.texData.has(dataId)) {
-            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors;
+            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors, isPacked = _a.isPacked;
             if (texture != null) {
-                this.releaseTexture(dataId, texture, texShape, usage);
+                this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             }
             if (complexTensors != null) {
                 complexTensors.real.dispose();
@@ -14481,7 +14990,7 @@ var MathBackendWebGL = (function () {
         return this.canvas;
     };
     MathBackendWebGL.prototype.complex = function (real, imag) {
-        var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
+        var result = this.makeOutputArray(real.shape, 'complex64');
         var resultData = this.texData.get(result.dataId);
         resultData.complexTensors = {
             real: environment_1.ENV.engine.keep(real.clone()),
@@ -14538,8 +15047,18 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.batchMatMul = function (a, b, transposeA, transposeB) {
-        var program = new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-        return this.compileAndRun(program, [a, b]);
+        var outerShapeA = transposeA ? a.shape[2] : a.shape[1];
+        var outerShapeB = transposeB ? b.shape[1] : b.shape[2];
+        if (a.shape[0] === 1 && b.shape[0] === 1) {
+            var aSqueezed = a.as2D(a.shape[1], a.shape[2]);
+            var bSqueezed = b.as2D(b.shape[1], b.shape[2]);
+            var program = new mulmat_packed_gpu_1.MatMulPackedProgram(aSqueezed.shape, bSqueezed.shape, [outerShapeA, outerShapeB], transposeA, transposeB);
+            var result = this.unpackTensor(this.compileAndRun(program, [aSqueezed, bSqueezed], this.makePackedTensor(program.outputShape)));
+            return result.reshape([1, result.shape[0], result.shape[1]]);
+        }
+        else {
+            return this.compileAndRun(new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB), [a, b]);
+        }
     };
     MathBackendWebGL.prototype.multiply = function (a, b) {
         if (a.dtype === 'complex64') {
@@ -14576,8 +15095,14 @@ var MathBackendWebGL = (function () {
             scaleShape = scale.shape;
             inputs.push(scale);
         }
-        var program = new batchnorm_gpu_1.BatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
-        return this.compileAndRun(program, inputs);
+        var output = null;
+        var envSpecificBatchNormProgram = batchnorm_gpu_1.BatchNormProgram;
+        if (environment_1.ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
+            output = this.makePackedTensor(x.shape);
+            envSpecificBatchNormProgram = batchnorm_packed_gpu_1.BatchNormPackedProgram;
+        }
+        var program = new envSpecificBatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
+        return this.compileAndRun(program, inputs, output);
     };
     MathBackendWebGL.prototype.localResponseNormalization4D = function (x, radius, bias, alpha, beta) {
         var program = new lrn_gpu_1.LRNProgram(x.shape, radius, bias, alpha, beta);
@@ -14676,6 +15201,13 @@ var MathBackendWebGL = (function () {
         var a2D = x.as2D(-1, inSize);
         var outputDType = types_1.sumOutType(x.dtype);
         return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+    };
+    MathBackendWebGL.prototype.prod = function (x, axes) {
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var inSize = util.sizeFromShape(reduceShape);
+        var a2D = x.as2D(-1, inSize);
+        var outputDType = types_1.sumOutType(x.dtype);
+        return this.reduce(a2D, 'prod', outputDType).reshape(outShape);
     };
     MathBackendWebGL.prototype.unsortedSegmentSum = function (x, segmentIds, numSegments) {
         var axis = 0;
@@ -14984,6 +15516,15 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.abs = function (x) {
+        if (x.dtype === 'complex64') {
+            var xData = this.texData.get(x.dataId);
+            var program_1 = new complex_abs_gpu_1.ComplexAbsProgram(x.shape);
+            var inputs = [
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+            ];
+            return this.compileAndRun(program_1, inputs);
+        }
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.ABS);
         return this.compileAndRun(program, [x]);
     };
@@ -15057,7 +15598,23 @@ var MathBackendWebGL = (function () {
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.STEP(alpha));
         return this.compileAndRun(program, [x]);
     };
+    MathBackendWebGL.prototype.conv2dWithIm2Row = function (x, filter, convInfo) {
+        var filterWidth = convInfo.filterWidth, filterHeight = convInfo.filterHeight, inChannels = convInfo.inChannels, outWidth = convInfo.outWidth, outHeight = convInfo.outHeight;
+        var sharedDim = filterWidth * filterHeight * inChannels;
+        var numCols = outHeight * outWidth;
+        var x2ColShape = [sharedDim, numCols];
+        var xSqueezed = x.squeeze([0]);
+        var w2Row = filter.reshape([sharedDim, -1]);
+        var im2ColProgram = new im2col_gpu_1.Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
+        var im2Col = this.compileAndRun(im2ColProgram, [xSqueezed], this.makePackedTensor(x2ColShape));
+        var matmulProgram = new mulmat_packed_gpu_1.MatMulPackedProgram(im2Col.shape, w2Row.shape, [numCols, convInfo.outChannels], true, false);
+        var product = this.unpackTensor(this.compileAndRun(matmulProgram, [im2Col, w2Row], this.makePackedTensor(matmulProgram.outputShape)));
+        return product.reshape([1, outHeight, outWidth, convInfo.outChannels]);
+    };
     MathBackendWebGL.prototype.conv2d = function (x, filter, convInfo) {
+        if (environment_1.ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
+            return this.conv2dWithIm2Row(x, filter, convInfo);
+        }
         var program = new conv_gpu_1.Conv2DProgram(convInfo);
         return this.compileAndRun(program, [x, filter]);
     };
@@ -15170,14 +15727,69 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.split = function (x, sizeSplits, axis) {
         return split_shared_1.split(x, sizeSplits, axis);
     };
+    MathBackendWebGL.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var flattenIndices = indices.reshape([numUpdates, sliceRank]);
+        var flattenX = updates.reshape([numUpdates, sliceSize]);
+        if (outputSize === 0) {
+            return backend_util.reshapeTensor(tensor_ops_1.tensor([]), shape);
+        }
+        var defaultValue = tensor_ops_1.scalar(0);
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, flattenIndices.rank, flattenX.rank, strides, flattenShape);
+        return this.compileAndRun(program, [flattenX, flattenIndices, defaultValue])
+            .reshape(shape);
+    };
+    MathBackendWebGL.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, sparseIndices.rank, sparseValues.rank, strides, [outputSize, 1], sumDupeIndices);
+        return this.compileAndRun(program, [sparseValues, sparseIndices, defaultValue])
+            .reshape(outputShape);
+    };
+    MathBackendWebGL.prototype.fft = function (x) {
+        var xData = this.texData.get(x.dataId);
+        var realProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
+        var imagProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+        var inputs = [
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+        ];
+        var real = this.compileAndRun(realProgram, inputs);
+        var imag = this.compileAndRun(imagProgram, inputs);
+        var complex = this.complex(real, imag).as2D(x.shape[0], x.shape[1]);
+        real.dispose();
+        imag.dispose();
+        return complex;
+    };
+    MathBackendWebGL.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        var flattenIndices = indices.reshape([numSlices, sliceRank]);
+        var flattenX = x.reshape([x.size / sliceSize, sliceSize]);
+        var program = new gather_nd_gpu_1.GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+        return this.compileAndRun(program, [flattenX, flattenIndices])
+            .reshape(resultShape);
+    };
     MathBackendWebGL.prototype.makeOutputArray = function (shape, dtype) {
         return tensor_1.Tensor.make(shape, {}, dtype);
+    };
+    MathBackendWebGL.prototype.makePackedTensor = function (shape) {
+        var packedTensor = tensor_1.Tensor.make(shape, {});
+        this.texData.get(packedTensor.dataId).isPacked = true;
+        return packedTensor;
+    };
+    MathBackendWebGL.prototype.unpackTensor = function (input) {
+        var program = new unpack_gpu_1.UnpackProgram(input.shape);
+        return this.compileAndRun(program, [input]);
     };
     MathBackendWebGL.prototype.compileAndRun = function (program, inputs, output, customSetup, pageToCpu) {
         var _this = this;
         if (pageToCpu === void 0) { pageToCpu = true; }
         if (output == null) {
-            output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+            output =
+                this.makeOutputArray(program.outputShape, inputs[0].dtype);
         }
         if (output.size === 0) {
             this.texData.get(output.dataId).values =
@@ -15192,13 +15804,29 @@ var MathBackendWebGL = (function () {
             }
             var texData = _this.texData.get(input.dataId);
             if (texData.texture == null &&
-                util.sizeFromShape(input.shape) <= exports.SIZE_UPLOAD_UNIFORM) {
+                !(!texData.isPacked && program.usesPackedTextures) &&
+                util.sizeFromShape(input.shape) <=
+                    environment_1.ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
                 return {
                     shape: input.shape,
                     texData: null,
                     isUniform: true,
                     uniformValues: _this.readSync(input.dataId)
                 };
+            }
+            if (texData.isPacked !== !!program.usesPackedTextures) {
+                var preProcessProgram = void 0;
+                var processedInput = void 0;
+                if (texData.isPacked) {
+                    preProcessProgram = new unpack_gpu_1.UnpackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input]);
+                }
+                else {
+                    preProcessProgram = new pack_gpu_1.PackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input], _this.makePackedTensor(input.shape));
+                }
+                texData = _this.texData.get(processedInput.dataId);
+                input = processedInput;
             }
             _this.uploadToGPU(input.dataId);
             return { shape: input.shape, texData: texData, isUniform: false };
@@ -15219,7 +15847,8 @@ var MathBackendWebGL = (function () {
             query = this.startTimer();
         }
         gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-        if (pageToCpu && this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED') && pageToCpu &&
+            this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
             var numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
             while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
                 var dataId = this.lruDataGPU.shift();
@@ -15230,7 +15859,7 @@ var MathBackendWebGL = (function () {
         }
         if (shouldTimeProgram) {
             query = this.endTimer(query);
-            this.activeTimers.push(this.getQueryTime(query));
+            this.activeTimers.push({ name: program.constructor.name, query: this.getQueryTime(query) });
         }
         return output;
     };
@@ -15269,22 +15898,16 @@ var MathBackendWebGL = (function () {
             return 16;
         });
     };
-    MathBackendWebGL.prototype.throwIfNoData = function (dataId) {
-        if (!this.texData.has(dataId)) {
-            throw new Error("WebGL backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
-    };
     MathBackendWebGL.prototype.uploadToGPU = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage;
+        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (texture != null) {
-            var index = this.lruDataGPU.indexOf(dataId);
-            if (index >= 0) {
-                this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
-                this.lruDataGPU.push(dataId);
+            if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+                var index = this.lruDataGPU.indexOf(dataId);
+                if (index >= 0) {
+                    this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
+                    this.lruDataGPU.push(dataId);
+                }
             }
             return;
         }
@@ -15293,12 +15916,20 @@ var MathBackendWebGL = (function () {
         if (shouldTimeProgram) {
             start = performance.now();
         }
-        var texShape = webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        var texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
         texData.texShape = texShape;
-        var newTexture = this.acquireTexture(dataId, texShape, usage);
+        var newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
         texData.texture = newTexture;
         if (values != null) {
-            this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            if (isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                this.gpgpu.uploadMatrixToPackedTexture(newTexture, batch, rows, cols, typedArrayToFloat32(values, dtype));
+            }
+            else {
+                this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            }
             texData.values = null;
             if (shouldTimeProgram) {
                 this.uploadWaitMs += performance.now() - start;
@@ -15308,9 +15939,9 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.cacheOnCPU = function (dataId, float32Values) {
         var dontKeepCopyOnGPU = this.delayedStorage;
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage;
+        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (dontKeepCopyOnGPU && texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -15319,20 +15950,24 @@ var MathBackendWebGL = (function () {
             texData.values = float32ToTypedArray(float32Values, dtype);
         }
     };
-    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType) {
+    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        var idx = this.lruDataGPU.indexOf(dataId);
-        if (idx >= 0) {
-            this.lruDataGPU.splice(idx, 1);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            var idx = this.lruDataGPU.indexOf(dataId);
+            if (idx >= 0) {
+                this.lruDataGPU.splice(idx, 1);
+            }
         }
         this.numBytesInGPU -= this.computeBytes(shape, dtype);
-        this.textureManager.releaseTexture(texture, texShape, texType);
+        this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
     };
-    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType) {
+    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        this.lruDataGPU.push(dataId);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.lruDataGPU.push(dataId);
+        }
         this.numBytesInGPU += this.computeBytes(shape, dtype);
-        return this.textureManager.acquireTexture(texShape, texType);
+        return this.textureManager.acquireTexture(texShape, texType, isPacked);
     };
     MathBackendWebGL.prototype.computeBytes = function (shape, dtype) {
         return util.sizeFromShape(shape) * util.bytesPerElement(dtype);
@@ -15363,7 +15998,7 @@ function typedArrayToFloat32(a, dtype) {
     return (a instanceof Float32Array) ? a : new Float32Array(a);
 }
 
-},{"../environment":64,"../globals":66,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/concat_util":143,"../ops/reduce_util":160,"../ops/segment_util":165,"../ops/slice_util":168,"../ops/softmax":169,"../ops/tensor_ops":171,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./webgl/argminmax_gpu":87,"./webgl/avg_pool_backprop_gpu":88,"./webgl/batchnorm_gpu":89,"./webgl/binaryop_complex_gpu":90,"./webgl/binaryop_gpu":91,"./webgl/clip_gpu":92,"./webgl/concat_gpu":93,"./webgl/conv_backprop_gpu":94,"./webgl/conv_backprop_gpu_depthwise":95,"./webgl/conv_gpu":96,"./webgl/conv_gpu_depthwise":97,"./webgl/crop_and_resize_gpu":98,"./webgl/cumsum_gpu":99,"./webgl/depth_to_space_gpu":100,"./webgl/encode_float_gpu":101,"./webgl/from_pixels_gpu":102,"./webgl/gather_gpu":103,"./webgl/gpgpu_context":104,"./webgl/gpgpu_math":105,"./webgl/gpgpu_util":106,"./webgl/lrn_gpu":107,"./webgl/lrn_grad_gpu":108,"./webgl/max_pool_backprop_gpu":109,"./webgl/mulmat_gpu":110,"./webgl/multinomial_gpu":111,"./webgl/onehot_gpu":112,"./webgl/pad_gpu":113,"./webgl/pool_gpu":114,"./webgl/reduce_gpu":115,"./webgl/resize_bilinear_backprop_gpu":116,"./webgl/resize_bilinear_gpu":117,"./webgl/resize_nearest_neighbor_backprop_gpu":118,"./webgl/resize_nearest_neighbor_gpu":119,"./webgl/reverse_gpu":120,"./webgl/segment_gpu":121,"./webgl/select_gpu":122,"./webgl/slice_gpu":124,"./webgl/strided_slice_gpu":125,"./webgl/tex_util":126,"./webgl/texture_manager":127,"./webgl/tile_gpu":128,"./webgl/transpose_gpu":129,"./webgl/unaryop_gpu":130,"./webgl/webgl_util":131,"./where_impl":132}],83:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/concat_util":155,"../ops/gather_nd_util":161,"../ops/reduce_util":175,"../ops/scatter_nd_util":180,"../ops/segment_util":182,"../ops/slice_util":185,"../ops/softmax":186,"../ops/tensor_ops":191,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./webgl/argminmax_gpu":89,"./webgl/avg_pool_backprop_gpu":90,"./webgl/batchnorm_gpu":91,"./webgl/batchnorm_packed_gpu":92,"./webgl/binaryop_complex_gpu":93,"./webgl/binaryop_gpu":94,"./webgl/clip_gpu":95,"./webgl/complex_abs_gpu":96,"./webgl/concat_gpu":97,"./webgl/conv_backprop_gpu":98,"./webgl/conv_backprop_gpu_depthwise":99,"./webgl/conv_gpu":100,"./webgl/conv_gpu_depthwise":101,"./webgl/crop_and_resize_gpu":102,"./webgl/cumsum_gpu":103,"./webgl/depth_to_space_gpu":104,"./webgl/encode_float_gpu":105,"./webgl/fft_gpu":106,"./webgl/from_pixels_gpu":107,"./webgl/gather_gpu":108,"./webgl/gather_nd_gpu":109,"./webgl/gpgpu_context":110,"./webgl/gpgpu_math":111,"./webgl/gpgpu_util":112,"./webgl/im2col_gpu":113,"./webgl/lrn_gpu":114,"./webgl/lrn_grad_gpu":115,"./webgl/max_pool_backprop_gpu":116,"./webgl/mulmat_gpu":117,"./webgl/mulmat_packed_gpu":118,"./webgl/multinomial_gpu":119,"./webgl/onehot_gpu":120,"./webgl/pack_gpu":121,"./webgl/pad_gpu":122,"./webgl/pool_gpu":123,"./webgl/reduce_gpu":124,"./webgl/resize_bilinear_backprop_gpu":125,"./webgl/resize_bilinear_gpu":126,"./webgl/resize_nearest_neighbor_backprop_gpu":127,"./webgl/resize_nearest_neighbor_gpu":128,"./webgl/reverse_gpu":129,"./webgl/scatter_gpu":130,"./webgl/segment_gpu":131,"./webgl/select_gpu":132,"./webgl/slice_gpu":134,"./webgl/strided_slice_gpu":135,"./webgl/tex_util":136,"./webgl/texture_manager":137,"./webgl/tile_gpu":138,"./webgl/transpose_gpu":139,"./webgl/unaryop_gpu":140,"./webgl/unpack_gpu":141,"./webgl/webgl_util":142,"./where_impl":143}],84:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function mergeRealAndImagArrays(real, imag) {
@@ -15389,8 +16024,59 @@ function splitRealAndImagArrays(complex) {
     return { real: real, imag: imag };
 }
 exports.splitRealAndImagArrays = splitRealAndImagArrays;
+function complexWithEvenIndex(complex) {
+    var len = Math.ceil(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 0; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithEvenIndex = complexWithEvenIndex;
+function complexWithOddIndex(complex) {
+    var len = Math.floor(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 2; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithOddIndex = complexWithOddIndex;
+function getComplexWithIndex(complex, index) {
+    var real = complex[index * 2];
+    var imag = complex[index * 2 + 1];
+    return { real: real, imag: imag };
+}
+exports.getComplexWithIndex = getComplexWithIndex;
+function assignToTypedArray(data, real, imag, index) {
+    data[index * 2] = real;
+    data[index * 2 + 1] = imag;
+}
+exports.assignToTypedArray = assignToTypedArray;
+function exponents(n) {
+    var real = new Float32Array(n / 2);
+    var imag = new Float32Array(n / 2);
+    for (var i = 0; i < Math.ceil(n / 2); i++) {
+        var x = -2 * Math.PI * (i / n);
+        real[i] = Math.cos(x);
+        imag[i] = Math.sin(x);
+    }
+    return { real: real, imag: imag };
+}
+exports.exponents = exponents;
+function exponent(k, n) {
+    var x = -2 * Math.PI * (k / n);
+    var real = Math.cos(x);
+    var imag = Math.sin(x);
+    return { real: real, imag: imag };
+}
+exports.exponent = exponent;
 
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15448,7 +16134,33 @@ function intersectionOverUnion(boxes, i, j) {
     return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 
-},{"../ops/tensor_ops":171}],85:[function(require,module,exports){
+},{"../ops/tensor_ops":191}],86:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function getChannels(name) {
+    return ['x', 'y', 'z', 'w'].map(function (d) { return name + "." + d; });
+}
+exports.getChannels = getChannels;
+function getInnerDims(rank, dims) {
+    return dims.slice(0, rank).slice(-2);
+}
+exports.getInnerDims = getInnerDims;
+function getSourceCoords(rank, dims) {
+    if (rank === 1) {
+        return 'rc';
+    }
+    var coords = '';
+    for (var i = 0; i < rank; i++) {
+        coords += dims[i];
+        if (i < rank - 1) {
+            coords += ',';
+        }
+    }
+    return coords;
+}
+exports.getSourceCoords = getSourceCoords;
+
+},{}],87:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function split(x, sizeSplits, axis) {
@@ -15463,7 +16175,7 @@ function split(x, sizeSplits, axis) {
 }
 exports.split = split;
 
-},{}],86:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15498,7 +16210,7 @@ function topkImpl(x, xShape, xDtype, k, sorted) {
 }
 exports.topkImpl = topkImpl;
 
-},{"../ops/tensor_ops":171,"../util":194}],87:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214}],89:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ArgMinMaxProgram = (function () {
@@ -15516,13 +16228,13 @@ var ArgMinMaxProgram = (function () {
         var indexSnippet = firstPass ?
             'inOffset + i;' :
             'round(getBestIndicesA(batch, inOffset + i));';
-        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = 0;\n        float bestValue = getA(batch, inOffset);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
+        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = inOffset;\n        float bestValue = getA(batch, bestIndex);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
     }
     return ArgMinMaxProgram;
 }());
 exports.ArgMinMaxProgram = ArgMinMaxProgram;
 
-},{}],88:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var AvgPool2DBackpropProgram = (function () {
@@ -15533,16 +16245,20 @@ var AvgPool2DBackpropProgram = (function () {
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
         var avgMultiplier = 1 / (filterHeight * filterWidth);
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + ";\n            wC+= " + dilationWidth + ") {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return AvgPool2DBackpropProgram;
 }());
 exports.AvgPool2DBackpropProgram = AvgPool2DBackpropProgram;
 
-},{}],89:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15566,13 +16282,52 @@ var BatchNormProgram = (function () {
             scaleSnippet = 'getScaleAtOutCoords()';
         }
         this.outputShape = xShape;
-        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput(dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));\n      }\n    ";
     }
     return BatchNormProgram;
 }());
 exports.BatchNormProgram = BatchNormProgram;
 
-},{"../../ops/broadcast_util":139}],90:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],92:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var broadcast_util = require("../../ops/broadcast_util");
+var BatchNormPackedProgram = (function () {
+    function BatchNormPackedProgram(xShape, meanShape, varianceShape, offsetShape, scaleShape, varianceEpsilon) {
+        this.supportsBroadcasting = true;
+        this.usesPackedTextures = true;
+        this.variableNames = ['x', 'mean', 'variance'];
+        broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+        broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+        var meanSnippet = broadcastSample('mean', meanShape.length);
+        var varianceSnippet = broadcastSample('variance', varianceShape.length);
+        var offsetSnippet = 'vec4 offset = vec4(0.0)';
+        if (offsetShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+            this.variableNames.push('offset');
+            offsetSnippet = broadcastSample('offset', offsetShape.length);
+        }
+        var scaleSnippet = 'vec4 scale = vec4(1.0)';
+        if (scaleShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+            this.variableNames.push('scale');
+            scaleSnippet = broadcastSample('scale', scaleShape.length);
+        }
+        this.outputShape = xShape;
+        this.userCode = "\n      void main() {\n        ivec4 rc = getOutputCoords();\n\n        " + offsetSnippet + ";\n        " + scaleSnippet + ";\n\n        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);\n        " + meanSnippet + ";\n        " + varianceSnippet + ";\n\n        vec4 inv = scale * inversesqrt(variance + vec4(" + varianceEpsilon + "));\n\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+    }
+    return BatchNormPackedProgram;
+}());
+exports.BatchNormPackedProgram = BatchNormPackedProgram;
+function broadcastSample(texName, rank) {
+    var texSampler = "get" + texName.charAt(0).toUpperCase() + texName.slice(1);
+    if (rank === 1) {
+        return "\n      vec4 " + texName + "Sample = " + texSampler + "(rc.w);\n      vec4 " + texName + " = vec4(" + texName + "Sample.xy, " + texName + "Sample.xy);\n    ";
+    }
+    return "vec4 " + texName + " = " + texSampler + "(rc.x, rc.y, rc.z, rc.w)";
+}
+
+},{"../../ops/broadcast_util":151}],93:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15592,7 +16347,7 @@ var BinaryOpComplexProgram = (function () {
 }());
 exports.BinaryOpComplexProgram = BinaryOpComplexProgram;
 
-},{"../../ops/broadcast_util":139}],91:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],94:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15641,7 +16396,7 @@ var BinaryOpProgram = (function () {
 }());
 exports.BinaryOpProgram = BinaryOpProgram;
 
-},{"../../ops/broadcast_util":139}],92:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],95:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ClipProgram = (function () {
@@ -15654,7 +16409,20 @@ var ClipProgram = (function () {
 }());
 exports.ClipProgram = ClipProgram;
 
-},{}],93:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var ComplexAbsProgram = (function () {
+    function ComplexAbsProgram(shape) {
+        this.variableNames = ['real', 'imag'];
+        this.outputShape = shape;
+        this.userCode = "\n      void main() {\n        float real = getRealAtOutCoords();\n        float imag = getImagAtOutCoords();\n        vec2 v = vec2(real, imag);\n\n        setOutput(sqrt(dot(v, v)));\n      }\n    ";
+    }
+    return ComplexAbsProgram;
+}());
+exports.ComplexAbsProgram = ComplexAbsProgram;
+
+},{}],97:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var concat_util = require("../../ops/concat_util");
@@ -15670,7 +16438,7 @@ var ConcatProgram = (function () {
 }());
 exports.ConcatProgram = ConcatProgram;
 
-},{"../../ops/concat_util":143}],94:[function(require,module,exports){
+},{"../../ops/concat_util":155}],98:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DDerFilterProgram = (function () {
@@ -15702,7 +16470,7 @@ var Conv2DDerInputProgram = (function () {
 }());
 exports.Conv2DDerInputProgram = Conv2DDerInputProgram;
 
-},{}],95:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DDerFilterProgram = (function () {
@@ -15736,7 +16504,7 @@ var DepthwiseConv2DDerInputProgram = (function () {
 }());
 exports.DepthwiseConv2DDerInputProgram = DepthwiseConv2DDerInputProgram;
 
-},{}],96:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DProgram = (function () {
@@ -15759,7 +16527,7 @@ var Conv2DProgram = (function () {
 }());
 exports.Conv2DProgram = Conv2DProgram;
 
-},{}],97:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DProgram = (function () {
@@ -15783,7 +16551,7 @@ var DepthwiseConv2DProgram = (function () {
 }());
 exports.DepthwiseConv2DProgram = DepthwiseConv2DProgram;
 
-},{}],98:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var CropAndResizeProgram = (function () {
@@ -15824,7 +16592,7 @@ var CropAndResizeProgram = (function () {
 }());
 exports.CropAndResizeProgram = CropAndResizeProgram;
 
-},{}],99:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -15875,7 +16643,7 @@ function getFinalCoord(rank, name) {
     }
 }
 
-},{"./shader_compiler":123}],100:[function(require,module,exports){
+},{"./shader_compiler":133}],104:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthToSpaceProgram = (function () {
@@ -15931,7 +16699,7 @@ var DepthToSpaceProgram = (function () {
 }());
 exports.DepthToSpaceProgram = DepthToSpaceProgram;
 
-},{}],101:[function(require,module,exports){
+},{}],105:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var EncodeFloatProgram = (function () {
@@ -15944,7 +16712,25 @@ var EncodeFloatProgram = (function () {
 }());
 exports.EncodeFloatProgram = EncodeFloatProgram;
 
-},{}],102:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COMPLEX_FFT = {
+    REAL: 'return real * expR - imag * expI;',
+    IMAG: 'return real * expI + imag * expR;'
+};
+var FFTProgram = (function () {
+    function FFTProgram(op, inputShape) {
+        this.variableNames = ['real', 'imag'];
+        var innerDim = inputShape[1];
+        this.outputShape = inputShape;
+        this.userCode = "\n      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;\n\n      float unaryOpComplex(float real, float expR, float imag, float expI) {\n        " + op + "\n      }\n\n      float mulMatDFT(int batch, int index) {\n        float indexRatio = float(index) / float(" + innerDim + ");\n        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;\n\n        float result = 0.0;\n\n        for (int i = 0; i < " + innerDim + "; i++) {\n          // x = (-2 * PI / N) * index * i;\n          float x = negativeTwoPiTimesIndexRatio * float(i);\n          float expR = cos(x);\n          float expI = sin(x);\n          float real = getReal(batch, i);\n          float imag = getImag(batch, i);\n\n          result += unaryOpComplex(real, expR, imag, expI);\n        }\n\n        return result;\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        setOutput(mulMatDFT(coords[0], coords[1]));\n      }\n    ";
+    }
+    return FFTProgram;
+}());
+exports.FFTProgram = FFTProgram;
+
+},{}],107:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var FromPixelsProgram = (function () {
@@ -15958,7 +16744,7 @@ var FromPixelsProgram = (function () {
 }());
 exports.FromPixelsProgram = FromPixelsProgram;
 
-},{}],103:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -15997,7 +16783,26 @@ function getSourceCoords(aShape, axis) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],104:[function(require,module,exports){
+},{"./shader_compiler":133}],109:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var GatherNDProgram = (function () {
+    function GatherNDProgram(sliceDim, strides, shape) {
+        this.sliceDim = sliceDim;
+        this.strides = strides;
+        this.variableNames = ['x', 'indices'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + this.strides + ");\n         void main() {\n          " + dtype + " coords = getOutputCoords();\n          int flattenIndex = 0;\n          for (int j = 0; j < " + this.sliceDim + "; j++) {\n            int index = round(getIndices(coords[0], j));\n            flattenIndex += index * " + strideString + ";\n          }\n          setOutput(getX(flattenIndex, coords[1]));\n        }\n      ";
+    }
+    return GatherNDProgram;
+}());
+exports.GatherNDProgram = GatherNDProgram;
+
+},{"./shader_compiler":133}],110:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16125,6 +16930,10 @@ var GPGPUContext = (function () {
         this.throwIfDisposed();
         gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
     };
+    GPGPUContext.prototype.createFloat16PackedMatrixTexture = function (rows, columns) {
+        this.throwIfDisposed();
+        return gpgpu_util.createFloat16PackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
+    };
     GPGPUContext.prototype.createPackedMatrixTexture = function (rows, columns) {
         this.throwIfDisposed();
         return gpgpu_util.createPackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
@@ -16143,9 +16952,9 @@ var GPGPUContext = (function () {
         var numChannels = webgl_util.getNumChannels();
         return gpgpu_util.uploadMatrixToTexture(this.gl, texture, rows, columns, matrix, numChannels, this.textureConfig);
     };
-    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, rows, columns, matrix) {
+    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, batch, rows, columns, matrix) {
         this.throwIfDisposed();
-        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, rows, columns, matrix, this.textureConfig);
+        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, batch, rows, columns, matrix, this.textureConfig);
     };
     GPGPUContext.prototype.downloadFloat32MatrixFromOutputTexture = function (texture, rows, columns) {
         var _this = this;
@@ -16193,9 +17002,9 @@ var GPGPUContext = (function () {
         }
         return { query: query, isFencePassed: isFencePassed };
     };
-    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, rows, columns) {
+    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, batch, rows, columns, physicalRows, physicalCols) {
         var _this = this;
-        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, rows, columns, _this.textureConfig); });
+        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, batch, rows, columns, physicalRows, physicalCols, _this.textureConfig); });
     };
     GPGPUContext.prototype.createProgram = function (fragmentShaderSource) {
         this.throwIfDisposed();
@@ -16477,7 +17286,7 @@ function binSearchLastTrue(arr) {
 }
 exports.binSearchLastTrue = binSearchLastTrue;
 
-},{"../../environment":64,"../../util":194,"./gpgpu_util":106,"./tex_util":126,"./webgl_util":131}],105:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./gpgpu_util":112,"./tex_util":136,"./webgl_util":142}],111:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../../util");
@@ -16488,7 +17297,8 @@ function compileProgram(gpgpu, program, inputs, output) {
         var shapeInfo = {
             logicalShape: input.shape,
             texShape: input.isUniform ? null : input.texData.texShape,
-            isUniform: input.isUniform
+            isUniform: input.isUniform,
+            isPacked: input.isUniform ? false : input.texData.isPacked
         };
         return { name: program.variableNames[i], shapeInfo: shapeInfo };
     });
@@ -16496,7 +17306,8 @@ function compileProgram(gpgpu, program, inputs, output) {
     var outShapeInfo = {
         logicalShape: output.shape,
         texShape: output.texData.texShape,
-        isUniform: false
+        isUniform: false,
+        isPacked: output.texData.isPacked
     };
     var source = shader_compiler.makeShader(inputInfos, outShapeInfo, userCode, program.supportsBroadcasting === true);
     var webGLProgram = gpgpu.createProgram(source);
@@ -16548,7 +17359,12 @@ function runProgram(binary, inputs, output, customSetup) {
     var outTex = output.texData.texture;
     var outTexShape = output.texData.texShape;
     var gpgpu = binary.gpgpu;
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    if (output.texData.isPacked) {
+        gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
+    else {
+        gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
     gpgpu.setProgram(binary.webGLProgram);
     inputs.forEach(function (input, i) {
         var variableName = binary.program.variableNames[i];
@@ -16590,10 +17406,11 @@ function makeShaderKey(program, inputs, output) {
 }
 exports.makeShaderKey = makeShaderKey;
 
-},{"../../util":194,"./shader_compiler":123}],106:[function(require,module,exports){
+},{"../../util":214,"./shader_compiler":133}],112:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 var tex_util = require("./tex_util");
 var webgl_util = require("./webgl_util");
 function getWebGLContextAttributes() {
@@ -16688,7 +17505,7 @@ function getTextureConfig(gl, textureHalfFloatExtension) {
 }
 exports.getTextureConfig = getTextureConfig;
 function createAndConfigureTexture(gl, width, height, internalFormat, textureFormat, textureType) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     var texture = webgl_util.createTexture(gl);
     var tex2d = gl.TEXTURE_2D;
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(tex2d, texture); });
@@ -16720,6 +17537,11 @@ function createPackedMatrixTexture(gl, rows, columns, textureConfig) {
     return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatPackedFloat, gl.RGBA, gl.FLOAT);
 }
 exports.createPackedMatrixTexture = createPackedMatrixTexture;
+function createFloat16PackedMatrixTexture(gl, rows, columns, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), width = _a[0], height = _a[1];
+    return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA, textureConfig.textureTypeHalfFloat);
+}
+exports.createFloat16PackedMatrixTexture = createFloat16PackedMatrixTexture;
 function bindVertexProgramAttributeStreams(gl, program, vertexBuffer) {
     var posOffset = 0;
     var uvOffset = 3 * 4;
@@ -16737,7 +17559,7 @@ function uploadPixelDataToTexture(gl, texture, pixels) {
 }
 exports.uploadPixelDataToTexture = uploadPixelDataToTexture;
 function uploadDataToTexture(gl, texture, width, height, data, textureFormat) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, texture); });
     webgl_util.callAndCheck(gl, function () { return gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, textureFormat, gl.FLOAT, data); });
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, null); });
@@ -16756,10 +17578,10 @@ function uploadMatrixToTexture(gl, texture, rows, columns, matrix, numChannels, 
     uploadDataToTexture(gl, texture, w, h, unpackedArray, textureConfig.textureFormatFloat);
 }
 exports.uploadMatrixToTexture = uploadMatrixToTexture;
-function uploadMatrixToPackedTexture(gl, texture, rows, columns, matrix, textureConfig) {
+function uploadMatrixToPackedTexture(gl, texture, batch, rows, columns, matrix, textureConfig) {
     var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
     var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
-    tex_util.encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA);
+    tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
     uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }
 exports.uploadMatrixToPackedTexture = uploadMatrixToPackedTexture;
@@ -16808,16 +17630,32 @@ function downloadByteEncodedFloatMatrixFromOutputTexture(gl, rows, columns, text
     return new Float32Array(downloadTarget.buffer);
 }
 exports.downloadByteEncodedFloatMatrixFromOutputTexture = downloadByteEncodedFloatMatrixFromOutputTexture;
-function downloadMatrixFromPackedOutputTexture(gl, rows, columns, textureConfig) {
-    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
-    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+function downloadMatrixFromPackedOutputTexture(gl, batch, rows, cols, physicalRows, physicalCols, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(physicalRows, physicalCols), w = _a[0], h = _a[1];
+    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
     webgl_util.callAndCheck(gl, function () { return gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, packedRGBA); });
-    var matrix = new Float32Array(rows * columns);
-    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix);
+    var matrix = new Float32Array(util.sizeFromShape([batch, rows, cols]));
+    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, batch, rows, cols, matrix);
 }
 exports.downloadMatrixFromPackedOutputTexture = downloadMatrixFromPackedOutputTexture;
 
-},{"../../environment":64,"./tex_util":126,"./webgl_util":131}],107:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./tex_util":136,"./webgl_util":142}],113:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Im2ColProgram = (function () {
+    function Im2ColProgram(outputShape, inputShape, convInfo) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var filterWidth = convInfo.filterWidth, inChannels = convInfo.inChannels, strideWidth = convInfo.strideWidth, strideHeight = convInfo.strideHeight, padInfo = convInfo.padInfo, outWidth = convInfo.outWidth, dilationWidth = convInfo.dilationWidth, dilationHeight = convInfo.dilationHeight;
+        var left = padInfo.left, top = padInfo.top;
+        var itemsPerBlockRow = inChannels * filterWidth;
+        this.userCode = "\n      void main() {\n        ivec2 rc = getOutputCoords();\n\n        vec4 result = vec4(0);\n\n        for(int row=0; row<=1; row++) {\n          for(int col=0; col<=1; col++) {\n            int blockIndex = rc.y + col;\n            int pos = rc.x + row;\n\n            if(blockIndex >= " + outputShape[1] + " || pos >= " + outputShape[0] + ") continue;\n\n            int offsetY = int(blockIndex / (" + outWidth + ")) * " + strideHeight + " - " + top + ";\n            int d0 = offsetY + " + dilationHeight + " * (pos / " + itemsPerBlockRow + ");\n\n            if(d0 >= " + inputShape[0] + " || d0 < 0) continue;\n\n            int offsetX = int(mod(float(blockIndex), " + outWidth + ".) * " + strideWidth + ". - " + left + ".);\n            int d1 = offsetX + " + dilationWidth + " * (int(mod(float(pos), " + itemsPerBlockRow + ".) / " + inChannels + ".));\n\n            if(d1 >= " + inputShape[1] + " || d1 < 0) continue;\n\n            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), " + inChannels + ".)));\n          }\n        }\n\n        gl_FragColor = result;\n      }\n    ";
+    }
+    return Im2ColProgram;
+}());
+exports.Im2ColProgram = Im2ColProgram;
+
+},{}],114:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNProgram = (function () {
@@ -16844,7 +17682,7 @@ var LRNProgram = (function () {
 }());
 exports.LRNProgram = LRNProgram;
 
-},{}],108:[function(require,module,exports){
+},{}],115:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNGradProgram = (function () {
@@ -16863,27 +17701,28 @@ var LRNGradProgram = (function () {
 }());
 exports.LRNGradProgram = LRNGradProgram;
 
-},{}],109:[function(require,module,exports){
+},{}],116:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MaxPool2DBackpropProgram = (function () {
     function MaxPool2DBackpropProgram(convInfo) {
         this.variableNames = ['dy', 'maxPos'];
         this.outputShape = convInfo.inShape;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var lastIndex = filterHeight * filterWidth - 1;
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + filterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        var dilationHeight = convInfo.dilationHeight;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var lastIndex = effectiveFilterHeight * effectiveFilterWidth - 1;
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n          wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + effectiveFilterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return MaxPool2DBackpropProgram;
 }());
 exports.MaxPool2DBackpropProgram = MaxPool2DBackpropProgram;
 
-},{}],110:[function(require,module,exports){
+},{}],117:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MatMulProgram = (function () {
@@ -16912,7 +17751,29 @@ var MatMulProgram = (function () {
 }());
 exports.MatMulProgram = MatMulProgram;
 
-},{}],111:[function(require,module,exports){
+},{}],118:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var MatMulPackedProgram = (function () {
+    function MatMulPackedProgram(aShape, bShape, outputShape, transposeA, transposeB) {
+        if (transposeA === void 0) { transposeA = false; }
+        if (transposeB === void 0) { transposeB = false; }
+        this.variableNames = ['matrixA', 'matrixB'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var sharedDim = transposeA ? aShape[0] : aShape[1];
+        var sharedDimensionPacked = Math.ceil(sharedDim / 2);
+        var aSample = transposeA ? 'i * 2, rc.x' : 'rc.x, i * 2';
+        var bSample = transposeB ? 'rc.y, i * 2' : 'i * 2, rc.y';
+        var aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
+        var bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
+        this.userCode = "\n      const float sharedDimension = " + sharedDimensionPacked + ".0;\n\n      vec4 dot2x2ARowBCol(ivec2 rc) {\n        vec4 result = vec4(0);\n        for (int i = 0; i < " + sharedDimensionPacked + "; i++) {\n          vec4 a = getMatrixA(" + aSample + ");\n          vec4 b = getMatrixB(" + bSample + ");\n\n          result += (" + aSwizzle[0] + " * " + bSwizzle[0] + ") + (" + aSwizzle[1] + " * " + bSwizzle[1] + ");\n        }\n        return result;\n      }\n\n      void main() {\n        ivec2 rc = getOutputCoords();\n        setOutput(dot2x2ARowBCol(rc));\n      }\n    ";
+    }
+    return MatMulPackedProgram;
+}());
+exports.MatMulPackedProgram = MatMulPackedProgram;
+
+},{}],119:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MultinomialProgram = (function () {
@@ -16934,7 +17795,7 @@ var MultinomialProgram = (function () {
 }());
 exports.MultinomialProgram = MultinomialProgram;
 
-},{}],112:[function(require,module,exports){
+},{}],120:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var OneHotProgram = (function () {
@@ -16947,7 +17808,69 @@ var OneHotProgram = (function () {
 }());
 exports.OneHotProgram = OneHotProgram;
 
-},{}],113:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var PackProgram = (function () {
+    function PackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var outOfBoundsCondition = getOutOfBoundsCondition(rank, outputShape, channels);
+        var setup = getSetup(rank, outputShape[outputShape.length - 1], outputShape[outputShape.length - 2], channels);
+        var output = getOutput(outputShape, channels);
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n\n        if(" + outOfBoundsCondition + ") {\n          gl_FragColor = vec4(0);\n        } else {\n          " + setup + "\n\n          setOutput(vec4(" + output + "));\n        }\n      }\n    ";
+    }
+    return PackProgram;
+}());
+exports.PackProgram = PackProgram;
+function getSourceCoordsArr(rank, dims) {
+    var coords = [];
+    for (var row = 0; row <= 1; row++) {
+        for (var col = 0; col <= 1; col++) {
+            var coord = (row === 0 ? 'r' : 'rp1') + ", " + (col === 0 ? 'c' : 'cp1');
+            for (var d = 2; d < rank; d++) {
+                coord = dims[dims.length - 1 - d] + "," + coord;
+            }
+            coords.push(coord);
+        }
+    }
+    return coords;
+}
+function getOutOfBoundsCondition(rank, shape, dims) {
+    if (rank === 1) {
+        return "rc > " + shape[0];
+    }
+    var cond = '';
+    for (var i = 0; i < rank; i++) {
+        cond += dims[i] + " >= " + shape[i];
+        if (i < rank - 1) {
+            cond += '||';
+        }
+    }
+    return cond;
+}
+function getSetup(rank, cols, rows, dims) {
+    if (rank === 1) {
+        return '';
+    }
+    var innerDims = packing_util_1.getInnerDims(rank, dims);
+    return "\n    int r = " + innerDims[0] + ";\n    int c = " + innerDims[1] + ";\n    int rp1 = r + 1;\n    int cp1 = c + 1;\n\n    bool cEdge = cp1 >= " + cols + ";\n    bool rEdge = rp1 >= " + rows + ";\n  ";
+}
+function getOutput(shape, dims) {
+    var rank = shape.length;
+    var sourceCoords = getSourceCoordsArr(rank, dims);
+    if (rank === 1) {
+        return "getA(rc),\n            rc + 1 >= " + shape[0] + " ? 0. : getA(rc + 1),\n            0, 0";
+    }
+    return "getA(" + sourceCoords[0] + "),\n          cEdge ? 0. : getA(" + sourceCoords[1] + "),\n          rEdge ? 0. : getA(" + sourceCoords[2] + "),\n          rEdge || cEdge ? 0. : getA(" + sourceCoords[3] + ")";
+}
+
+},{"../packing_util":86,"./shader_compiler":133}],122:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16970,7 +17893,7 @@ var PadProgram = (function () {
 }());
 exports.PadProgram = PadProgram;
 
-},{"./shader_compiler":123}],114:[function(require,module,exports){
+},{"./shader_compiler":133}],123:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Pool2DProgram = (function () {
@@ -16979,10 +17902,13 @@ var Pool2DProgram = (function () {
         if (poolType === 'avg' && computePositions) {
             throw new Error('Cannot compute positions for average pool.');
         }
-        var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         this.outputShape = convInfo.outShape;
@@ -16993,7 +17919,7 @@ var Pool2DProgram = (function () {
         }
         if (computePositions) {
             var compareOp_1 = '>=';
-            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + filterHeight + "; wR++) {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + filterWidth + "; wC++) {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + filterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
+            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + effectiveFilterHeight + ";\n              wR += " + dilationHeight + ") {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + effectiveFilterWidth + ";\n                wC += " + dilationWidth + ") {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + effectiveFilterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
             return;
         }
         var compareOp = 'max';
@@ -17005,13 +17931,13 @@ var Pool2DProgram = (function () {
         var filterWidthNearestVec4 = Math.floor(filterWidth / 4) * 4;
         var filterWidthVec4Remainder = filterWidth % 4;
         var updateSnippet = "\n      if (" + isAvgPool + ") {\n        avgValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
-        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC;\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              getValue(batch, xR, xC + 3, d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC * " + dilationWidth + ";\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 3 * " + dilationWidth + ", d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return Pool2DProgram;
 }());
 exports.Pool2DProgram = Pool2DProgram;
 
-},{}],115:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ReduceProgram = (function () {
@@ -17024,7 +17950,10 @@ var ReduceProgram = (function () {
         this.outputShape = [batchSize, outSize];
         var initializationValue = '0.0';
         var compareOp = "";
-        if (reduceType === 'min') {
+        if (reduceType === 'prod') {
+            initializationValue = '1.0';
+        }
+        else if (reduceType === 'min') {
             initializationValue = '1.0 / 0.0';
             compareOp = "min";
         }
@@ -17037,6 +17966,9 @@ var ReduceProgram = (function () {
         if (reduceType === 'sum') {
             returnValue = "sumValue";
         }
+        else if (reduceType === 'prod') {
+            returnValue = "prodValue";
+        }
         else if (reduceType === 'all') {
             returnValue = "allValue";
         }
@@ -17045,7 +17977,7 @@ var ReduceProgram = (function () {
         }
         var windowSizeNearestVec4 = Math.floor(windowSize / 4) * 4;
         var windowSizeVec4Remainder = windowSize % 4;
-        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
+        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else if (" + (reduceType === 'prod') + ") {\n        vec2 tmp = vec2(values[0], values[1]) * vec2(values[2], values[3]);\n        prodValue *= tmp[0] * tmp[1];\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
         var vecType = "vec4";
         if (reduceType === 'all') {
             initializationValue = '1.0';
@@ -17061,13 +17993,13 @@ var ReduceProgram = (function () {
         if (inSize % windowSize > 0) {
             checkOutOfBounds = "\n        if (inIdx < 0 || inIdx >= " + inSize + ") {\n          return initializationValue;\n        }\n      ";
         }
-        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float prodValue = 1.0;\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return ReduceProgram;
 }());
 exports.ReduceProgram = ReduceProgram;
 
-},{}],116:[function(require,module,exports){
+},{}],125:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearBackpropProgram = (function () {
@@ -17097,7 +18029,7 @@ var ResizeBilinearBackpropProgram = (function () {
 }());
 exports.ResizeBilinearBackpropProgram = ResizeBilinearBackpropProgram;
 
-},{}],117:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearProgram = (function () {
@@ -17120,7 +18052,7 @@ var ResizeBilinearProgram = (function () {
 }());
 exports.ResizeBilinearProgram = ResizeBilinearProgram;
 
-},{}],118:[function(require,module,exports){
+},{}],127:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeigborBackpropProgram = (function () {
@@ -17150,7 +18082,7 @@ var ResizeNearestNeigborBackpropProgram = (function () {
 }());
 exports.ResizeNearestNeigborBackpropProgram = ResizeNearestNeigborBackpropProgram;
 
-},{}],119:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeighborProgram = (function () {
@@ -17174,7 +18106,7 @@ var ResizeNearestNeighborProgram = (function () {
 }());
 exports.ResizeNearestNeighborProgram = ResizeNearestNeighborProgram;
 
-},{}],120:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17204,7 +18136,41 @@ var ReverseProgram = (function () {
 }());
 exports.ReverseProgram = ReverseProgram;
 
-},{"./shader_compiler":123}],121:[function(require,module,exports){
+},{"./shader_compiler":133}],130:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var ScatterProgram = (function () {
+    function ScatterProgram(updateSize, sliceDim, indicesRank, updatesRank, strides, shape, summingDupeIndex) {
+        if (summingDupeIndex === void 0) { summingDupeIndex = true; }
+        this.variableNames = ['updates', 'indices', 'defaultValue'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var indicesString = '';
+        if (indicesRank === 1) {
+            indicesString = 'i';
+        }
+        else if (indicesRank === 2) {
+            indicesString = 'i, j';
+        }
+        var indicesSnippet = "getIndices(" + indicesString + ")";
+        var updatesString = '';
+        if (updatesRank === 1) {
+            updatesString = 'i';
+        }
+        else if (updatesRank === 2) {
+            updatesString = 'i, coords[1]';
+        }
+        var updatesSnippet = "getUpdates(" + updatesString + ")";
+        var strideString = sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + strides + ");\n\n        void main() {\n          " + dtype + " coords = getOutputCoords();\n          float sum = 0.0;\n          bool found = false;\n          for (int i = 0; i < " + updateSize + "; i++) {\n            int flattenedIndex = 0;\n            for (int j = 0; j < " + sliceDim + "; j++) {\n              int index = round(" + indicesSnippet + ");\n              flattenedIndex += index * " + strideString + ";\n            }\n            if (flattenedIndex == coords[0]) {\n              sum += " + updatesSnippet + ";\n              found = true;\n            }\n          }\n          setOutput(mix(getDefaultValue(), sum, float(found)));\n        }\n      ";
+    }
+    return ScatterProgram;
+}());
+exports.ScatterProgram = ScatterProgram;
+
+},{"./shader_compiler":133}],131:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var SegmentOpProgram = (function () {
@@ -17235,7 +18201,7 @@ var SegmentOpProgram = (function () {
 }());
 exports.SegmentOpProgram = SegmentOpProgram;
 
-},{}],122:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17272,7 +18238,7 @@ var SelectProgram = (function () {
 }());
 exports.SelectProgram = SelectProgram;
 
-},{"./shader_compiler":123}],123:[function(require,module,exports){
+},{"./shader_compiler":133}],133:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -17289,11 +18255,21 @@ function makeShader(inputsInfo, outputShape, userCode, broadcast) {
     var inputSamplingSnippet = inputsInfo.map(function (x) { return getInputSamplingSnippet(x, outputShape, broadcast); })
         .join('\n');
     var outTexShape = outputShape.texShape;
-    var outputSamplingSnippet = getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    var outputSamplingSnippet;
+    var floatTextureSetOutputSnippet;
+    if (outputShape.isPacked) {
+        outputSamplingSnippet =
+            getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    }
+    else {
+        outputSamplingSnippet =
+            getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    }
     var source = [
-        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-        FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-        inputSamplingSnippet, userCode
+        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+        inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
     ].join('\n');
     return source;
 }
@@ -17320,14 +18296,47 @@ function getSamplerFromInInfo(inInfo) {
                 " is not yet supported");
     }
 }
+function getPackedSamplerFromInInfo(inInfo) {
+    var shape = inInfo.shapeInfo.logicalShape;
+    switch (shape.length) {
+        case 1:
+            return getPackedSampler1D(inInfo);
+        case 2:
+            return getPackedSampler2D(inInfo);
+        case 4:
+            return getPackedSampler4D(inInfo);
+        default:
+            throw new Error("Packed " + shape.length + "-D input sampling" +
+                " is not yet supported");
+    }
+}
 function getInputSamplingSnippet(inInfo, outShapeInfo, broadcast) {
     var res = getSamplerFlat(inInfo);
-    res += getSamplerFromInInfo(inInfo);
+    if (inInfo.shapeInfo.isPacked) {
+        res += getPackedSamplerFromInInfo(inInfo);
+    }
+    else {
+        res += getSamplerFromInInfo(inInfo);
+    }
     if (broadcast ||
         util.arraysEqual(inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
         res += getSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     }
     return res;
+}
+function getPackedOutputSamplingSnippet(outShape, outTexShape) {
+    switch (outShape.length) {
+        case 0:
+            return getOutputScalarCoords();
+        case 1:
+            return getOutputPacked1DCoords(outShape, outTexShape);
+        case 2:
+            return getOutputPacked2DCoords(outShape, outTexShape);
+        case 4:
+            return getOutputPacked4DCoords(outShape, outTexShape);
+        default:
+            throw new Error(outShape.length + "-D output packed sampling is not yet supported");
+    }
 }
 function getOutputSamplingSnippet(outShape, outTexShape) {
     switch (outShape.length) {
@@ -17349,17 +18358,28 @@ function getOutputSamplingSnippet(outShape, outTexShape) {
             throw new Error(outShape.length + "-D output sampling is not yet supported");
     }
 }
-var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom1D(int texNumR, int texNumC, int index) {\n  int texelIndex = index / 2;\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom2D(int texelsInLogicalRow, int texNumR,\n  int texNumC, int row, int col) {\n  int texelIndex = (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_3D_SNIPPET = "\nvec2 UVfrom3D(int texNumR, int texNumC, int stride0,\n    int stride1, int row, int col, int depth) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,\n    int texelsInBatch, int texelsInLogicalRow, int b2, int b,\n    int row, int col) {\n  int index = b2 * texelsInBatch2 + b * texelsInBatch +\n    (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_5D_SNIPPET = "\nvec2 UVfrom5D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int row, int col, int depth,\n    int depth2, int depth3) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 +\n              depth * stride2 + depth2 * stride3 + depth3;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_6D_SNIPPET = "\nvec2 UVfrom6D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int stride4,\n    int row, int col, int depth, int depth2, int depth3, int depth4) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2 *\n    stride3 + depth3 * stride4 + depth4;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var FLOAT_TEXTURE_SAMPLE_SNIPPET = "\n  float sampleTexture(sampler2D textureSampler, vec2 uv) {\n    return texture2D(textureSampler, uv).r;\n  }\n";
-var FLOAT_TEXTURE_SETOUTPUT_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
-var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
+var FLOAT_TEXTURE_SET_R_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
+var FLOAT_TEXTURE_SET_RGBA_SNIPPET = "\n  void setOutput(vec4 val) {\n    gl_FragColor = val;\n  }\n";
+var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
 function getOutputScalarCoords() {
     return "\n    int getOutputCoords() {\n      return 0;\n    }\n  ";
+}
+function getOutputPacked1DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (texShape[0] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.x * " + packedTexShape[1] + ".0);\n      }\n    ";
+    }
+    if (texShape[1] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.y * " + packedTexShape[0] + ".0);\n      }\n    ";
+    }
+    return "\n    int getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      return resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n    }\n  ";
 }
 function getOutput1DCoords(shape, texShape) {
     if (texShape[0] === 1) {
@@ -17374,6 +18394,13 @@ function getOutput3DCoords(shape, texShape) {
     var stride0 = shape[1] * shape[2];
     var stride1 = shape[2];
     return "\n    ivec3 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n      int c = index / " + stride1 + ";\n      int d = index - c * " + stride1 + ";\n      return ivec3(r, c, d);\n    }\n  ";
+}
+function getOutputPacked4DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texelsInLogicalRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    ivec4 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n\n      int b2 = index / " + texelsInBatch2 + ";\n      index -= b2 * " + texelsInBatch2 + ";\n\n      int b = index / " + texelsInBatch + ";\n      index -= b * " + texelsInBatch + ";\n\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = int(mod(float(index), " + texelsInLogicalRow + ".)) * 2;\n\n      return ivec4(b2, b, r, c);\n    }\n  ";
 }
 function getOutput4DCoords(shape, texShape) {
     var stride2 = shape[3];
@@ -17396,6 +18423,14 @@ function getOutput6DCoords(shape, texShape) {
     var stride0 = shape[1] * stride1;
     return "\n    ivec6 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n        vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n\n      int c = index / " + stride1 + ";\n      index -= c * " + stride1 + ";\n\n      int d = index / " + stride2 + ";\n      index -= d * " + stride2 + ";\n\n      int d2 = index / " + stride3 + ";\n      index -= d2 * " + stride3 + ";\n\n      int d3 = index / " + stride4 + ";\n      int d4 = index - d3 * " + stride4 + ";\n\n      ivec6 result = ivec6(r, c, d, d2, d3, d4);\n      return result;\n    }\n  ";
 }
+function getOutputPacked2DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (util.arraysEqual(shape, texShape)) {
+        return "\n      ivec2 getOutputCoords() {\n        return 2 * ivec2(resultUV.yx * vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      }\n    ";
+    }
+    var texelsInLogicalRow = Math.ceil(shape[1] / 2);
+    return "\n    ivec2 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = imod(index, " + texelsInLogicalRow + ") * 2;\n\n      return ivec2(r, c);\n    }\n  ";
+}
 function getOutput2DCoords(shape, texShape) {
     if (util.arraysEqual(shape, texShape)) {
         return "\n      ivec2 getOutputCoords() {\n        return ivec2(resultUV.yx * vec2(" + texShape[0] + ", " + texShape[1] + "));\n      }\n    ";
@@ -17416,10 +18451,31 @@ function getSamplerScalar(inputInfo) {
     }
     return "\n    float " + funcName + "() {\n      return sampleTexture(" + texName + ", halfCR);\n    }\n  ";
 }
+function getPackedSampler1D(inputInfo) {
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    return "\n    vec4 " + funcName + "(int index) {\n      vec2 uv = packedUVfrom1D(\n        " + packedTexShape[0] + ", " + packedTexShape[1] + ", index);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
+}
 function getSampler1D(inputInfo) {
     var texName = inputInfo.name;
     var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
     return "\n    float " + funcName + "(int index) {\n      return " + funcName + "Flat(index);\n    }\n  ";
+}
+function getPackedSampler2D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var texNumR = texShape[0];
+    var texNumC = texShape[1];
+    if (texShape != null && util.arraysEqual(shape, texShape)) {
+        return "\n      vec4 " + funcName + "(int row, int col) {\n        vec2 uv = (vec2(col, row) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n\n        return texture2D(" + texName + ", uv);\n      }\n    ";
+    }
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var valuesPerRow = Math.ceil(shape[1] / 2);
+    return "\n    vec4 " + funcName + "(int row, int col) {\n      vec2 uv = packedUVfrom2D(" + valuesPerRow + ", " + packedTexShape[0] + ", " + packedTexShape[1] + ", row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler2D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17439,15 +18495,15 @@ function getSampler2D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col) {\n        int index = row * " + shape[1] + " + col;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col) {\n        float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2(0.5, (float(index) + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2(0.5, (index + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     if (texNumR === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2((float(index) + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2((index + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n  float " + funcName + "(int row, int col) {\n    vec2 uv = UVfrom2D(" + texNumR + ", " + texNumC + ", " + shape[1] + ", row, col);\n    return sampleTexture(" + texName + ", uv);\n  }\n";
 }
@@ -17465,18 +18521,31 @@ function getSampler3D(inputInfo) {
         return "\n        " + getSamplerFromInInfo(newInputInfo) + "\n        float " + funcName + "(int row, int col, int depth) {\n          return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n        }\n      ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth) {\n        int index = row * " + stride0 + " + col * " + stride1 + " + depth;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth) {\n        float index = dot(vec3(row, col, depth),\n                          vec3(" + stride0 + ", " + stride1 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n        float " + funcName + "(int row, int col, int depth) {\n          int texR = row;\n          int texC = col * " + stride1 + " + depth;\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
+        return "\n        float " + funcName + "(int row, int col, int depth) {\n          float texR = float(row);\n          float texC = dot(vec2(col, depth), vec2(" + stride1 + ", 1));\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
     }
     if (texNumC === stride1) {
-        return "\n    float " + funcName + "(int row, int col, int depth) {\n      int texR = row * " + shape[1] + " + col;\n      int texC = depth;\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col, int depth) {\n      float texR = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      float texC = float(depth);\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n      float " + funcName + "(int row, int col, int depth) {\n        vec2 uv = UVfrom3D(\n            " + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ", row, col, depth);\n        return sampleTexture(" + texName + ", uv);\n      }\n  ";
+}
+function getPackedSampler4D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texNumR = packedTexShape[0];
+    var texNumC = packedTexShape[1];
+    var valuesPerRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    vec4 " + funcName + "(int b2, int b, int row, int col) {\n      vec2 uv = packedUVfrom4D(\n        " + texNumR + ", " + texNumC + ", " + texelsInBatch2 + ",\n        " + texelsInBatch + ", " + valuesPerRow + ", b2, b, row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler4D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17492,16 +18561,16 @@ function getSampler4D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float index = dot(vec4(row, col, depth, depth2),\n                          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = float(row);\n        float texC =\n            dot(vec3(col, depth, depth2), vec3(" + stride1 + ", " + stride2 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride2) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = dot(vec3(row, col, depth),\n                         vec3(" + shape[1] * shape[2] + ", " + shape[2] + ", 1));\n        float texC = float(depth2);\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2) {\n      vec2 uv = UVfrom4D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", row, col, depth, depth2);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17520,16 +18589,16 @@ function getSampler5D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " +\n                   depth2 * " + stride3 + " + depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride3) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " +\n                   depth * " + shape[3] + " + depth2;\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] + ", " + shape[2] * shape[3] + ",\n            " + shape[3] + ", 1));\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n      vec2 uv = UVfrom5D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", row, col, depth, depth2, depth3);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17549,16 +18618,16 @@ function getSampler6D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3 * " + stride3 + "\n            + depth4\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          dot(\n            vec2(depth3, depth4),\n            vec2(" + stride4 + ", 1));\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", " + stride4 + ")) + depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride4) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] * shape[4] + ",\n               " + shape[2] * shape[3] * shape[4] + ",\n               " + shape[3] * shape[4] + ",\n               " + shape[4] + ")) + depth3;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n      vec2 uv = UVfrom6D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", " + stride4 + "\n          ,row, col, depth, depth2, depth3, depth4);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17687,7 +18756,7 @@ function getSqueezedParams(params, keptDims) {
     return keptDims.map(function (d) { return params[d]; }).join(', ');
 }
 
-},{"../../ops/broadcast_util":139,"../../util":194}],124:[function(require,module,exports){
+},{"../../ops/broadcast_util":151,"../../util":214}],134:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17751,7 +18820,7 @@ function getCoords(rank) {
     }
 }
 
-},{"./shader_compiler":123}],125:[function(require,module,exports){
+},{"./shader_compiler":133}],135:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17789,9 +18858,10 @@ var StridedSliceProgram = (function () {
 }());
 exports.StridedSliceProgram = StridedSliceProgram;
 
-},{"./shader_compiler":123}],126:[function(require,module,exports){
+},{"./shader_compiler":133}],136:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var util = require("../../util");
 var TextureUsage;
 (function (TextureUsage) {
     TextureUsage[TextureUsage["RENDER"] = 0] = "RENDER";
@@ -17801,9 +18871,11 @@ var TextureUsage;
 })(TextureUsage = exports.TextureUsage || (exports.TextureUsage = {}));
 var PhysicalTextureType;
 (function (PhysicalTextureType) {
-    PhysicalTextureType[PhysicalTextureType["FLOAT16"] = 0] = "FLOAT16";
-    PhysicalTextureType[PhysicalTextureType["FLOAT32"] = 1] = "FLOAT32";
-    PhysicalTextureType[PhysicalTextureType["UNSIGNED_BYTE"] = 2] = "UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT16"] = 0] = "UNPACKED_FLOAT16";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT32"] = 1] = "UNPACKED_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_4X1_UNSIGNED_BYTE"] = 2] = "PACKED_4X1_UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT32"] = 3] = "PACKED_2X2_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT16"] = 4] = "PACKED_2X2_FLOAT16";
 })(PhysicalTextureType = exports.PhysicalTextureType || (exports.PhysicalTextureType = {}));
 function getUnpackedMatrixTextureShapeWidthHeight(rows, columns) {
     return [columns, rows];
@@ -17871,118 +18943,130 @@ function getPackedRGBAArraySizeFromMatrixShape(rows, columns) {
     return w * h * 4;
 }
 exports.getPackedRGBAArraySizeFromMatrixShape = getPackedRGBAArraySizeFromMatrixShape;
-function encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA) {
+function encodeMatrixToPackedRGBA(matrix, batches, rows, columns, packedRGBA) {
     var requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
     if (packedRGBA.length < requiredSize) {
-        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >= " + requiredSize);
+        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >=\n        " + requiredSize);
     }
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    {
-        var dstStride = (oddWidth ? 4 : 0);
-        var oneRow = columns;
-        var dst = 0;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            var matrixSrcRow = (blockY * 2 * columns);
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                var matrixSrcCol = blockX * 2;
-                var src = matrixSrcRow + matrixSrcCol;
-                packedRGBA[dst] = matrix[src];
-                packedRGBA[dst + 1] = matrix[src + 1];
-                packedRGBA[dst + 2] = matrix[src + oneRow];
-                packedRGBA[dst + 3] = matrix[src + oneRow + 1];
-                dst += 4;
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var sourceOffset = batch * rows * columns;
+        var batchOffset = batch * flattenedMatrixSize;
+        {
+            var dstStride = (oddWidth ? 4 : 0);
+            var oneRow = columns;
+            var dst = batchOffset;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                var matrixSrcRow = (blockY * 2 * columns);
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    var matrixSrcCol = blockX * 2;
+                    var src = sourceOffset + matrixSrcRow + matrixSrcCol;
+                    packedRGBA[dst] = matrix[src];
+                    packedRGBA[dst + 1] = matrix[src + 1];
+                    packedRGBA[dst + 2] = matrix[src + oneRow];
+                    packedRGBA[dst + 3] = matrix[src + oneRow + 1];
+                    dst += 4;
+                }
+                dst += dstStride;
             }
-            dst += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = columns - 1;
-        var dst = (textureWidth - 1) * 4;
-        var srcStride = 2 * columns;
-        var dstStride = textureWidth * 4;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            packedRGBA[dst] = matrix[src];
-            packedRGBA[dst + 2] = matrix[src + columns];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + columns - 1;
+            var dst = batchOffset + (texelsPerRow - 1) * 4;
+            var srcStride = 2 * columns;
+            var dstStride = texelsPerRow * 4;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                packedRGBA[dst] = matrix[src];
+                packedRGBA[dst + 2] = matrix[src + columns];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (rows - 1) * columns;
-        var dst = (textureHeight - 1) * textureWidth * 4;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            packedRGBA[dst++] = matrix[src++];
-            packedRGBA[dst++] = matrix[src++];
-            dst += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (rows - 1) * columns;
+            var dst = batchOffset + (texelsPerBatch - texelsPerRow) * 4;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                packedRGBA[dst++] = matrix[src++];
+                packedRGBA[dst++] = matrix[src++];
+                dst += 2;
+            }
+            if (oddWidth && oddHeight) {
+                packedRGBA[batchOffset + flattenedMatrixSize - 4] = matrix[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        packedRGBA[packedRGBA.length - 4] = matrix[matrix.length - 1];
     }
     return packedRGBA;
 }
 exports.encodeMatrixToPackedRGBA = encodeMatrixToPackedRGBA;
-function decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix) {
+function decodeMatrixFromPackedRGBA(packedRGBA, batches, rows, columns, matrix) {
     var requiredSize = rows * columns;
-    if (requiredSize < matrix.length) {
+    if (matrix.length < requiredSize) {
         throw new Error("matrix length (" + matrix.length + ") must be >= " + requiredSize);
     }
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
-    {
-        var srcStride = oddWidth ? 4 : 0;
-        var dstStride = columns + (oddWidth ? 1 : 0);
-        var src = 0;
-        var dstRow1 = 0;
-        var dstRow2 = columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var batchOffset = batch * rows * columns;
+        var sourceOffset = batch * flattenedMatrixSize;
+        {
+            var srcStride = oddWidth ? 4 : 0;
+            var dstStride = columns + (oddWidth ? 1 : 0);
+            var src = sourceOffset;
+            var dstRow1 = batchOffset;
+            var dstRow2 = batchOffset + columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                }
+                src += srcStride;
+                dstRow1 += dstStride;
+                dstRow2 += dstStride;
             }
-            src += srcStride;
-            dstRow1 += dstStride;
-            dstRow2 += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = (textureWidth - 1) * 4;
-        var dst = columns - 1;
-        var srcStride = textureWidth * 4;
-        var dstStride = 2 * columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            matrix[dst] = packedRGBA[src];
-            matrix[dst + columns] = packedRGBA[src + 2];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + (texelsPerRow - 1) * 4;
+            var dst = batchOffset + columns - 1;
+            var srcStride = texelsPerRow * 4;
+            var dstStride = 2 * columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                matrix[dst] = packedRGBA[src];
+                matrix[dst + columns] = packedRGBA[src + 2];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (textureHeight - 1) * textureWidth * 4;
-        var dst = (rows - 1) * columns;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            matrix[dst++] = packedRGBA[src++];
-            matrix[dst++] = packedRGBA[src++];
-            src += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (texelsPerBatch - texelsPerRow) * 4;
+            var dst = batchOffset + (rows - 1) * columns;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                matrix[dst++] = packedRGBA[src++];
+                matrix[dst++] = packedRGBA[src++];
+                src += 2;
+            }
+            if (oddWidth) {
+                matrix[batchOffset + (rows * columns) - 1] = packedRGBA[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        matrix[matrix.length - 1] = packedRGBA[packedRGBA.length - 4];
     }
     return matrix;
 }
 exports.decodeMatrixFromPackedRGBA = decodeMatrixFromPackedRGBA;
 
-},{}],127:[function(require,module,exports){
+},{"../../util":214}],137:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
@@ -17996,9 +19080,9 @@ var TextureManager = (function () {
         this.logEnabled = false;
         this.usedTextures = {};
     }
-    TextureManager.prototype.acquireTexture = function (shapeRC, usage) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(usage);
-        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType);
+    TextureManager.prototype.acquireTexture = function (shapeRC, usage, isPacked) {
+        var physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
+        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18016,24 +19100,34 @@ var TextureManager = (function () {
         this.numUsedTextures++;
         this.log();
         var newTexture;
-        if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT32) {
+        if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32) {
+            newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16) {
+            newTexture =
+                this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32) {
             newTexture =
                 this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT16) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16) {
             newTexture =
                 this.gpgpu.createFloat16MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNSIGNED_BYTE) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE) {
             newTexture =
                 this.gpgpu.createUnsignedBytesMatrixTexture(shapeRC[0], shapeRC[1]);
         }
         this.usedTextures[shapeKey].push(newTexture);
         return newTexture;
     };
-    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType);
-        var shapeKey = getKeyFromTextureShape(shape, physicalTexType);
+    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType, isPacked) {
+        if (this.freeTextures == null) {
+            return;
+        }
+        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+        var shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18085,26 +19179,31 @@ var TextureManager = (function () {
     return TextureManager;
 }());
 exports.TextureManager = TextureManager;
-function getPhysicalFromLogicalTextureType(logicalTexType) {
-    if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
+function getPhysicalFromLogicalTextureType(logicalTexType, isPacked) {
+    if (isPacked) {
+        return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32 :
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    else if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
         logicalTexType === tex_util_1.TextureUsage.PIXELS) {
-        return tex_util_1.PhysicalTextureType.UNSIGNED_BYTE;
+        return tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.UPLOAD) {
-        return tex_util_1.PhysicalTextureType.FLOAT32;
+        return tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.RENDER) {
         return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-            tex_util_1.PhysicalTextureType.FLOAT32 :
-            tex_util_1.PhysicalTextureType.FLOAT16;
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32 :
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16;
     }
     throw new Error("Unknown logical texture type " + logicalTexType);
 }
-function getKeyFromTextureShape(shapeRowsCol, physicalTexType) {
-    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType;
+function getKeyFromTextureShape(shapeRowsCol, physicalTexType, isPacked) {
+    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType + "_" + isPacked;
 }
 
-},{"../../environment":64,"./tex_util":126}],128:[function(require,module,exports){
+},{"../../environment":64,"./tex_util":136}],138:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18140,7 +19239,7 @@ function getSourceCoords(aShape) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],129:[function(require,module,exports){
+},{"./shader_compiler":133}],139:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18173,7 +19272,7 @@ function getSwitchedCoords(newDim) {
     return switchedCoords.join();
 }
 
-},{"./shader_compiler":123}],130:[function(require,module,exports){
+},{"./shader_compiler":133}],140:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var erf_util = require("../../ops/erf_util");
@@ -18240,12 +19339,33 @@ exports.RECIPROCAL = "return 1.0 / x;";
 exports.LOGICAL_NOT = "return float(!(x >= 1.0));";
 exports.TO_INT = "return float(int(x));";
 
-},{"../../ops/erf_util":146,"../../ops/selu_util":166}],131:[function(require,module,exports){
+},{"../../ops/erf_util":159,"../../ops/selu_util":183}],141:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var MAX_TEXTURE_SIZE = null;
-var util = require("../../util");
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var UnpackProgram = (function () {
+    function UnpackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var sourceCoords = packing_util_1.getSourceCoords(rank, channels);
+        var innerDims = packing_util_1.getInnerDims(rank, channels);
+        var coords = rank === 1 ? 'rc' : innerDims.join(',');
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n        vec2 modCoord = mod(vec2(" + coords + "), 2.);\n        vec4 packedInput = getA(" + sourceCoords + ");\n\n        setOutput(\n          modCoord.x == 0. ?\n            (modCoord.y == 0. ? packedInput.r : packedInput.g) :\n            (modCoord.y == 0. ? packedInput.b : packedInput.a)\n        );\n      }\n    ";
+    }
+    return UnpackProgram;
+}());
+exports.UnpackProgram = UnpackProgram;
+
+},{"../packing_util":86,"./shader_compiler":133}],142:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 function createWebGLRenderingContext(attributes) {
     var canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -18396,15 +19516,6 @@ function createStaticIndexBuffer(gl, data) {
     return buffer;
 }
 exports.createStaticIndexBuffer = createStaticIndexBuffer;
-function queryMaxTextureSize(gl) {
-    if (MAX_TEXTURE_SIZE != null) {
-        return MAX_TEXTURE_SIZE;
-    }
-    MAX_TEXTURE_SIZE =
-        callAndCheck(gl, function () { return gl.getParameter(gl.MAX_TEXTURE_SIZE); });
-    return MAX_TEXTURE_SIZE;
-}
-exports.queryMaxTextureSize = queryMaxTextureSize;
 function getNumChannels() {
     if (environment_1.ENV.get('WEBGL_VERSION') === 2) {
         return 1;
@@ -18416,8 +19527,8 @@ function createTexture(gl) {
     return throwIfNull(gl, function () { return gl.createTexture(); }, 'Unable to create WebGLTexture.');
 }
 exports.createTexture = createTexture;
-function validateTextureSize(gl, width, height) {
-    var maxTextureSize = queryMaxTextureSize(gl);
+function validateTextureSize(width, height) {
+    var maxTextureSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
     if ((width <= 0) || (height <= 0)) {
         var requested = "[" + width + "x" + height + "]";
         throw new Error('Requested texture size ' + requested + ' is invalid.');
@@ -18523,12 +19634,19 @@ function validateTextureUnit(gl, textureUnit) {
         throw new Error("textureUnit must be in " + textureUnitRange + ".");
     }
 }
-function getTextureShapeFromLogicalShape(gl, logShape) {
+function getTextureShapeFromLogicalShape(logShape, isPacked) {
+    if (isPacked === void 0) { isPacked = false; }
+    var maxTexSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    if (isPacked) {
+        maxTexSize = maxTexSize * 2;
+        logShape = logShape.map(function (d, i) { return i >= logShape.length - 2 ?
+            util.nearestLargerEven(logShape[i]) :
+            logShape[i]; });
+    }
     if (logShape.length !== 2) {
         var squeezeResult = util.squeezeShape(logShape);
         logShape = squeezeResult.newShape;
     }
-    var maxTexSize = queryMaxTextureSize(gl);
     var size = util.sizeFromShape(logShape);
     if (logShape.length <= 1 && size <= maxTexSize) {
         return [size, 1];
@@ -18537,9 +19655,18 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
         logShape[1] <= maxTexSize) {
         return logShape;
     }
+    else if (logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+        logShape[2] <= maxTexSize) {
+        return [logShape[0] * logShape[1], logShape[2]];
+    }
     else if (logShape.length === 3 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] <= maxTexSize) {
         return [logShape[0], logShape[1] * logShape[2]];
+    }
+    else if (logShape.length === 4 &&
+        logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+        logShape[3] <= maxTexSize) {
+        return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
     }
     else if (logShape.length === 4 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
@@ -18551,7 +19678,7 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
 }
 exports.getTextureShapeFromLogicalShape = getTextureShapeFromLogicalShape;
 
-},{"../../environment":64,"../../util":194}],132:[function(require,module,exports){
+},{"../../environment":64,"../../util":214}],143:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var array_ops_1 = require("../ops/array_ops");
@@ -18573,7 +19700,7 @@ function whereImpl(condShape, condVals) {
 }
 exports.whereImpl = whereImpl;
 
-},{"../ops/array_ops":134}],133:[function(require,module,exports){
+},{"../ops/array_ops":146}],144:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -18598,7 +19725,13 @@ function log() {
 }
 exports.log = log;
 
-},{"./environment":64}],134:[function(require,module,exports){
+},{"./environment":64}],145:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var confusion_matrix_1 = require("./ops/confusion_matrix");
+exports.confusionMatrix = confusion_matrix_1.confusionMatrix;
+
+},{"./ops/confusion_matrix":156}],146:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -18997,9 +20130,10 @@ function stack_(tensors, axis) {
 function batchToSpaceND_(x, blockShape, crops) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'batchToSpaceND');
     var prod = blockShape.reduce(function (a, b) { return a * b; });
-    util.assert($x.rank >= 1 + blockShape.length, "input rank should be > than [blockShape] but got " + $x.rank);
-    util.assert(crops.length === blockShape.length, "crops.shape[0] must be equal to [blockShape] but got " + crops.length);
-    util.assert($x.shape[0] % prod === 0, "input tensor batch must be divisible by prod( blockShape )");
+    util.assert($x.rank >= 1 + blockShape.length, "input rank is " + $x.rank + " but should be > than blockShape.length " + blockShape.length);
+    util.assert(crops.length === blockShape.length, "crops.length is " + crops.length + " but should be equal to blockShape.length  " + blockShape.length);
+    util.assert($x.shape[0] % prod === 0, "input tensor batch is " + $x.shape[0] + " but is not divisible by the product of " +
+        ("the elements of blockShape " + blockShape.join(' * ') + " === " + prod));
     var grad = function (dy) {
         return { $x: function () { return dy.spaceToBatchND(blockShape, crops); } };
     };
@@ -19126,7 +20260,7 @@ exports.tile = operation_1.op({ tile_: tile_ });
 exports.truncatedNormal = operation_1.op({ truncatedNormal_: truncatedNormal_ });
 exports.unstack = operation_1.op({ unstack_: unstack_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_split":142,"./operation":156,"./rand":159,"./tensor_ops":171}],135:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_split":154,"./operation":171,"./rand":174,"./tensor_ops":191}],147:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getReshaped(inputShape, blockShape, prod, batchToSpace) {
@@ -19224,7 +20358,7 @@ function getSliceSize(uncroppedShape, crops, blockShape) {
 }
 exports.getSliceSize = getSliceSize;
 
-},{}],136:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -19314,7 +20448,7 @@ function getInnerMostAxes(numAxes, rank) {
 }
 exports.getInnerMostAxes = getInnerMostAxes;
 
-},{"../util":194}],137:[function(require,module,exports){
+},{"../util":214}],149:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19534,7 +20668,7 @@ exports.batchNormalization3d = operation_1.op({ batchNormalization3d_: batchNorm
 exports.batchNormalization4d = operation_1.op({ batchNormalization4d_: batchNormalization4d_ });
 exports.batchNormalization = operation_1.op({ batchNormalization_: batchNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],138:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],150:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19900,7 +21034,7 @@ exports.squaredDifferenceStrict = operation_1.op({ squaredDifferenceStrict_: squ
 exports.sub = operation_1.op({ sub_: sub_ });
 exports.subStrict = operation_1.op({ subStrict_: subStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../types":193,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],139:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../types":213,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],151:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getBroadcastDims(inShape, outShape) {
@@ -19970,7 +21104,7 @@ function assertAndGetBroadcastShape(shapeA, shapeB) {
 }
 exports.assertAndGetBroadcastShape = assertAndGetBroadcastShape;
 
-},{}],140:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20074,7 +21208,7 @@ exports.lessStrict = operation_1.op({ lessStrict_: lessStrict_ });
 exports.notEqual = operation_1.op({ notEqual_: notEqual_ });
 exports.notEqualStrict = operation_1.op({ notEqualStrict_: notEqualStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],141:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],153:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20100,7 +21234,7 @@ exports.complex = operation_1.op({ complex_: complex_ });
 exports.real = operation_1.op({ real_: real_ });
 exports.imag = operation_1.op({ imag_: imag_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],142:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],154:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20126,6 +21260,7 @@ function concat_(tensors, axis) {
     if (axis === void 0) { axis = 0; }
     util_1.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     var $tensors = tensor_util_env_1.convertToTensorArray(tensors, 'tensors', 'concat');
+    axis = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var outShape = concat_util_1.computeOutShape($tensors.map(function (t) { return t.shape; }), axis);
     if (util_1.sizeFromShape(outShape) === 0) {
         return tensor_ops_1.tensor([], outShape);
@@ -20134,16 +21269,15 @@ function concat_(tensors, axis) {
     if ($tensors.length === 1) {
         return $tensors[0];
     }
-    var axes = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var shapes = $tensors.map(function (t) { return t.shape; });
-    concat_util_1.assertParamsConsistent(shapes, axes);
+    concat_util_1.assertParamsConsistent(shapes, axis);
     var der = function (dy) {
         var sizeSplits = shapes.map(function (s) { return s[axis]; });
         var derTensors = exports.split(dy, sizeSplits, axis);
         return derTensors.map(function (t) { return function () { return t; }; });
     };
     var inputs = $tensors;
-    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axes); }, inputs, der);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axis); }, inputs, der);
 }
 function split_(x, numOrSizeSplits, axis) {
     if (axis === void 0) { axis = 0; }
@@ -20168,7 +21302,7 @@ exports.concat3d = operation_1.op({ concat3d_: concat3d_ });
 exports.concat4d = operation_1.op({ concat4d_: concat4d_ });
 exports.split = operation_1.op({ split_: split_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_util":143,"./operation":156,"./tensor_ops":171}],143:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_util":155,"./operation":171,"./tensor_ops":191}],155:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -20198,13 +21332,40 @@ function computeOutShape(shapes, axis) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194}],144:[function(require,module,exports){
+},{"../util":214}],156:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tensor_util_env_1 = require("../tensor_util_env");
+var util = require("../util");
+var array_ops_1 = require("./array_ops");
+var operation_1 = require("./operation");
+function confusionMatrix_(labels, predictions, numClasses) {
+    var $labels = tensor_util_env_1.convertToTensor(labels, 'label', 'confusionMatrix', 'int32');
+    var $predictions = tensor_util_env_1.convertToTensor(predictions, 'label', 'confusionMatrix', 'int32');
+    util.assert(numClasses == null || numClasses > 0 && Number.isInteger(numClasses), "If provided, numClasses must be a positive integer, " +
+        ("but got " + numClasses));
+    util.assert($labels.rank === 1, "Expected the rank of labels to be 1, but got " + $labels.rank);
+    util.assert($predictions.rank === 1, "Expected the rank of predictions to be 1, " +
+        ("but got " + $predictions.rank));
+    util.assert($labels.shape[0] === $predictions.shape[0], "Mismatch in the number of examples: " +
+        ($labels.shape[0] + " vs. " + $predictions.shape[0] + ". ") +
+        "Labels and predictions should have the same number of elements.");
+    util.assert(numClasses > 0 && Number.isInteger(numClasses), "numClasses is required to be a positive integer, but got " + numClasses);
+    var oneHotLabels = array_ops_1.oneHot($labels, numClasses);
+    var oneHotPredictions = array_ops_1.oneHot($predictions, numClasses);
+    return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+exports.confusionMatrix_ = confusionMatrix_;
+exports.confusionMatrix = operation_1.op({ confusionMatrix_: confusionMatrix_ });
+
+},{"../tensor_util_env":210,"../util":214,"./array_ops":146,"./operation":171}],157:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
+var matmul_1 = require("./matmul");
 var operation_1 = require("./operation");
 function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) {
     if (dataFormat === void 0) { dataFormat = 'NWC'; }
@@ -20226,7 +21387,7 @@ function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) 
     }
     util.assert(x3D.shape[2] === $filter.shape[1], "Error in conv1d: depth of input (" + x3D.shape[2] + ") must match " +
         ("input depth for filter " + $filter.shape[1] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
         ("Got stride " + stride + " and dilation '" + dilation + "'"));
     util.assert(dataFormat === 'NWC', "Error in conv1d: got dataFormat of " + dataFormat + " but only NWC is currently supported.");
     var filter4D = $filter.as4D(1, $filter.shape[0], $filter.shape[1], $filter.shape[2]);
@@ -20260,19 +21421,30 @@ function conv2d_(x, filter, strides, pad, dataFormat, dilations, dimRoundingMode
     }
     util.assert(x4D.shape[3] === $filter.shape[2], "Error in conv2d: depth of input (" + x4D.shape[3] + ") must match " +
         ("input depth for filter " + $filter.shape[2] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert(dataFormat === 'NHWC', "Error in conv2d: got dataFormat of " + dataFormat + " but only NHWC is currently supported.");
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
-    var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
-            ("yet supported in gradients. Got dilations '" + dilations + "'"));
-        return {
-            x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
-            $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+    var res;
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' || convInfo.padInfo.type === 'VALID')) {
+        var x2d = x4D.reshape([-1, convInfo.inChannels]);
+        var w2d = $filter.reshape([convInfo.inChannels, convInfo.outChannels]);
+        res = matmul_1.matMul(x2d, w2d).reshape(convInfo.outShape);
+    }
+    else {
+        var grad = function (dy) {
+            util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+                ("yet supported in gradients. Got dilations '" + dilations + "'"));
+            return {
+                x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
+                $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+            };
         };
-    };
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+        res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+    }
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20306,8 +21478,15 @@ function conv2dDerInput_(xShape, dy, filter, strides, pad, dimRoundingMode) {
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
     var dilations = 1;
+    var grad = function (ddx) {
+        var dataFormat = 'NHWC';
+        return {
+            dy4D: function () { return exports.conv2d(ddx, filter, strides, pad, dataFormat, dilations, dimRoundingMode); },
+            filter: function () { return exports.conv2dDerFilter(ddx, dy4D, filter.shape, strides, pad, dimRoundingMode); }
+        };
+    };
     var convInfo = conv_util.computeConv2DInfo(xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D });
+    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D, filter: filter }, grad);
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20366,7 +21545,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     if (dilations == null) {
         dilations = [1, 1];
     }
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in depthwiseConv2d: pad must be an integer when using, " +
@@ -20374,7 +21553,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     }
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode, true);
     var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+        util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
             ("1 are not yet supported. Got dilations '" + dilations + "'"));
         return {
             x: function () { return depthwiseConv2dDerInput(x4D.shape, dy, $filter, convInfo); },
@@ -20426,16 +21605,6 @@ function separableConv2d_(x, depthwiseFilter, pointwiseFilter, strides, pad, dil
     }
     return res;
 }
-function parseTupleParam(param) {
-    return typeof param === 'number' ? [param, param] : param;
-}
-function tupleValuesAreOne(param) {
-    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
-    return dimA === 1 && dimB === 1;
-}
-function eitherStridesOrDilationsAreOne(strides, dilations) {
-    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
-}
 function depthwiseConv2dDerInput(xShape, dy, filter, convInfo) {
     var dy4D = dy;
     var reshapedTo4D = false;
@@ -20462,15 +21631,16 @@ function depthwiseConv2dDerFilter(x, dy, filterShape, convInfo) {
 }
 exports.conv1d = operation_1.op({ conv1d_: conv1d_ });
 exports.conv2d = operation_1.op({ conv2d_: conv2d_ });
+exports.conv2dDerFilter = operation_1.op({ conv2dDerFilter_: conv2dDerFilter_ });
 exports.depthwiseConv2d = operation_1.op({ depthwiseConv2d_: depthwiseConv2d_ });
 exports.separableConv2d = operation_1.op({ separableConv2d_: separableConv2d_ });
 exports.conv2dTranspose = operation_1.op({ conv2dTranspose_: conv2dTranspose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],145:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./matmul":168,"./operation":171}],158:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
-function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, dataFormat) {
+function computePool2DInfo(inShape, filterSize, strides, dilations, pad, roundingMode, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var _a = parseTupleParam(filterSize), filterHeight = _a[0], filterWidth = _a[1];
     var filterShape;
@@ -20483,7 +21653,6 @@ function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, data
     else {
         throw new Error("Unknown dataFormat " + dataFormat);
     }
-    var dilations = 1;
     return computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundingMode, false, dataFormat);
 }
 exports.computePool2DInfo = computePool2DInfo;
@@ -20528,6 +21697,8 @@ function computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundi
         strideWidth: strideWidth,
         filterHeight: filterHeight,
         filterWidth: filterWidth,
+        effectiveFilterHeight: effectiveFilterHeight,
+        effectiveFilterWidth: effectiveFilterWidth,
         dilationHeight: dilationHeight,
         dilationWidth: dilationWidth,
         inShape: inShape,
@@ -20612,8 +21783,17 @@ function conditionalRound(value, roundingMode) {
             throw new Error("Unknown roundingMode " + roundingMode);
     }
 }
+function tupleValuesAreOne(param) {
+    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
+    return dimA === 1 && dimB === 1;
+}
+exports.tupleValuesAreOne = tupleValuesAreOne;
+function eitherStridesOrDilationsAreOne(strides, dilations) {
+    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+exports.eitherStridesOrDilationsAreOne = eitherStridesOrDilationsAreOne;
 
-},{"../util":194}],146:[function(require,module,exports){
+},{"../util":214}],159:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ERF_P = 0.3275911;
@@ -20623,7 +21803,64 @@ exports.ERF_A3 = 1.421413741;
 exports.ERF_A4 = -1.453152027;
 exports.ERF_A5 = 1.061405429;
 
-},{}],147:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function gatherND_(x, indices) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'gatherND', 'int32');
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'gatherND');
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.gatherND($x, $indices); }, { $x: $x, $indices: $indices });
+}
+exports.gatherND = operation_1.op({ gatherND_: gatherND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],161:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function prepareAndValidate(tensor, indices) {
+    if (tensor.rank < 1) {
+        throw new Error('tf.gatherND() expects the input to be rank 1 or higher,' +
+            (" but the rank was " + tensor.rank + "."));
+    }
+    if (indices.rank < 1) {
+        throw new Error('tf.gatherND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error('tf.gatherND() expects the indices to be int32 type,' +
+            (" but the dtype was " + indices.dtype + "."));
+    }
+    if (indices.shape[indices.rank - 1] > tensor.rank) {
+        throw new Error('index innermost dimension length must be <= tensor rank; saw: ' +
+            (indices.shape[indices.rank - 1] + " vs. " + tensor.rank));
+    }
+    if (tensor.size === 0) {
+        throw new Error('Requested more than 0 entries, but input is empty.' +
+            (" Input shape: " + tensor.shape + "."));
+    }
+    var indicesShape = indices.shape;
+    var sliceRank = indicesShape[indicesShape.length - 1];
+    var nResult = 1;
+    for (var i = 0; i < indicesShape.length - 1; ++i) {
+        nResult *= indicesShape[i];
+    }
+    var inputShape = tensor.shape;
+    var resultShape = indicesShape.slice();
+    resultShape.pop();
+    var sliceSize = 1;
+    for (var i = sliceRank; i < tensor.rank; ++i) {
+        sliceSize *= inputShape[i];
+        resultShape.push(inputShape[i]);
+    }
+    var strides = util_1.computeStrides(tensor.shape).map(function (stride) { return stride / sliceSize; }).concat([1]).slice(0, sliceRank);
+    return [resultShape, nResult, sliceSize, strides];
+}
+exports.prepareAndValidate = prepareAndValidate;
+
+},{"../util":214}],162:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -20818,7 +22055,7 @@ exports.nonMaxSuppression = operation_1.op({ nonMaxSuppression_: nonMaxSuppressi
 exports.nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
 exports.cropAndResize = cropAndResize_;
 
-},{"../environment":64,"../kernels/non_max_suppression_impl":84,"../tensor_util_env":190,"../util":194,"./operation":156}],148:[function(require,module,exports){
+},{"../environment":64,"../kernels/non_max_suppression_impl":85,"../tensor_util_env":210,"../util":214,"./operation":171}],163:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20964,7 +22201,7 @@ function qr2d(x, fullMatrices) {
 exports.gramSchmidt = operation_1.op({ gramSchmidt_: gramSchmidt_ });
 exports.qr = operation_1.op({ qr_: qr_ });
 
-},{"../environment":64,"../globals":66,"../util":194,"./array_ops":134,"./concat_split":142,"./norm":155,"./operation":156,"./reduction_ops":161,"./tensor_ops":171}],149:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../util":214,"./array_ops":146,"./concat_split":154,"./norm":170,"./operation":171,"./reduction_ops":176,"./tensor_ops":191}],164:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21081,7 +22318,7 @@ exports.logicalXor = operation_1.op({ logicalXor_: logicalXor_ });
 exports.where = operation_1.op({ where_: where_ });
 exports.whereAsync = whereAsync_;
 
-},{"../environment":64,"../kernels/where_impl":132,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],150:[function(require,module,exports){
+},{"../environment":64,"../kernels/where_impl":143,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],165:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var globals_1 = require("../globals");
@@ -21306,7 +22543,7 @@ exports.meanSquaredError = operation_1.op({ meanSquaredError_: meanSquaredError_
 exports.sigmoidCrossEntropy = operation_1.op({ sigmoidCrossEntropy_: sigmoidCrossEntropy_ });
 exports.softmaxCrossEntropy = operation_1.op({ softmaxCrossEntropy_: softmaxCrossEntropy_ });
 
-},{"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],151:[function(require,module,exports){
+},{"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],166:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21343,7 +22580,7 @@ function localResponseNormalization_(x, depthRadius, bias, alpha, beta) {
 }
 exports.localResponseNormalization = operation_1.op({ localResponseNormalization_: localResponseNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],152:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],167:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21392,7 +22629,7 @@ function basicLSTMCell_(forgetBias, lstmKernel, lstmBias, data, c, h) {
 exports.basicLSTMCell = operation_1.op({ basicLSTMCell_: basicLSTMCell_ });
 exports.multiRNNCell = operation_1.op({ multiRNNCell_: multiRNNCell_ });
 
-},{"../tensor_util_env":190,"./operation":156}],153:[function(require,module,exports){
+},{"../tensor_util_env":210,"./operation":171}],168:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21488,7 +22725,7 @@ exports.matMul = operation_1.op({ matMul_: matMul_ });
 exports.dot = operation_1.op({ dot_: dot_ });
 exports.outerProduct = operation_1.op({ outerProduct_: outerProduct_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],154:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],169:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_1 = require("../tensor_util");
@@ -21516,7 +22753,7 @@ function movingAverage_(v, x, decay, step, zeroDebias) {
 }
 exports.movingAverage = operation_1.op({ movingAverage_: movingAverage_ });
 
-},{"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],155:[function(require,module,exports){
+},{"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],170:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21579,7 +22816,7 @@ function normImpl(x, p, axis) {
 }
 exports.norm = operation_1.op({ norm_: norm_ });
 
-},{"../tensor_util_env":190,"./axis_util":136,"./operation":156,"./tensor_ops":171}],156:[function(require,module,exports){
+},{"../tensor_util_env":210,"./axis_util":148,"./operation":171,"./tensor_ops":191}],171:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21619,7 +22856,7 @@ function op(f) {
 }
 exports.op = op;
 
-},{"../environment":64}],157:[function(require,module,exports){
+},{"../environment":64}],172:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -21650,6 +22887,10 @@ __export(require("./lstm"));
 __export(require("./moving_average"));
 __export(require("./strided_slice"));
 __export(require("./topk"));
+__export(require("./scatter_nd"));
+__export(require("./spectral_ops"));
+__export(require("./sparse_to_dense"));
+__export(require("./gather_nd"));
 var operation_1 = require("./operation");
 exports.op = operation_1.op;
 var losses = require("./loss_ops");
@@ -21658,8 +22899,10 @@ var linalg = require("./linalg_ops");
 exports.linalg = linalg;
 var image = require("./image_ops");
 exports.image = image;
+var spectral = require("./spectral_ops");
+exports.spectral = spectral;
 
-},{"./array_ops":134,"./batchnorm":137,"./binary_ops":138,"./compare":140,"./complex_ops":141,"./concat_split":142,"./conv":144,"./image_ops":147,"./linalg_ops":148,"./logical_ops":149,"./loss_ops":150,"./lrn":151,"./lstm":152,"./matmul":153,"./moving_average":154,"./norm":155,"./operation":156,"./pool":158,"./reduction_ops":161,"./relu_ops":162,"./reverse":163,"./segment_ops":164,"./slice":167,"./softmax":169,"./strided_slice":170,"./tensor_ops":171,"./topk":172,"./transpose":173,"./unary_ops":174}],158:[function(require,module,exports){
+},{"./array_ops":146,"./batchnorm":149,"./binary_ops":150,"./compare":152,"./complex_ops":153,"./concat_split":154,"./conv":157,"./gather_nd":160,"./image_ops":162,"./linalg_ops":163,"./logical_ops":164,"./loss_ops":165,"./lrn":166,"./lstm":167,"./matmul":168,"./moving_average":169,"./norm":170,"./operation":171,"./pool":173,"./reduction_ops":176,"./relu_ops":177,"./reverse":178,"./scatter_nd":179,"./segment_ops":181,"./slice":184,"./softmax":186,"./sparse_to_dense":187,"./spectral_ops":189,"./strided_slice":190,"./tensor_ops":191,"./topk":192,"./transpose":193,"./unary_ops":194}],173:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21667,7 +22910,7 @@ var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
 var operation_1 = require("./operation");
-function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'maxPool');
     var x4D = $x;
     var reshapedTo4D = false;
@@ -21675,18 +22918,21 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
         reshapedTo4D = true;
         x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
     }
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
     util.assert(x4D.rank === 4, "Error in maxPool: input must be rank 4 but got rank " + x4D.rank + ".");
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in maxPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var grad = function (dy, saved) {
         var y4D = saved[0];
         return {
-            x: function () {
-                return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, pad);
-            }
+            x: function () { return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, dilations, pad); }
         };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.maxPool(x4D, convInfo)); }, { x: x4D }, grad);
@@ -21695,9 +22941,17 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return maxPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function avgPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'avgPool');
     util.assert($x.dtype === 'float32', 'The input dtype to avgPool must be float32');
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var x4D = $x;
     var reshapedTo4D = false;
     if ($x.rank === 3) {
@@ -21709,9 +22963,11 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
         util.assert(util.isInt(pad), "Error in avgPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad);
     var grad = function (dy) {
-        return { x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, pad); } };
+        return {
+            x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, dilations, pad); }
+        };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPool(x4D, convInfo); }, { x: x4D }, grad);
     res = res.cast($x.dtype);
@@ -21720,11 +22976,33 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundingMode) {
+function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return avgPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function pool_(input, windowShape, poolingType, padding, dilationRate, strides) {
+    if (dilationRate == null) {
+        dilationRate = 1;
+    }
+    if (strides == null) {
+        strides = 1;
+    }
+    if (poolingType === 'avg') {
+        return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+    else {
+        return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+}
+function maxPoolBackprop(dy, input, output, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'maxPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'maxPoolBackprop');
     var $output = tensor_util_env_1.convertToTensor(output, 'output', 'maxPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPoolBackProp: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert($dy.rank === 4, "Error in maxPoolBackprop: dy must be rank 4 but got rank " +
         ($dy.rank + "."));
     util.assert($input.rank === 4, "Error in maxPoolBackprop: input must be rank 4 but got rank " +
@@ -21733,14 +23011,19 @@ function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundin
         util.assert(util.isInt(pad), "Error in maxPoolBackprop: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.maxPoolBackprop($dy, $input, $output, convInfo); }, { $dy: $dy, $input: $input });
     return res;
 }
-function avgPoolBackprop(dy, input, filterSize, strides, pad) {
+function avgPoolBackprop(dy, input, filterSize, strides, dilations, pad) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'avgPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'avgPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPoolBackprop: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var input4D = $input;
     var dy4D = $dy;
     var reshapedTo4D = false;
@@ -21753,7 +23036,7 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
         (dy4D.rank + "."));
     util.assert(input4D.rank === 4, "Error in avgPoolBackprop: input must be rank 4 but got rank " +
         (input4D.rank + "."));
-    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, dilations, pad);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPoolBackprop(dy4D, input4D, convInfo); }, { dy4D: dy4D, input4D: input4D });
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
@@ -21762,8 +23045,9 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
 }
 exports.maxPool = operation_1.op({ maxPool_: maxPool_ });
 exports.avgPool = operation_1.op({ avgPool_: avgPool_ });
+exports.pool = operation_1.op({ pool_: pool_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],159:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./operation":171}],174:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var seedrandom = require("seedrandom");
@@ -21821,7 +23105,7 @@ var MPRandGauss = (function () {
 }());
 exports.MPRandGauss = MPRandGauss;
 
-},{"seedrandom":281}],160:[function(require,module,exports){
+},{"seedrandom":305}],175:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -21834,7 +23118,7 @@ function computeOptimalWindowSize(inSize) {
 }
 exports.computeOptimalWindowSize = computeOptimalWindowSize;
 
-},{"../util":194}],161:[function(require,module,exports){
+},{"../util":214}],176:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21895,6 +23179,28 @@ function sum_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function prod_(x, axis, keepDims) {
+    if (axis === void 0) { axis = null; }
+    if (keepDims === void 0) { keepDims = false; }
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'prod');
+    if ($x.dtype === 'bool') {
+        $x = $x.toInt();
+    }
+    var axes = axis_util.parseAxisParam(axis, $x.shape);
+    var permutation = axis_util.getAxesPermutation(axes, $x.rank);
+    var reductionAxes = axes;
+    var permutedX = $x;
+    if (permutation != null) {
+        permutedX = $x.transpose(permutation);
+        reductionAxes = axis_util.getInnerMostAxes(reductionAxes.length, $x.rank);
+    }
+    var value = environment_1.ENV.engine.runKernel(function (backend) { return backend.prod(permutedX, reductionAxes); }, { permutedX: permutedX });
+    if (keepDims) {
+        var newShape = axis_util.expandShapeToKeepDim(value.shape, axes);
+        value = value.reshape(newShape);
+    }
+    return value;
+}
 function mean_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
@@ -21921,10 +23227,26 @@ function mean_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes) {
+    var y = saved[0];
+    if (y.rank < xOrig.rank) {
+        y = y.reshape(axis_util.expandShapeToKeepDim(y.shape, origAxes));
+    }
+    if (dy.rank < xOrig.rank) {
+        dy = dy.reshape(axis_util.expandShapeToKeepDim(dy.shape, origAxes));
+    }
+    return {
+        $x: function () {
+            var dx = dy.mul(xOrig.equal(y).cast(dy.dtype));
+            return permutedAxes == null ? dx : dx.transpose(permutedAxes);
+        }
+    };
+}
 function min_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'min');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -21932,10 +23254,13 @@ function min_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.min($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.min($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -21943,6 +23268,7 @@ function max_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'max');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -21950,10 +23276,13 @@ function max_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.max($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.max($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22053,8 +23382,9 @@ exports.mean = operation_1.op({ mean_: mean_ });
 exports.min = operation_1.op({ min_: min_ });
 exports.moments = operation_1.op({ moments_: moments_ });
 exports.sum = operation_1.op({ sum_: sum_ });
+exports.prod = operation_1.op({ prod_: prod_ });
 
-},{"../environment":64,"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156,"./tensor_ops":171}],162:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171,"./tensor_ops":191}],177:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22120,7 +23450,7 @@ exports.prelu = operation_1.op({ prelu_: prelu_ });
 exports.relu = operation_1.op({ relu_: relu_ });
 exports.selu = operation_1.op({ selu_: selu_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./binary_ops":138,"./logical_ops":149,"./operation":156,"./selu_util":166,"./tensor_ops":171}],163:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./binary_ops":150,"./logical_ops":164,"./operation":171,"./selu_util":183,"./tensor_ops":191}],178:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22166,7 +23496,99 @@ exports.reverse2d = operation_1.op({ reverse2d_: reverse2d_ });
 exports.reverse3d = operation_1.op({ reverse3d_: reverse3d_ });
 exports.reverse4d = operation_1.op({ reverse4d_: reverse4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],164:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],179:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+var scatter_nd_util = require("./scatter_nd_util");
+function scatterND_(indices, updates, shape) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'scatterND', 'int32');
+    var $updates = tensor_util_env_1.convertToTensor(updates, 'updates', 'scatterND');
+    scatter_nd_util.validateInput($updates, $indices, shape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.scatterND($indices, $updates, shape); }, { $indices: $indices, $updates: $updates });
+}
+exports.scatterND = operation_1.op({ scatterND_: scatterND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171,"./scatter_nd_util":180}],180:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function validateUpdateShape(shape, indices, updates) {
+    var sliceDim = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var batchDim = (indices.rank > 1) ? indices.rank - 1 : 1;
+    var shapeError = 'Must have updates.shape = indices.shape[:batchDim] + ' +
+        ("shape[sliceDim:], got updates.shape: " + updates.shape) +
+        (", indices.shape: " + indices.shape + ", shape: " + shape) +
+        (", sliceDim: " + sliceDim + ", and batchDim: " + batchDim + ".");
+    if (updates.rank < batchDim) {
+        throw new Error(shapeError + (" update.rank < " + batchDim + ". "));
+    }
+    if (shape.length < sliceDim + (updates.rank - batchDim)) {
+        throw new Error(shapeError +
+            (" Output shape length < " + (sliceDim + (updates.rank - batchDim))));
+    }
+    if (updates.rank !== batchDim + shape.length - sliceDim) {
+        throw new Error(shapeError + (" update.rank != " + (batchDim + shape.length - sliceDim)));
+    }
+    for (var d = 0; d < batchDim; ++d) {
+        if (updates.shape[d] !== indices.shape[d]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + d + "] (" + updates.shape[d] + ") != indices.shape[" + d + "] (" + indices.shape[d] + ")."));
+        }
+    }
+    for (var d = 0; d < updates.rank - batchDim; ++d) {
+        if (updates.shape[d + batchDim] !== shape[d + sliceDim]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + (d + batchDim) + "] (" + updates.shape[d + batchDim] + ") != shape[" + (d + batchDim) + "] (" + shape[d + batchDim] + ")"));
+        }
+    }
+}
+exports.validateUpdateShape = validateUpdateShape;
+function validateInput(updates, indices, shape) {
+    if (indices.rank < 1) {
+        throw new Error('tf.scatterND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (updates.rank < 1) {
+        throw new Error('tf.scatterND() expects the updates to be rank 1 or higher,' +
+            (" but the rank was " + updates.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error("The dtype of 'indices' should be int32, but got dtype: " + indices.dtype);
+    }
+    if (shape.length < 1) {
+        throw new Error("Output rank must be greater or equal to 1, but got shape: " + shape);
+    }
+    if (shape.length === 0) {
+        if (indices.size === 0) {
+            throw new Error("Indices specified for empty output. indices shape: " + indices.shape);
+        }
+        if (updates.size === 0) {
+            throw new Error("Updates specified for empty output. updates shape: " + updates.shape);
+        }
+    }
+    validateUpdateShape(shape, indices, updates);
+}
+exports.validateInput = validateInput;
+function calculateShapes(updates, indices, shape) {
+    var sliceRank = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var totalNd = shape.length;
+    var sliceSize = 1;
+    for (var i = sliceRank; i < totalNd; ++i) {
+        sliceSize *= shape[i];
+    }
+    var safeSliceDim = (sliceRank < 1) ? 1 : sliceRank;
+    var numUpdates = indices.size / safeSliceDim;
+    var outputStrides = util_1.computeStrides(shape).concat([1]);
+    var strides = outputStrides.slice(outputStrides.length - sliceRank, outputStrides.length);
+    var outputSize = util_1.sizeFromShape(shape);
+    return { sliceRank: sliceRank, numUpdates: numUpdates, sliceSize: sliceSize, strides: strides, outputSize: outputSize };
+}
+exports.calculateShapes = calculateShapes;
+
+},{"../util":214}],181:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22258,7 +23680,7 @@ function gatherDropNegatives(x, indices) {
 exports.gather = operation_1.op({ gather_: gather_ });
 exports.unsortedSegmentSum = operation_1.op({ unsortedSegmentSum_: unsortedSegmentSum_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./axis_util":136,"./binary_ops":138,"./compare":140,"./logical_ops":149,"./operation":156,"./tensor_ops":171}],165:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./axis_util":148,"./binary_ops":150,"./compare":152,"./logical_ops":164,"./operation":171,"./tensor_ops":191}],182:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22300,13 +23722,13 @@ function computeOutShape(aShape, axis, numSegments) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194,"./reduce_util":160}],166:[function(require,module,exports){
+},{"../util":214,"./reduce_util":175}],183:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SELU_SCALEALPHA = 1.7580993408473768599402175208123;
 exports.SELU_SCALE = 1.0507009873554804934193349852946;
 
-},{}],167:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22321,17 +23743,17 @@ function slice1d_(x, begin, size) {
 }
 function slice2d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice2d');
-    util.assert($x.rank === 2, "slice1d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 2, "slice2d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice3d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice3d');
-    util.assert($x.rank === 3, "slice1d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 3, "slice3d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice4d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice4d');
-    util.assert($x.rank === 4, "slice1d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 4, "slice4d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice_(x, begin, size) {
@@ -22388,7 +23810,7 @@ exports.slice2d = operation_1.op({ slice2d_: slice2d_ });
 exports.slice3d = operation_1.op({ slice3d_: slice3d_ });
 exports.slice4d = operation_1.op({ slice4d_: slice4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./slice_util":168}],168:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./slice_util":185}],185:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -22479,7 +23901,7 @@ function stopForAxis(endMask, stopIndices, strides, inputShape, axis) {
 }
 exports.stopForAxis = stopForAxis;
 
-},{"../util":194}],169:[function(require,module,exports){
+},{"../util":214}],186:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gradients_1 = require("../gradients");
@@ -22511,7 +23933,67 @@ function softmax_(logits, dim) {
 }
 exports.softmax = operation_1.op({ softmax_: softmax_ });
 
-},{"../gradients":67,"../tensor_util_env":190,"./operation":156}],170:[function(require,module,exports){
+},{"../gradients":67,"../tensor_util_env":210,"./operation":171}],187:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var sparse_to_dense = require("../ops/sparse_to_dense_util");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function sparseToDense_(sparseIndices, sparseValues, outputShape, defaultValue) {
+    var $sparseIndices = tensor_util_env_1.convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
+    var $sparseValues = tensor_util_env_1.convertToTensor(sparseValues, 'sparseValues', 'sparseToDense');
+    var $defaultValue = tensor_util_env_1.convertToTensor(defaultValue, 'defaultValue', 'sparseToDense');
+    sparse_to_dense.validateInput($sparseIndices, $sparseValues, outputShape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.sparseToDense($sparseIndices, $sparseValues, outputShape, $defaultValue); }, { $sparseIndices: $sparseIndices, $sparseValues: $sparseValues, $defaultValue: $defaultValue });
+}
+exports.sparseToDense = operation_1.op({ sparseToDense_: sparseToDense_ });
+
+},{"../environment":64,"../ops/sparse_to_dense_util":188,"../tensor_util_env":210,"./operation":171}],188:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateInput(sparseIndices, sparseValues, outputShape) {
+    if (sparseIndices.dtype !== 'int32') {
+        throw new Error('tf.sparseToDense() expects the indices to be int32 type,' +
+            (" but the dtype was " + sparseIndices.dtype + "."));
+    }
+    if (sparseIndices.rank > 2) {
+        throw new Error('sparseIndices should be a scalar, vector, or matrix,' +
+            (" but got shape " + sparseIndices.shape + "."));
+    }
+    var numElems = sparseIndices.rank > 0 ? sparseIndices.shape[0] : 1;
+    var numDims = sparseIndices.rank > 1 ? sparseIndices.shape[1] : 1;
+    if (outputShape.length !== numDims) {
+        throw new Error('outputShape has incorrect number of elements:,' +
+            (" " + outputShape.length + ", should be: " + numDims + "."));
+    }
+    var numValues = sparseValues.size;
+    if (!(sparseValues.rank === 0 ||
+        sparseValues.rank === 1 && numValues === numElems)) {
+        throw new Error('sparseValues has incorrect shape ' +
+            (sparseValues.shape + ", should be [] or [" + numElems + "]"));
+    }
+}
+exports.validateInput = validateInput;
+
+},{}],189:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var operation_1 = require("../ops/operation");
+var util_1 = require("../util");
+function fft_(input) {
+    util_1.assert(input.dtype === 'complex64', "The dtype for tf.spectral.fft() must be complex64 " +
+        ("but got " + input.dtype + "."));
+    var innerDimensionSize = input.shape[input.shape.length - 1];
+    var batch = input.size / innerDimensionSize;
+    var input2D = input.as2D(batch, innerDimensionSize);
+    var ret = environment_1.ENV.engine.runKernel(function (backend) { return backend.fft(input2D); }, { input: input });
+    return ret.reshape(input.shape);
+}
+exports.fft = operation_1.op({ fft_: fft_ });
+
+},{"../environment":64,"../ops/operation":171,"../util":214}],190:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22534,12 +24016,13 @@ function stridedSlice_(x, begin, end, strides, beginMask, endMask, ellipsisMask,
 }
 exports.stridedSlice = operation_1.op({ stridedSlice_: stridedSlice_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],171:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],191:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_1 = require("../tensor");
 var tensor_util_env_1 = require("../tensor_util_env");
+var tensor_util_env_2 = require("../tensor_util_env");
 var util_1 = require("../util");
 var complex_ops_1 = require("./complex_ops");
 var operation_1 = require("./operation");
@@ -22554,7 +24037,7 @@ function tensor(values, shape, dtype) {
         throw new Error('values passed to tensor(values) must be an ' +
             'array of numbers or booleans, or a TypedArray');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (shape != null && inferredShape.length !== 1) {
         util_1.assertShapesMatch(shape, inferredShape, "Error creating a new Tensor. " +
             ("Inferred shape (" + inferredShape + ") does not match the ") +
@@ -22581,7 +24064,7 @@ exports.scalar = scalar;
 function tensor1d(values, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     util_1.assertNonNull(values);
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 1) {
         throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
@@ -22594,7 +24077,7 @@ function tensor2d(values, shape, dtype) {
     if (shape != null && shape.length !== 2) {
         throw new Error('tensor2d() requires shape to have two numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
         throw new Error('tensor2d() requires values to be number[][] or flat/TypedArray');
     }
@@ -22612,7 +24095,7 @@ function tensor3d(values, shape, dtype) {
     if (shape != null && shape.length !== 3) {
         throw new Error('tensor3d() requires shape to have three numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
         throw new Error('tensor3d() requires values to be number[][][] or flat/TypedArray');
     }
@@ -22630,7 +24113,7 @@ function tensor4d(values, shape, dtype) {
     if (shape != null && shape.length !== 4) {
         throw new Error('tensor4d() requires shape to have four numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
         throw new Error('tensor4d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22648,7 +24131,7 @@ function tensor5d(values, shape, dtype) {
     if (shape != null && shape.length !== 5) {
         throw new Error('tensor5d() requires shape to have five numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 5 && inferredShape.length !== 1) {
         throw new Error('tensor5d() requires values to be ' +
             'number[][][][][] or flat/TypedArray');
@@ -22667,7 +24150,7 @@ function tensor6d(values, shape, dtype) {
     if (shape != null && shape.length !== 6) {
         throw new Error('tensor6d() requires shape to have six numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 6 && inferredShape.length !== 1) {
         throw new Error('tensor6d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22758,7 +24241,7 @@ exports.range = range;
 exports.onesLike = operation_1.op({ onesLike_: onesLike_ });
 exports.zerosLike = operation_1.op({ zerosLike_: zerosLike_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./complex_ops":141,"./operation":156}],172:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./complex_ops":153,"./operation":171}],192:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22781,7 +24264,7 @@ function topk_(x, k, sorted) {
 }
 exports.topk = operation_1.op({ topk_: topk_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],173:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],193:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22811,7 +24294,7 @@ function transpose_(x, perm) {
 }
 exports.transpose = operation_1.op({ transpose_: transpose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],174:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],194:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23101,7 +24584,7 @@ exports.step = operation_1.op({ step_: step_ });
 exports.tan = operation_1.op({ tan_: tan_ });
 exports.tanh = operation_1.op({ tanh_: tanh_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./tensor_ops":171}],175:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./tensor_ops":191}],195:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23208,7 +24691,7 @@ var AdadeltaOptimizer = (function (_super) {
 exports.AdadeltaOptimizer = AdadeltaOptimizer;
 serialization_1.registerClass(AdadeltaOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],176:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],196:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23290,7 +24773,7 @@ var AdagradOptimizer = (function (_super) {
 exports.AdagradOptimizer = AdagradOptimizer;
 serialization_1.registerClass(AdagradOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],177:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],197:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23409,7 +24892,7 @@ var AdamOptimizer = (function (_super) {
 exports.AdamOptimizer = AdamOptimizer;
 serialization_1.registerClass(AdamOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],178:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],198:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23530,7 +25013,7 @@ var AdamaxOptimizer = (function (_super) {
 exports.AdamaxOptimizer = AdamaxOptimizer;
 serialization_1.registerClass(AdamaxOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],179:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],199:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23620,7 +25103,7 @@ var MomentumOptimizer = (function (_super) {
 exports.MomentumOptimizer = MomentumOptimizer;
 serialization_1.registerClass(MomentumOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./sgd_optimizer":183}],180:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./sgd_optimizer":203}],200:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23661,7 +25144,7 @@ var Optimizer = (function (_super) {
 }(serialization_1.Serializable));
 exports.Optimizer = Optimizer;
 
-},{"../globals":66,"../serialization":185}],181:[function(require,module,exports){
+},{"../globals":66,"../serialization":205}],201:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./adadelta_optimizer");
@@ -23717,7 +25200,7 @@ var OptimizerConstructors = (function () {
 }());
 exports.OptimizerConstructors = OptimizerConstructors;
 
-},{"./adadelta_optimizer":175,"./adagrad_optimizer":176,"./adam_optimizer":177,"./adamax_optimizer":178,"./momentum_optimizer":179,"./rmsprop_optimizer":182,"./sgd_optimizer":183}],182:[function(require,module,exports){
+},{"./adadelta_optimizer":195,"./adagrad_optimizer":196,"./adam_optimizer":197,"./adamax_optimizer":198,"./momentum_optimizer":199,"./rmsprop_optimizer":202,"./sgd_optimizer":203}],202:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23861,7 +25344,7 @@ var RMSPropOptimizer = (function (_super) {
 exports.RMSPropOptimizer = RMSPropOptimizer;
 serialization_1.registerClass(RMSPropOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],183:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],203:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23921,7 +25404,7 @@ var SGDOptimizer = (function (_super) {
 exports.SGDOptimizer = SGDOptimizer;
 serialization_1.registerClass(SGDOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],184:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],204:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("./util");
@@ -23945,7 +25428,11 @@ var Profiler = (function () {
             var vals = r.dataSync();
             util.checkComputationForNaN(vals, r.dtype, name);
             timer.then(function (timing) {
-                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+                var extraInfo = '';
+                if (timing.getExtraProfileInfo != null) {
+                    extraInfo = timing.getExtraProfileInfo();
+                }
+                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
             });
         });
         return result;
@@ -23956,19 +25443,19 @@ exports.Profiler = Profiler;
 var Logger = (function () {
     function Logger() {
     }
-    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs) {
+    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs, extraInfo) {
         var time = util.rightPad(timeMs + "ms", 9);
         var paddedName = util.rightPad(name, 25);
         var rank = result.rank;
         var size = result.size;
         var shape = util.rightPad(result.shape.toString(), 14);
-        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size + "\t%c" + extraInfo, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange', 'color: green');
     };
     return Logger;
 }());
 exports.Logger = Logger;
 
-},{"./util":194}],185:[function(require,module,exports){
+},{"./util":214}],205:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -24013,7 +25500,7 @@ function registerClass(cls) {
 }
 exports.registerClass = registerClass;
 
-},{"./util":194}],186:[function(require,module,exports){
+},{"./util":214}],206:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -24126,7 +25613,7 @@ function backpropagateGradients(tensorAccumulatedGradientMap, filteredTape) {
 }
 exports.backpropagateGradients = backpropagateGradients;
 
-},{"./tensor":187,"./util":194}],187:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],207:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24512,6 +25999,12 @@ var Tensor = (function () {
         if (keepDims === void 0) { keepDims = false; }
         this.throwIfDisposed();
         return opHandler.sum(this, axis, keepDims);
+    };
+    Tensor.prototype.prod = function (axis, keepDims) {
+        if (axis === void 0) { axis = null; }
+        if (keepDims === void 0) { keepDims = false; }
+        this.throwIfDisposed();
+        return opHandler.prod(this, axis, keepDims);
     };
     Tensor.prototype.mean = function (axis, keepDims) {
         if (axis === void 0) { axis = null; }
@@ -24913,6 +26406,10 @@ var Tensor = (function () {
         if (beta === void 0) { beta = 0.5; }
         return opHandler.localResponseNormalization(this, radius, bias, alpha, beta);
     };
+    Tensor.prototype.pool = function (windowShape, poolingType, padding, dilationRate, strides) {
+        this.throwIfDisposed();
+        return opHandler.pool(this, windowShape, poolingType, padding, dilationRate, strides);
+    };
     Tensor.prototype.variable = function (trainable, name, dtype) {
         if (trainable === void 0) { trainable = true; }
         this.throwIfDisposed();
@@ -24945,6 +26442,10 @@ var Tensor = (function () {
     Tensor.prototype.depthToSpace = function (blockSize, dataFormat) {
         this.throwIfDisposed();
         return opHandler.depthToSpace(this, blockSize, dataFormat);
+    };
+    Tensor.prototype.fft = function () {
+        this.throwIfDisposed();
+        return opHandler.spectral.fft(this);
     };
     Tensor.nextId = 0;
     return Tensor;
@@ -25008,7 +26509,7 @@ Object.defineProperty(Variable, Symbol.hasInstance, {
 var variable = Variable.variable;
 exports.variable = variable;
 
-},{"./tensor_format":188,"./util":194}],188:[function(require,module,exports){
+},{"./tensor_format":208,"./util":214}],208:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -25139,7 +26640,7 @@ function createComplexTuples(vals) {
     return complexTuples;
 }
 
-},{"./util":194}],189:[function(require,module,exports){
+},{"./util":214}],209:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -25214,12 +26715,47 @@ function isIterable(obj) {
     return Array.isArray(obj) || typeof obj === 'object';
 }
 
-},{"./tensor":187,"./util":194}],190:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],210:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
 var tensor_1 = require("./tensor");
 var util_1 = require("./util");
+function inferShape(val) {
+    var firstElem = val;
+    if (util_1.isTypedArray(val)) {
+        return [val.length];
+    }
+    if (!Array.isArray(val)) {
+        return [];
+    }
+    var shape = [];
+    while (firstElem instanceof Array) {
+        shape.push(firstElem.length);
+        firstElem = firstElem[0];
+    }
+    if (val instanceof Array && environment_1.ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+        deepAssertShapeConsistency(val, shape, []);
+    }
+    return shape;
+}
+exports.inferShape = inferShape;
+function deepAssertShapeConsistency(val, shape, indices) {
+    indices = indices || [];
+    if (!(val instanceof Array)) {
+        util_1.assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
+            ("but should be an array of " + shape[0] + " elements"); });
+        return;
+    }
+    util_1.assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
+        ("but is an array of " + val.length + " elements"); });
+    util_1.assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
+        ("elements, but has " + val.length + " elements"); });
+    var subShape = shape.slice(1);
+    for (var i = 0; i < val.length; ++i) {
+        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
+    }
+}
 function convertToTensor(x, argName, functionName, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     dtype = dtype || 'float32';
@@ -25231,7 +26767,7 @@ function convertToTensor(x, argName, functionName, dtype) {
         throw new Error("Argument '" + argName + "' passed to '" + functionName + "' must be a " +
             ("Tensor or TensorLike, but got " + x.constructor.name));
     }
-    var inferredShape = util_1.inferShape(x);
+    var inferredShape = inferShape(x);
     if (!util_1.isTypedArray(x) && !Array.isArray(x)) {
         x = [x];
     }
@@ -25248,7 +26784,7 @@ function convertToTensorArray(arg, argName, functionName) {
 }
 exports.convertToTensorArray = convertToTensorArray;
 
-},{"./environment":64,"./tensor":187,"./util":194}],191:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],211:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -25268,6 +26804,9 @@ exports.BROWSER_ENVS = {
 };
 exports.CPU_ENVS = {
     'HAS_WEBGL': false
+};
+exports.BROWSER_CPU_ENVS = {
+    'BACKEND': 'test-cpu'
 };
 exports.ALL_ENVS = {};
 function expectArraysClose(actual, expected, epsilon) {
@@ -25369,7 +26908,7 @@ function expectArrayBuffersEqual(actual, expected) {
 }
 exports.expectArrayBuffersEqual = expectArrayBuffersEqual;
 
-},{"./environment":64,"./tensor":187,"./util":194}],192:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],212:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./optimizers/adadelta_optimizer");
@@ -25392,7 +26931,7 @@ exports.train = {
     adam: optimizer_constructors_1.OptimizerConstructors.adam
 };
 
-},{"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer_constructors":181,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183}],193:[function(require,module,exports){
+},{"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer_constructors":201,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203}],213:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DType;
@@ -25454,7 +26993,7 @@ function sumOutType(type) {
 }
 exports.sumOutType = sumOutType;
 
-},{}],194:[function(require,module,exports){
+},{}],214:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -25475,6 +27014,18 @@ function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 exports.clamp = clamp;
+function nearestLargerEven(val) {
+    return val % 2 === 0 ? val : val + 1;
+}
+exports.nearestLargerEven = nearestLargerEven;
+function sum(arr) {
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) {
+        sum += arr[i];
+    }
+    return sum;
+}
+exports.sum = sum;
 function randUniform(a, b) {
     var r = Math.random();
     return (b * r) + (1 - r) * a;
@@ -25517,41 +27068,6 @@ function flatten(arr, ret) {
     return ret;
 }
 exports.flatten = flatten;
-function inferShape(val) {
-    var firstElem = val;
-    if (isTypedArray(val)) {
-        return [val.length];
-    }
-    if (!Array.isArray(val)) {
-        return [];
-    }
-    var shape = [];
-    while (firstElem instanceof Array) {
-        shape.push(firstElem.length);
-        firstElem = firstElem[0];
-    }
-    if (val instanceof Array) {
-        deepAssertShapeConsistency(val, shape, []);
-    }
-    return shape;
-}
-exports.inferShape = inferShape;
-function deepAssertShapeConsistency(val, shape, indices) {
-    indices = indices || [];
-    if (!(val instanceof Array)) {
-        assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
-            ("but should be an array of " + shape[0] + " elements"); });
-        return;
-    }
-    assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
-        ("but is an array of " + val.length + " elements"); });
-    assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
-        ("elements, but has " + val.length + " elements"); });
-    var subShape = shape.slice(1);
-    for (var i = 0; i < val.length; ++i) {
-        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
-    }
-}
 function sizeFromShape(shape) {
     if (shape.length === 0) {
         return 1;
@@ -25568,6 +27084,12 @@ function isScalarShape(shape) {
 }
 exports.isScalarShape = isScalarShape;
 function arraysEqual(n1, n2) {
+    if (n1 === n2) {
+        return true;
+    }
+    if (n1 == null || n2 == null) {
+        return false;
+    }
     if (n1.length !== n2.length) {
         return false;
     }
@@ -25885,13 +27407,13 @@ function now() {
 exports.now = now;
 
 }).call(this,require('_process'))
-},{"_process":269}],195:[function(require,module,exports){
+},{"_process":293}],215:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.17';
+var version = '0.13.8';
 exports.version = version;
 
-},{}],196:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gpgpu_util = require("./kernels/webgl/gpgpu_util");
@@ -25903,7 +27425,7 @@ exports.MathBackendWebGL = backend_webgl_1.MathBackendWebGL;
 var gpgpu_context_1 = require("./kernels/webgl/gpgpu_context");
 exports.GPGPUContext = gpgpu_context_1.GPGPUContext;
 
-},{"./kernels/backend_webgl":82,"./kernels/webgl/gpgpu_context":104,"./kernels/webgl/gpgpu_util":106,"./kernels/webgl/webgl_util":131}],197:[function(require,module,exports){
+},{"./kernels/backend_webgl":83,"./kernels/webgl/gpgpu_context":110,"./kernels/webgl/gpgpu_util":112,"./kernels/webgl/webgl_util":142}],217:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -25945,7 +27467,7 @@ var Elu = (function (_super) {
     return Elu;
 }(Activation));
 exports.Elu = Elu;
-tfjs_core_1.serialization.SerializationMap.register(Elu);
+tfjs_core_1.serialization.registerClass(Elu);
 var Selu = (function (_super) {
     __extends(Selu, _super);
     function Selu() {
@@ -25958,7 +27480,7 @@ var Selu = (function (_super) {
     return Selu;
 }(Activation));
 exports.Selu = Selu;
-tfjs_core_1.serialization.SerializationMap.register(Selu);
+tfjs_core_1.serialization.registerClass(Selu);
 var Relu = (function (_super) {
     __extends(Relu, _super);
     function Relu() {
@@ -25971,7 +27493,7 @@ var Relu = (function (_super) {
     return Relu;
 }(Activation));
 exports.Relu = Relu;
-tfjs_core_1.serialization.SerializationMap.register(Relu);
+tfjs_core_1.serialization.registerClass(Relu);
 var Relu6 = (function (_super) {
     __extends(Relu6, _super);
     function Relu6() {
@@ -25984,7 +27506,7 @@ var Relu6 = (function (_super) {
     return Relu6;
 }(Activation));
 exports.Relu6 = Relu6;
-tfjs_core_1.serialization.SerializationMap.register(Relu6);
+tfjs_core_1.serialization.registerClass(Relu6);
 var Linear = (function (_super) {
     __extends(Linear, _super);
     function Linear() {
@@ -25997,7 +27519,7 @@ var Linear = (function (_super) {
     return Linear;
 }(Activation));
 exports.Linear = Linear;
-tfjs_core_1.serialization.SerializationMap.register(Linear);
+tfjs_core_1.serialization.registerClass(Linear);
 var Sigmoid = (function (_super) {
     __extends(Sigmoid, _super);
     function Sigmoid() {
@@ -26010,7 +27532,7 @@ var Sigmoid = (function (_super) {
     return Sigmoid;
 }(Activation));
 exports.Sigmoid = Sigmoid;
-tfjs_core_1.serialization.SerializationMap.register(Sigmoid);
+tfjs_core_1.serialization.registerClass(Sigmoid);
 var HardSigmoid = (function (_super) {
     __extends(HardSigmoid, _super);
     function HardSigmoid() {
@@ -26023,7 +27545,7 @@ var HardSigmoid = (function (_super) {
     return HardSigmoid;
 }(Activation));
 exports.HardSigmoid = HardSigmoid;
-tfjs_core_1.serialization.SerializationMap.register(HardSigmoid);
+tfjs_core_1.serialization.registerClass(HardSigmoid);
 var Softplus = (function (_super) {
     __extends(Softplus, _super);
     function Softplus() {
@@ -26036,7 +27558,7 @@ var Softplus = (function (_super) {
     return Softplus;
 }(Activation));
 exports.Softplus = Softplus;
-tfjs_core_1.serialization.SerializationMap.register(Softplus);
+tfjs_core_1.serialization.registerClass(Softplus);
 var Softsign = (function (_super) {
     __extends(Softsign, _super);
     function Softsign() {
@@ -26049,7 +27571,7 @@ var Softsign = (function (_super) {
     return Softsign;
 }(Activation));
 exports.Softsign = Softsign;
-tfjs_core_1.serialization.SerializationMap.register(Softsign);
+tfjs_core_1.serialization.registerClass(Softsign);
 var Tanh = (function (_super) {
     __extends(Tanh, _super);
     function Tanh() {
@@ -26062,7 +27584,7 @@ var Tanh = (function (_super) {
     return Tanh;
 }(Activation));
 exports.Tanh = Tanh;
-tfjs_core_1.serialization.SerializationMap.register(Tanh);
+tfjs_core_1.serialization.registerClass(Tanh);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax() {
@@ -26076,7 +27598,7 @@ var Softmax = (function (_super) {
     return Softmax;
 }(Activation));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 function serializeActivation(activation) {
     return activation.getClassName();
 }
@@ -26104,7 +27626,7 @@ function getActivation(identifier) {
 }
 exports.getActivation = getActivation;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],198:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],218:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26122,7 +27644,7 @@ function imageDataFormat() {
 }
 exports.imageDataFormat = imageDataFormat;
 
-},{"@tensorflow/tfjs-core":68}],199:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26167,7 +27689,7 @@ function disposeScalarCache() {
 }
 exports.disposeScalarCache = disposeScalarCache;
 
-},{"@tensorflow/tfjs-core":68}],200:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -26376,27 +27898,42 @@ function randomNormal(shape, mean, stddev, dtype, seed) {
 }
 exports.randomNormal = randomNormal;
 function dot(x, y) {
-    if (y.rank !== 2) {
-        throw new errors_1.NotImplementedError("dot support for y other than rank 2 is not yet implemented: " +
-            ("y shape = " + y.shape));
+    if ((x.rank < 2) || (y.rank < 2)) {
+        throw new errors_1.NotImplementedError("dot requires both inputs to be rank >= 2" +
+            (" but got x shape = " + x.shape + " and y shape = " + y.shape));
+    }
+    if (y.rank >= 3) {
+        var xLastDim = x.shape.slice(-1)[0];
+        var ySecondLastDim = y.shape.slice(-2)[0];
+        if (xLastDim !== ySecondLastDim) {
+            throw new errors_1.NotImplementedError("If rank y >= 3, then the second last dim" +
+                (" of y must equal the last dim of x but got x shape = " + x.shape + " and ") +
+                (" y shape = " + y.shape));
+        }
+    }
+    if ((x.rank === 2) && (y.rank === 2)) {
+        return tfc.matMul(x, y);
     }
     else {
-        if (x.rank === 2) {
-            return tfc.matMul(x, y);
-        }
-        else if (x.rank === 3) {
-            var xShape0 = x.shape[0];
-            var xShape1 = x.shape[1];
-            var xShape2 = x.shape[2];
-            x = x.reshape([xShape0 * xShape1, xShape2]);
-            return tfc.matMul(x, y).reshape([
-                xShape0, xShape1, y.shape[1]
-            ]);
-        }
-        else {
-            throw new errors_1.NotImplementedError("dot support for x of rank " + x.rank + " is not yet implemented: " +
-                ("x shape = " + x.shape));
-        }
+        var xFirstDims = x.shape.slice();
+        var xLastDim = xFirstDims.pop();
+        x = x.reshape([-1, xLastDim]);
+        var yShape = y.shape.slice();
+        var yLastDim = yShape.pop();
+        var ySecondLastDim = yShape.pop();
+        var yOtherDims = yShape.concat([yLastDim]);
+        var perm = Array.from({ length: y.rank }, function (_, i) {
+            if (i === 0) {
+                return y.rank - 2;
+            }
+            else if (i <= y.rank - 2) {
+                return i - 1;
+            }
+            return i;
+        });
+        y = y.transpose(perm).reshape([ySecondLastDim, -1]);
+        var outputShape = xFirstDims.concat(yOtherDims);
+        return tfc.matMul(x, y).reshape(outputShape);
     }
 }
 exports.dot = dot;
@@ -26564,7 +28101,7 @@ function inTrainPhase(x, alt, training) {
 }
 exports.inTrainPhase = inTrainPhase;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/math_utils":240,"./common":198,"@tensorflow/tfjs-core":68}],201:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/math_utils":264,"./common":218,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26614,8 +28151,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("./backend/state");
+var errors_1 = require("./errors");
 var logs_1 = require("./logs");
 var generic_utils = require("./utils/generic_utils");
+var ModelLoggingVerbosity;
+(function (ModelLoggingVerbosity) {
+    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
+    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
+})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
 var BaseCallback = (function () {
     function BaseCallback() {
         this.validationData = null;
@@ -26769,19 +28312,22 @@ var CallbackList = (function () {
                         if (logs == null) {
                             logs = {};
                         }
-                        _i = 0, _a = this.callbacks;
-                        _b.label = 1;
+                        return [4, logs_1.resolveScalarsInLogs(logs)];
                     case 1:
-                        if (!(_i < _a.length)) return [3, 4];
+                        _b.sent();
+                        _i = 0, _a = this.callbacks;
+                        _b.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3, 5];
                         callback = _a[_i];
                         return [4, callback.onBatchEnd(batch, logs)];
-                    case 2:
-                        _b.sent();
-                        _b.label = 3;
                     case 3:
+                        _b.sent();
+                        _b.label = 4;
+                    case 4:
                         _i++;
-                        return [3, 1];
-                    case 4: return [2];
+                        return [3, 2];
+                    case 5: return [2];
                 }
             });
         });
@@ -27265,8 +28811,70 @@ function standardizeCallbacks(callbacks) {
     return callbackConfigs.map(function (callbackConfig) { return new CustomCallback(callbackConfig); });
 }
 exports.standardizeCallbacks = standardizeCallbacks;
+var CallbackConstructorRegistry = (function () {
+    function CallbackConstructorRegistry() {
+    }
+    CallbackConstructorRegistry.registerCallbackConstructor = function (verbosityLevel, callbackConstructor) {
+        tfjs_core_1.util.assert(verbosityLevel >= 0 && Number.isInteger(verbosityLevel), "Verbosity level is expected to be an integer >= 0, " +
+            ("but got " + verbosityLevel));
+        CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
+        if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {
+            CallbackConstructorRegistry.constructors[verbosityLevel] = [];
+        }
+        CallbackConstructorRegistry.constructors[verbosityLevel].push(callbackConstructor);
+    };
+    CallbackConstructorRegistry.checkForDuplicate = function (callbackConstructor) {
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var constructors = CallbackConstructorRegistry.constructors[+levelName];
+            constructors.forEach(function (ctor) {
+                if (ctor === callbackConstructor) {
+                    throw new errors_1.ValueError('Duplicate callback constructor.');
+                }
+            });
+        }
+    };
+    CallbackConstructorRegistry.clear = function () {
+        CallbackConstructorRegistry.constructors = {};
+    };
+    CallbackConstructorRegistry.createCallbacks = function (verbosityLevel) {
+        var constructors = [];
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var level = +levelName;
+            if (verbosityLevel >= level) {
+                constructors.push.apply(constructors, CallbackConstructorRegistry.constructors[level]);
+            }
+        }
+        return constructors.map(function (ctor) { return new ctor(); });
+    };
+    CallbackConstructorRegistry.constructors = {};
+    return CallbackConstructorRegistry;
+}());
+exports.CallbackConstructorRegistry = CallbackConstructorRegistry;
+function configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics) {
+    var history = new History();
+    var actualCallbacks = [
+        new BaseLogger(yieldEvery)
+    ].concat(CallbackConstructorRegistry.createCallbacks(verbose));
+    if (callbacks != null) {
+        actualCallbacks.push.apply(actualCallbacks, callbacks);
+    }
+    actualCallbacks.push(history);
+    var callbackList = new CallbackList(actualCallbacks);
+    callbackList.setParams({
+        epochs: epochs,
+        initialEpoch: initialEpoch,
+        samples: numTrainSamples,
+        steps: stepsPerEpoch,
+        batchSize: batchSize,
+        verbose: verbose,
+        doValidation: doValidation,
+        metrics: callbackMetrics,
+    });
+    return { callbackList: callbackList, history: history };
+}
+exports.configureCallbacks = configureCallbacks;
 
-},{"./backend/state":199,"./logs":231,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],202:[function(require,module,exports){
+},{"./backend/state":219,"./errors":233,"./logs":255,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27298,7 +28906,7 @@ var Callback = (function (_super) {
 }(base_callbacks_1.BaseCallback));
 exports.Callback = Callback;
 
-},{"./base_callbacks":201,"./engine/training":209}],203:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/training":230}],223:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils_1 = require("./utils/generic_utils");
@@ -27367,13 +28975,13 @@ function getUniqueTensorName(scopedName) {
     }
 }
 exports.getUniqueTensorName = getUniqueTensorName;
-var tensorNameRegex = new RegExp(/^[A-Za-z][A-Za-z0-9\._\/]*$/);
+var tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
 function isValidTensorName(name) {
     return name.match(tensorNameRegex) ? true : false;
 }
 exports.isValidTensorName = isValidTensorName;
 
-},{"./utils/generic_utils":238}],204:[function(require,module,exports){
+},{"./utils/generic_utils":262}],224:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27431,7 +29039,7 @@ var MaxNorm = (function (_super) {
     return MaxNorm;
 }(Constraint));
 exports.MaxNorm = MaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MaxNorm);
+tfjs_core_1.serialization.registerClass(MaxNorm);
 var UnitNorm = (function (_super) {
     __extends(UnitNorm, _super);
     function UnitNorm(config) {
@@ -27451,7 +29059,7 @@ var UnitNorm = (function (_super) {
     return UnitNorm;
 }(Constraint));
 exports.UnitNorm = UnitNorm;
-tfjs_core_1.serialization.SerializationMap.register(UnitNorm);
+tfjs_core_1.serialization.registerClass(UnitNorm);
 var NonNeg = (function (_super) {
     __extends(NonNeg, _super);
     function NonNeg() {
@@ -27464,7 +29072,7 @@ var NonNeg = (function (_super) {
     return NonNeg;
 }(Constraint));
 exports.NonNeg = NonNeg;
-tfjs_core_1.serialization.SerializationMap.register(NonNeg);
+tfjs_core_1.serialization.registerClass(NonNeg);
 var MinMaxNorm = (function (_super) {
     __extends(MinMaxNorm, _super);
     function MinMaxNorm(config) {
@@ -27501,7 +29109,7 @@ var MinMaxNorm = (function (_super) {
     return MinMaxNorm;
 }(Constraint));
 exports.MinMaxNorm = MinMaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MinMaxNorm);
+tfjs_core_1.serialization.registerClass(MinMaxNorm);
 exports.CONSTRAINT_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'maxNorm': 'MaxNorm',
     'minMaxNorm': 'MinMaxNorm',
@@ -27537,7 +29145,7 @@ function getConstraint(identifier) {
 }
 exports.getConstraint = getConstraint;
 
-},{"./backend/common":198,"./backend/state":199,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],205:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28200,7 +29808,7 @@ var Container = (function (_super) {
             keptNodes = layer instanceof Container ? 1 : 0;
             for (var originalNodeIndex = 0; originalNodeIndex < layer.inboundNodes.length; originalNodeIndex++) {
                 var nodeKey = Container.nodeKey(layer, originalNodeIndex);
-                if (nodeKey in this.containerNodes) {
+                if (this.containerNodes.has(nodeKey)) {
                     nodeConversionMap[nodeKey] = keptNodes;
                     keptNodes += 1;
                 }
@@ -28283,7 +29891,7 @@ var Container = (function (_super) {
                             var tensorIndex = node.tensorIndices[i];
                             var nodeKey_1 = Container.nodeKey(inboundLayer, nodeIndex);
                             var newNodeIndex = nodeConversionMap[nodeKey_1];
-                            if (newNodeIndex === null || newNodeIndex === undefined) {
+                            if (newNodeIndex == null) {
                                 newNodeIndex = 0;
                             }
                             nodeData.push([inboundLayer.name, newNodeIndex, tensorIndex, kwargs]);
@@ -28404,19 +30012,20 @@ var Container = (function (_super) {
                 var layerData = layersFromConfig_2[_a];
                 var layer = createdLayers[layerData.name];
                 if (layer.name in unprocessedNodes) {
-                    for (var _b = 0, _c = unprocessedNodes[layer.name]; _b < _c.length; _b++) {
-                        var nodeData = _c[_b];
+                    var currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
+                    delete unprocessedNodes[layer.name];
+                    for (var _b = 0, currentUnprocessedNodesForLayer_1 = currentUnprocessedNodesForLayer; _b < currentUnprocessedNodesForLayer_1.length; _b++) {
+                        var nodeData = currentUnprocessedNodesForLayer_1[_b];
                         processNode(layer, nodeData);
                     }
-                    delete unprocessedNodes[layer.name];
                 }
             }
         }
         var inputTensors = [];
         var outputTensors = [];
         var inputLayersFromConfig = config.inputLayers;
-        for (var _d = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _d < inputLayersFromConfig_1.length; _d++) {
-            var layerData = inputLayersFromConfig_1[_d];
+        for (var _c = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _c < inputLayersFromConfig_1.length; _c++) {
+            var layerData = inputLayersFromConfig_1[_c];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28426,8 +30035,8 @@ var Container = (function (_super) {
             inputTensors.push(layerOutputTensors[tensorIndex]);
         }
         var outputLayersFromConfig = config.outputLayers;
-        for (var _e = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _e < outputLayersFromConfig_1.length; _e++) {
-            var layerData = outputLayersFromConfig_1[_e];
+        for (var _d = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _d < outputLayersFromConfig_1.length; _d++) {
+            var layerData = outputLayersFromConfig_1[_d];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28470,7 +30079,23 @@ var Container = (function (_super) {
 }(topology_1.Layer));
 exports.Container = Container;
 
-},{"../backend/state":199,"../errors":210,"../layers/serialization":229,"../utils/generic_utils":238,"../utils/serialization_utils":241,"../utils/types_utils":242,"../variables":244,"../version":245,"./input_layer":207,"./topology":208,"@tensorflow/tfjs-core":68}],206:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"../layers/serialization":253,"../utils/generic_utils":262,"../utils/serialization_utils":265,"../utils/types_utils":266,"../variables":268,"../version":269,"./input_layer":228,"./topology":229,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyIterator = (function () {
+    function LazyIterator() {
+    }
+    return LazyIterator;
+}());
+exports.LazyIterator = LazyIterator;
+var Dataset = (function () {
+    function Dataset() {
+    }
+    return Dataset;
+}());
+exports.Dataset = Dataset;
+
+},{}],227:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -28604,7 +30229,7 @@ function getNodeOutputs(fetch) {
     return layerOutputs;
 }
 
-},{"../errors":210,"./input_layer":207,"@tensorflow/tfjs-core":68}],207:[function(require,module,exports){
+},{"../errors":233,"./input_layer":228,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28683,10 +30308,7 @@ var InputLayer = (function (_super) {
             ("InputLayer's apply() method. InputLayer name: " + this.name));
     };
     InputLayer.prototype.dispose = function () {
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: 0
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: 0 };
     };
     InputLayer.prototype.getConfig = function () {
         return {
@@ -28700,7 +30322,7 @@ var InputLayer = (function (_super) {
     return InputLayer;
 }(topology_1.Layer));
 exports.InputLayer = InputLayer;
-tfjs_core_1.serialization.SerializationMap.register(InputLayer);
+tfjs_core_1.serialization.registerClass(InputLayer);
 function Input(config) {
     if (config.batchShape == null && config.shape == null) {
         throw new Error('Please provide to Input either a `shape`' +
@@ -28731,7 +30353,7 @@ function Input(config) {
 }
 exports.Input = Input;
 
-},{"../backend/state":199,"../errors":210,"./topology":208,"@tensorflow/tfjs-core":68}],208:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"./topology":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29419,10 +31041,7 @@ var Layer = (function (_super) {
         if (--this._refCount === 0) {
             numDisposedVariables = this.disposeWeights();
         }
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: numDisposedVariables
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: numDisposedVariables };
     };
     return Layer;
 }(tfjs_core_1.serialization.Serializable));
@@ -29473,7 +31092,7 @@ function getSourceInputs(tensor, layer, nodeIndex) {
 }
 exports.getSourceInputs = getSourceInputs;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"../utils/variable_utils":243,"../variables":244,"@tensorflow/tfjs-core":68}],209:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"../utils/variable_utils":267,"../variables":268,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29525,10 +31144,8 @@ var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
-var base_callbacks_1 = require("../base_callbacks");
 var common_1 = require("../common");
 var errors_1 = require("../errors");
-var logs_1 = require("../logs");
 var losses = require("../losses");
 var Metrics = require("../metrics");
 var optimizers = require("../optimizers");
@@ -29537,6 +31154,8 @@ var layer_utils_1 = require("../utils/layer_utils");
 var math_utils_1 = require("../utils/math_utils");
 var container_1 = require("./container");
 var executor_1 = require("./executor");
+var training_dataset_1 = require("./training_dataset");
+var training_tensors_1 = require("./training_tensors");
 function isDataTensor(x) {
     return x instanceof tfjs_core_1.Tensor;
 }
@@ -29701,46 +31320,6 @@ function checkLossAndTargetCompatibility(targets, lossFns, outputShapes) {
         }
     }
 }
-function makeBatches(size, batchSize) {
-    var output = [];
-    var batchStart = 0;
-    var batchEnd = null;
-    while (batchStart < size) {
-        batchEnd = batchStart + batchSize;
-        if (batchEnd >= size) {
-            batchEnd = size;
-        }
-        output.push([batchStart, batchEnd]);
-        batchStart = batchEnd;
-    }
-    return output;
-}
-exports.makeBatches = makeBatches;
-function sliceArrays(arrays, start, stop) {
-    if (arrays == null) {
-        return [null];
-    }
-    else if (Array.isArray(arrays)) {
-        return arrays.map(function (array) { return K.sliceAlongFirstAxis(array, start, stop - start); });
-    }
-    else {
-        return K.sliceAlongFirstAxis(arrays, start, stop - start);
-    }
-}
-function sliceArraysByIndices(arrays, indices) {
-    return tfc.tidy(function () {
-        if (arrays == null) {
-            return null;
-        }
-        else if (Array.isArray(arrays)) {
-            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
-        }
-        else {
-            return K.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
-        }
-    });
-}
-exports.sliceArraysByIndices = sliceArraysByIndices;
 function checkInputData(data, names, shapes, checkBatchAxis, exceptionPrefix) {
     if (checkBatchAxis === void 0) { checkBatchAxis = true; }
     if (exceptionPrefix === void 0) { exceptionPrefix = ''; }
@@ -29813,14 +31392,6 @@ function collectMetrics(metrics, outputNames) {
         throw new TypeError('Type of metrics argument not understood. Expected an Array or ' +
             'Object, found: ' + metrics);
     }
-}
-var ModelLoggingVerbosity;
-(function (ModelLoggingVerbosity) {
-    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
-    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
-})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
-function checkBatchSize(batchSize) {
-    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
 }
 var Model = (function (_super) {
     __extends(Model, _super);
@@ -30011,13 +31582,21 @@ var Model = (function (_super) {
     Model.prototype.evaluate = function (x, y, config) {
         if (config === void 0) { config = {}; }
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         var standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
         var ins = standardizedOuts[0].concat(standardizedOuts[1]);
         this.makeTestFunction();
         var f = this.testFunction;
         var testOuts = this.testLoop(f, ins, batchSize, config.verbose, config.steps);
         return generic_utils_1.singletonOrArray(testOuts);
+    };
+    Model.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                this.makeTestFunction();
+                return [2, training_dataset_1.evaluateDataset(this, dataset, config)];
+            });
+        });
     };
     Model.prototype.checkNumSamples = function (ins, batchSize, steps, stepsName) {
         if (stepsName === void 0) { stepsName = 'steps'; }
@@ -30122,13 +31701,13 @@ var Model = (function (_super) {
             if (verbose) {
                 throw new errors_1.NotImplementedError('Verbose predictLoop() is not implemented yet.');
             }
-            var batches = makeBatches(numSamples, batchSize);
+            var batches = training_tensors_1.makeBatches(numSamples, batchSize);
             var outs = [];
             var _loop_3 = function (batchIndex) {
                 var batchOuts = tfc.tidy(function () {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
-                    var insBatch = sliceArrays(ins, batchStart, batchEnd);
+                    var insBatch = training_tensors_1.sliceArrays(ins, batchStart, batchEnd);
                     var feeds = [];
                     if (Array.isArray(insBatch)) {
                         for (var i = 0; i < insBatch.length; ++i) {
@@ -30163,7 +31742,7 @@ var Model = (function (_super) {
         if (config === void 0) { config = {}; }
         checkInputData(x, this.inputNames, this.feedInputShapes, false);
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         return this.predictLoop(x, batchSize);
     };
     Model.prototype.predictOnBatch = function (x) {
@@ -30200,204 +31779,26 @@ var Model = (function (_super) {
         }
         return [x, y, null];
     };
-    Model.prototype.fitLoop = function (f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var doValidation, numTrainSamples, indexArray, baseLogger, callbackList, _loop_4, this_1, epoch, state_2;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (batchSize == null) {
-                            batchSize = 32;
-                        }
-                        if (epochs == null) {
-                            epochs = 1;
-                        }
-                        if (shuffle == null) {
-                            shuffle = true;
-                        }
-                        if (initialEpoch == null) {
-                            initialEpoch = 0;
-                        }
-                        doValidation = false;
-                        if (valF != null && valIns != null) {
-                            doValidation = true;
-                        }
-                        if (validationSteps != null) {
-                            doValidation = true;
-                            if (stepsPerEpoch == null) {
-                                throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
-                                    'i.e., `stepsPerEpoch` must be set.');
-                            }
-                        }
-                        numTrainSamples = this.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
-                        if (numTrainSamples != null) {
-                            indexArray = math_utils_1.range(0, numTrainSamples);
-                        }
-                        this.history = new base_callbacks_1.History();
-                        baseLogger = new base_callbacks_1.BaseLogger(yieldEvery);
-                        if (callbacks == null) {
-                            callbacks = [baseLogger];
-                        }
-                        else {
-                            callbacks = [baseLogger].concat(callbacks);
-                        }
-                        callbacks = callbacks.concat([this.history]);
-                        if (verbose > 0) {
-                            throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
-                        }
-                        callbackList = new base_callbacks_1.CallbackList(callbacks);
-                        callbackList.setModel(this);
-                        callbackList.setParams({
-                            epochs: epochs,
-                            initialEpoch: initialEpoch,
-                            samples: numTrainSamples,
-                            steps: stepsPerEpoch,
-                            batchSize: batchSize,
-                            verbose: verbose,
-                            doValidation: doValidation,
-                            metrics: callbackMetrics,
-                        });
-                        return [4, callbackList.onTrainBegin()];
-                    case 1:
-                        _a.sent();
-                        this.stopTraining_ = false;
-                        _loop_4 = function (epoch) {
-                            var epochLogs, epochIndexArray1D_1, batches_1, _loop_5, batchIndex, state_3;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4, callbackList.onEpochBegin(epoch)];
-                                    case 1:
-                                        _a.sent();
-                                        epochLogs = {};
-                                        if (!(stepsPerEpoch != null)) return [3, 2];
-                                        throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
-                                    case 2:
-                                        if (shuffle === 'batch') {
-                                            throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
-                                        }
-                                        else if (shuffle) {
-                                            tfjs_core_1.util.shuffle(indexArray);
-                                        }
-                                        epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
-                                        batches_1 = makeBatches(numTrainSamples, batchSize);
-                                        _loop_5 = function (batchIndex) {
-                                            var batchLogs;
-                                            return __generator(this, function (_a) {
-                                                switch (_a.label) {
-                                                    case 0:
-                                                        batchLogs = {};
-                                                        return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
-                                                    case 1:
-                                                        _a.sent();
-                                                        tfc.tidy(function () {
-                                                            var batchStart = batches_1[batchIndex][0];
-                                                            var batchEnd = batches_1[batchIndex][1];
-                                                            var batchIds = K.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
-                                                            batchLogs['batch'] = batchIndex;
-                                                            batchLogs['size'] = batchEnd - batchStart;
-                                                            var insBatch = sliceArraysByIndices(ins, batchIds);
-                                                            var outs = f(insBatch);
-                                                            for (var i = 0; i < outLabels.length; ++i) {
-                                                                var label = outLabels[i];
-                                                                var out = outs[i];
-                                                                batchLogs[label] = out;
-                                                                tfc.keep(out);
-                                                            }
-                                                            if (batchIndex === batches_1.length - 1) {
-                                                                if (doValidation) {
-                                                                    var valOuts = _this.testLoop(valF, valIns, batchSize);
-                                                                    for (var i = 0; i < outLabels.length; ++i) {
-                                                                        var label = outLabels[i];
-                                                                        var out = valOuts[i];
-                                                                        tfc.keep(out);
-                                                                        epochLogs['val_' + label] = out;
-                                                                    }
-                                                                }
-                                                            }
-                                                        });
-                                                        return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
-                                                    case 2:
-                                                        _a.sent();
-                                                        logs_1.disposeTensorsInLogs(batchLogs);
-                                                        if (this_1.stopTraining_) {
-                                                            return [2, "break"];
-                                                        }
-                                                        return [2];
-                                                }
-                                            });
-                                        };
-                                        batchIndex = 0;
-                                        _a.label = 3;
-                                    case 3:
-                                        if (!(batchIndex < batches_1.length)) return [3, 6];
-                                        return [5, _loop_5(batchIndex)];
-                                    case 4:
-                                        state_3 = _a.sent();
-                                        if (state_3 === "break")
-                                            return [3, 6];
-                                        _a.label = 5;
-                                    case 5:
-                                        ++batchIndex;
-                                        return [3, 3];
-                                    case 6:
-                                        epochIndexArray1D_1.dispose();
-                                        _a.label = 7;
-                                    case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
-                                    case 8:
-                                        _a.sent();
-                                        if (this_1.stopTraining_) {
-                                            return [2, "break"];
-                                        }
-                                        return [2];
-                                }
-                            });
-                        };
-                        this_1 = this;
-                        epoch = initialEpoch;
-                        _a.label = 2;
-                    case 2:
-                        if (!(epoch < epochs)) return [3, 5];
-                        return [5, _loop_4(epoch)];
-                    case 3:
-                        state_2 = _a.sent();
-                        if (state_2 === "break")
-                            return [3, 5];
-                        _a.label = 4;
-                    case 4:
-                        ++epoch;
-                        return [3, 2];
-                    case 5: return [4, callbackList.onTrainEnd()];
-                    case 6:
-                        _a.sent();
-                        return [4, this.history.syncData()];
-                    case 7:
-                        _a.sent();
-                        return [2, this.history];
-                }
-            });
-        });
-    };
     Model.prototype.testLoop = function (f, ins, batchSize, verbose, steps) {
         var _this = this;
         if (verbose === void 0) { verbose = 0; }
         return tfc.tidy(function () {
             var numSamples = _this.checkNumSamples(ins, batchSize, steps, 'steps');
             var outs = [];
-            if (verbose === 1) {
+            if (verbose > 0) {
                 throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
             }
             if (steps != null) {
                 throw new errors_1.NotImplementedError('steps mode in testLoop() is not implemented yet');
             }
             else {
-                var batches = makeBatches(numSamples, batchSize);
+                var batches = training_tensors_1.makeBatches(numSamples, batchSize);
                 var indexArray = tfjs_core_1.tensor1d(math_utils_1.range(0, numSamples));
                 for (var batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
                     var batchIds = K.sliceAlongFirstAxis(indexArray, batchStart, batchEnd - batchStart);
-                    var insBatch = sliceArraysByIndices(ins, batchIds);
+                    var insBatch = training_tensors_1.sliceArraysByIndices(ins, batchIds);
                     var batchOuts = f(insBatch);
                     if (batchIndex === 0) {
                         for (var i = 0; i < batchOuts.length; ++i) {
@@ -30430,6 +31831,54 @@ var Model = (function (_super) {
             dedupedOutLabels.push(newLabel);
         }
         return dedupedOutLabels;
+    };
+    Model.prototype.makeTrainFunction = function () {
+        var _this = this;
+        return function (data) {
+            var losses = [];
+            var lossValues = [];
+            var inputs = data.slice(0, _this.inputs.length);
+            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
+            var metricsValues = [];
+            var totalLossFunction = function () {
+                var feeds = [];
+                for (var i = 0; i < _this.inputs.length; ++i) {
+                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
+                }
+                var feedDict = new executor_1.FeedDict(feeds);
+                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
+                var totalLoss;
+                for (var i = 0; i < _this.lossFunctions.length; ++i) {
+                    var lossFunction = _this.lossFunctions[i];
+                    var loss = lossFunction(targets[i], outputs[i]);
+                    losses.push(loss);
+                    var meanLoss = tfc.mean(loss);
+                    lossValues.push(meanLoss);
+                    if (i === 0) {
+                        totalLoss = loss;
+                    }
+                    else {
+                        totalLoss = tfc.add(totalLoss, loss);
+                    }
+                }
+                for (var i = 0; i < _this.metricsTensors.length; ++i) {
+                    var metric = _this.metricsTensors[i][0];
+                    var outputIndex = _this.metricsTensors[i][1];
+                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
+                    tfc.keep(meanMetric);
+                    metricsValues.push(meanMetric);
+                }
+                totalLoss = tfc.mean(totalLoss);
+                _this.calculateLosses().forEach(function (regularizerLoss) {
+                    totalLoss = tfc.add(totalLoss, regularizerLoss);
+                });
+                return totalLoss;
+            };
+            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
+            var returnCost = true;
+            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
+            return [totalLossValue].concat(metricsValues);
+        };
     };
     Model.prototype.makeTestFunction = function () {
         var _this = this;
@@ -30469,139 +31918,15 @@ var Model = (function (_super) {
     Model.prototype.fit = function (x, y, config) {
         if (config === void 0) { config = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (this.isTraining) {
-                            throw new Error('Cannot start training because another fit() call is ongoing.');
-                        }
-                        this.isTraining = true;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, , 3, 4]);
-                        batchSize = config.batchSize == null ? 32 : config.batchSize;
-                        checkBatchSize(batchSize);
-                        standardizedOuts = this.standardizeUserData(x, y, false, batchSize);
-                        inputs = standardizedOuts[0];
-                        targets = standardizedOuts[1];
-                        doValidation = false;
-                        valX = void 0;
-                        valY = void 0;
-                        valIns = void 0;
-                        needValidationDisposal = false;
-                        if (config.validationData != null && config.validationData.length > 0) {
-                            doValidation = true;
-                            if (config.validationData.length === 2) {
-                                valX = config.validationData[0];
-                                valY = config.validationData[1];
-                            }
-                            else if (config.validationData.length === 3) {
-                                throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
-                            }
-                            else {
-                                throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
-                                    "or 3 (valX, valY, valSampleWeight) items; " +
-                                    (config.validationData + " is invalid."));
-                            }
-                            valStandardized = this.standardizeUserData(valX, valY, true, batchSize);
-                            valX = valStandardized[0];
-                            valY = valStandardized[1];
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSplit != null && config.validationSplit > 0 &&
-                            config.validationSplit < 1) {
-                            doValidation = true;
-                            splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
-                            originalBatchSize = inputs[0].shape[0];
-                            valX = sliceArrays(inputs, splitAt, originalBatchSize);
-                            inputs = sliceArrays(inputs, 0, splitAt);
-                            valY = sliceArrays(targets, splitAt, originalBatchSize);
-                            targets = sliceArrays(targets, 0, splitAt);
-                            needValidationDisposal = true;
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSteps != null) {
-                            doValidation = true;
-                        }
-                        ins = inputs.concat(targets);
-                        this.checkTrainableWeightsConsistency();
-                        trainFunction = function (data) {
-                            var losses = [];
-                            var lossValues = [];
-                            var inputs = data.slice(0, _this.inputs.length);
-                            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
-                            var metricsValues = [];
-                            var totalLossFunction = function () {
-                                var feeds = [];
-                                for (var i = 0; i < _this.inputs.length; ++i) {
-                                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
-                                }
-                                var feedDict = new executor_1.FeedDict(feeds);
-                                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
-                                var totalLoss;
-                                for (var i = 0; i < _this.lossFunctions.length; ++i) {
-                                    var lossFunction = _this.lossFunctions[i];
-                                    var loss = lossFunction(targets[i], outputs[i]);
-                                    losses.push(loss);
-                                    var meanLoss = tfc.mean(loss);
-                                    lossValues.push(meanLoss);
-                                    if (i === 0) {
-                                        totalLoss = loss;
-                                    }
-                                    else {
-                                        totalLoss = tfc.add(totalLoss, loss);
-                                    }
-                                }
-                                for (var i = 0; i < _this.metricsTensors.length; ++i) {
-                                    var metric = _this.metricsTensors[i][0];
-                                    var outputIndex = _this.metricsTensors[i][1];
-                                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
-                                    tfc.keep(meanMetric);
-                                    metricsValues.push(meanMetric);
-                                }
-                                totalLoss = tfc.mean(totalLoss);
-                                _this.calculateLosses().forEach(function (regularizerLoss) {
-                                    totalLoss = tfc.add(totalLoss, regularizerLoss);
-                                });
-                                return totalLoss;
-                            };
-                            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
-                            var returnCost = true;
-                            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
-                            return [totalLossValue].concat(metricsValues);
-                        };
-                        outLabels = this.getDedupedMetricsNames();
-                        valFunction = void 0;
-                        callbackMetrics = void 0;
-                        if (doValidation) {
-                            this.makeTestFunction();
-                            valFunction = this.testFunction;
-                            callbackMetrics =
-                                outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
-                        }
-                        else {
-                            valFunction = null;
-                            valIns = [];
-                            callbackMetrics = outLabels.slice();
-                        }
-                        callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
-                        return [4, this.fitLoop(trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
-                    case 2:
-                        out = _a.sent();
-                        if (needValidationDisposal) {
-                            valIns.forEach(function (tensor) { return tensor.dispose(); });
-                            inputs.forEach(function (tensor) { return tensor.dispose(); });
-                            targets.forEach(function (tensor) { return tensor.dispose(); });
-                        }
-                        this.isTraining = false;
-                        return [2, out];
-                    case 3:
-                        this.isTraining = false;
-                        return [7];
-                    case 4: return [2];
-                }
+                return [2, training_tensors_1.fitTensors(this, x, y, config)];
+            });
+        });
+    };
+    Model.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, training_dataset_1.fitDataset(this, dataset, config)];
             });
         });
     };
@@ -30665,9 +31990,699 @@ var Model = (function (_super) {
     return Model;
 }(container_1.Container));
 exports.Model = Model;
-tfjs_core_1.serialization.SerializationMap.register(Model);
+tfjs_core_1.serialization.registerClass(Model);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../base_callbacks":201,"../common":203,"../errors":210,"../logs":231,"../losses":232,"../metrics":233,"../optimizers":235,"../utils/generic_utils":238,"../utils/layer_utils":239,"../utils/math_utils":240,"./container":205,"./executor":206,"@tensorflow/tfjs-core":68}],210:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../errors":233,"../losses":256,"../metrics":257,"../optimizers":259,"../utils/generic_utils":262,"../utils/layer_utils":263,"../utils/math_utils":264,"./container":225,"./executor":227,"./training_dataset":231,"./training_tensors":232,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var state_1 = require("../backend/state");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var generic_utils_1 = require("../utils/generic_utils");
+var dataset_stub_1 = require("./dataset_stub");
+var DEFAULT_VALIDATION_BATCH_SIZE = 32;
+function standardizeDataIteratorOutput(model, iteratorOut) {
+    if (model.outputs.length > 1) {
+        throw new errors_1.NotImplementedError("Support for training a model with multiple output tensors with " +
+            "a dataset object is not implemented yet.");
+    }
+    tfc.util.assert(Array.isArray(iteratorOut) && iteratorOut.length === 2, 'Dataset iterator for fitDataset() is expected to generate ' +
+        'an Array of length 2: `[xs, ys]`, but instead generates ' +
+        iteratorOut);
+    iteratorOut = iteratorOut;
+    var ys = iteratorOut[1];
+    var xs = iteratorOut[0];
+    if (xs instanceof tfc.Tensor) {
+        tfc.util.assert(model.inputs.length === 1, "Model has multiple " + model.inputs.length + " inputs, hence it " +
+            "expects the input dataset to generate a dictionary of tensors " +
+            (" (with keys " + JSON.stringify(model.inputNames) + ", ") +
+            "but received a single tensor.");
+        tfc.util.assert(xs.shape[0] === ys.shape[0], "Mismatch in batch size between x and y tensors (" + xs.shape[0] + " vs. " +
+            (ys.shape[0] + ")"));
+        return [xs, ys];
+    }
+    else {
+        var batchSize = void 0;
+        xs = xs;
+        var flattendXs = [];
+        for (var _i = 0, _a = model.inputNames; _i < _a.length; _i++) {
+            var inputName = _a[_i];
+            if (xs[inputName] == null) {
+                throw new errors_1.ValueError("The feature data generated by the dataset lacks the required " +
+                    ("input key '" + inputName + "'."));
+            }
+            flattendXs.push(xs[inputName]);
+            if (batchSize == null) {
+                batchSize = xs[inputName].shape[0];
+            }
+            else {
+                tfc.util.assert(xs[inputName].shape[0] === batchSize, "Mismatch in batch size between x and y tensors " +
+                    ("(" + xs[inputName].shape[0] + " vs. " + ys.shape[0] + ")"));
+            }
+        }
+        return flattendXs.concat(ys);
+    }
+}
+function standardizeTensorValidationData(data) {
+    if (data.length === 3) {
+        throw new errors_1.NotImplementedError('Validation with sample weights is not implemented yet.');
+    }
+    return { xs: data[0], ys: data[1] };
+}
+function fitDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, validationDataIterator, valXs, valYs, validationData, trainFunction, outLabels, callbackMetrics, callbacks, _a, callbackList, history_1, epoch, epochLogs, dataIterator, stepsDone, batchIndex, iteratorOut, xsAndYs, batchLogs, outs, i, label, out, valOuts, _b, i;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    tfc.util.assert(model.optimizer != null, 'You must compile a model before training/testing. Use ' +
+                        'Model.compile(modelCompileConfig).');
+                    tfc.util.assert(config != null, "For fitDataset(), the 2nd argument (config) is required, " +
+                        "but it is not provided in this call.");
+                    tfc.util.assert(config.epochs != null && config.epochs > 0 &&
+                        Number.isInteger(config.epochs), "For fitDataset(), config.epochs is expected to be a positive " +
+                        ("integer, but got " + config.epochs));
+                    tfc.util.assert(config.batchesPerEpoch != null && config.batchesPerEpoch > 0 &&
+                        Number.isInteger(config.batchesPerEpoch), "For fitDataset(), config.batchesPerEpoch is expected to be a " +
+                        ("positive integer, but got " + config.batchesPerEpoch));
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _c.label = 1;
+                case 1:
+                    _c.trys.push([1, , 21, 22]);
+                    doValidation = config.validationData != null;
+                    validationDataIterator = void 0;
+                    valXs = void 0;
+                    valYs = void 0;
+                    if (!doValidation) return [3, 4];
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 3];
+                    tfc.util.assert(config.validationBatches > 0 &&
+                        Number.isInteger(config.validationBatches), "For fitDataset() with dataset-based validation, " +
+                        "config.validationBatches is expected to be a " +
+                        ("positive integer, but got " + config.validationBatches));
+                    return [4, config.validationData.iterator()];
+                case 2:
+                    validationDataIterator = _c.sent();
+                    return [3, 4];
+                case 3:
+                    validationData = standardizeTensorValidationData(config.validationData);
+                    valXs = validationData.xs;
+                    valYs = validationData.ys;
+                    _c.label = 4;
+                case 4:
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    _a = base_callbacks_1.configureCallbacks(callbacks, config.yieldEvery, config.verbose, config.epochs, null, null, config.batchesPerEpoch, null, doValidation, callbackMetrics), callbackList = _a.callbackList, history_1 = _a.history;
+                    model.history = history_1;
+                    return [4, callbackList.onTrainBegin()];
+                case 5:
+                    _c.sent();
+                    epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
+                    epochLogs = {};
+                    return [4, dataset.iterator()];
+                case 6:
+                    dataIterator = _c.sent();
+                    _c.label = 7;
+                case 7:
+                    if (!(epoch < config.epochs)) return [3, 18];
+                    return [4, callbackList.onEpochBegin(epoch)];
+                case 8:
+                    _c.sent();
+                    stepsDone = 0;
+                    batchIndex = 0;
+                    _c.label = 9;
+                case 9:
+                    if (!(stepsDone < config.batchesPerEpoch)) return [3, 16];
+                    return [4, dataIterator.next()];
+                case 10:
+                    iteratorOut = _c.sent();
+                    if (iteratorOut.done) {
+                        console.warn('Your dataset iterator ran out of data; ' +
+                            'interrupting training. Make sure that your ' +
+                            'dataset can generate at least `batchesPerEpoch * epochs` ' +
+                            'batches (in this case, ' +
+                            (config.batchesPerEpoch * config.epochs + " batches). ") +
+                            'You may need to use the repeat() function when building ' +
+                            'your dataset.');
+                        return [3, 16];
+                    }
+                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                    batchLogs = {};
+                    batchLogs['batch'] = batchIndex;
+                    batchLogs['size'] = xsAndYs[0].shape[0];
+                    callbackList.onBatchBegin(batchIndex, batchLogs);
+                    outs = trainFunction(xsAndYs);
+                    tfc.dispose(xsAndYs);
+                    for (i = 0; i < outLabels.length; ++i) {
+                        label = outLabels[i];
+                        out = outs[i];
+                        batchLogs[label] = out;
+                        tfc.keep(out);
+                    }
+                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                case 11:
+                    _c.sent();
+                    logs_1.disposeTensorsInLogs(batchLogs);
+                    batchIndex++;
+                    stepsDone++;
+                    if (!(stepsDone >= config.batchesPerEpoch && doValidation)) return [3, 15];
+                    valOuts = void 0;
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 13];
+                    _b = generic_utils_1.toList;
+                    return [4, model.evaluateDataset(validationDataIterator, { batches: config.validationBatches })];
+                case 12:
+                    valOuts = _b.apply(void 0, [_c.sent()]);
+                    return [3, 14];
+                case 13:
+                    valOuts = generic_utils_1.toList(model.evaluate(valXs, valYs, {
+                        batchSize: config.validationBatchSize == null ?
+                            DEFAULT_VALIDATION_BATCH_SIZE :
+                            config.validationBatchSize,
+                        verbose: 0
+                    }));
+                    _c.label = 14;
+                case 14:
+                    for (i = 0; i < model.metricsNames.length; ++i) {
+                        epochLogs["val_" + model.metricsNames[i]] = valOuts[i];
+                    }
+                    _c.label = 15;
+                case 15:
+                    if (model.stopTraining_) {
+                        return [3, 16];
+                    }
+                    return [3, 9];
+                case 16: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                case 17:
+                    _c.sent();
+                    epoch++;
+                    if (model.stopTraining_) {
+                        return [3, 18];
+                    }
+                    return [3, 7];
+                case 18: return [4, callbackList.onTrainEnd()];
+                case 19:
+                    _c.sent();
+                    return [4, model.history.syncData()];
+                case 20:
+                    _c.sent();
+                    return [2, model.history];
+                case 21:
+                    model.isTraining = false;
+                    return [7];
+                case 22: return [2];
+            }
+        });
+    });
+}
+exports.fitDataset = fitDataset;
+function evaluateDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var f, outs, dataIterator, _a, numExamples, _loop_1, batch, state_2, _loop_2, i;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    f = model.testFunction;
+                    outs = [];
+                    if (config.verbose > 0) {
+                        throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
+                    }
+                    tfc.util.assert(config.batches > 0 && Number.isInteger(config.batches), 'Test loop expects `batches` to be a positive integer, but ' +
+                        ("received " + JSON.stringify(config.batches)));
+                    if (!(dataset instanceof dataset_stub_1.LazyIterator)) return [3, 1];
+                    _a = dataset;
+                    return [3, 3];
+                case 1: return [4, dataset.iterator()];
+                case 2:
+                    _a = _b.sent();
+                    _b.label = 3;
+                case 3:
+                    dataIterator = _a;
+                    numExamples = 0;
+                    _loop_1 = function (batch) {
+                        var iteratorOut, xsAndYs, batchOuts, i, batchSize, _loop_3, i;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, dataIterator.next()];
+                                case 1:
+                                    iteratorOut = _a.sent();
+                                    if (iteratorOut.done) {
+                                        console.warn('Your dataset iterator ran out of data during evaluateDataset(). ' +
+                                            'Interrupting evalution. Make sure that your ' +
+                                            'dataset can generate at least `batches` ' +
+                                            ("batches (in this case, " + config.batches + " batches). ") +
+                                            'You may need to use the repeat() function when building ' +
+                                            'your dataset.');
+                                        return [2, "break"];
+                                    }
+                                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                                    batchOuts = tfc.tidy(function () { return f(xsAndYs); });
+                                    tfc.dispose(xsAndYs);
+                                    if (batch === 0) {
+                                        for (i = 0; i < batchOuts.length; ++i) {
+                                            outs.push(state_1.getScalar(0));
+                                        }
+                                    }
+                                    batchSize = xsAndYs[0].shape[0];
+                                    _loop_3 = function (i) {
+                                        var batchOut = batchOuts[i];
+                                        var oldScalar = outs[i];
+                                        outs[i] = tfc.tidy(function () { return tfc.add(outs[i], tfc.mul(state_1.getScalar(batchSize), batchOut)); });
+                                        if (batch > 0) {
+                                            tfc.dispose(oldScalar);
+                                        }
+                                    };
+                                    for (i = 0; i < batchOuts.length; ++i) {
+                                        _loop_3(i);
+                                    }
+                                    tfc.dispose(batchOuts);
+                                    numExamples += batchSize;
+                                    return [2];
+                            }
+                        });
+                    };
+                    batch = 0;
+                    _b.label = 4;
+                case 4:
+                    if (!(batch < config.batches)) return [3, 7];
+                    return [5, _loop_1(batch)];
+                case 5:
+                    state_2 = _b.sent();
+                    if (state_2 === "break")
+                        return [3, 7];
+                    _b.label = 6;
+                case 6:
+                    ++batch;
+                    return [3, 4];
+                case 7:
+                    _loop_2 = function (i) {
+                        var oldScalar = outs[i];
+                        outs[i] =
+                            tfc.tidy(function () { return tfc.div(outs[i], state_1.getScalar(numExamples)); });
+                        tfc.dispose(oldScalar);
+                    };
+                    for (i = 0; i < outs.length; ++i) {
+                        _loop_2(i);
+                    }
+                    return [2, generic_utils_1.singletonOrArray(outs)];
+            }
+        });
+    });
+}
+exports.evaluateDataset = evaluateDataset;
+
+},{"../backend/state":219,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/generic_utils":262,"./dataset_stub":226,"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfjs_backend_1 = require("../backend/tfjs_backend");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var math_utils_1 = require("../utils/math_utils");
+function checkBatchSize(batchSize) {
+    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
+}
+exports.checkBatchSize = checkBatchSize;
+function sliceArrays(arrays, start, stop) {
+    if (arrays == null) {
+        return [null];
+    }
+    else if (Array.isArray(arrays)) {
+        return arrays.map(function (array) { return tfjs_backend_1.sliceAlongFirstAxis(array, start, stop - start); });
+    }
+    else {
+        return tfjs_backend_1.sliceAlongFirstAxis(arrays, start, stop - start);
+    }
+}
+exports.sliceArrays = sliceArrays;
+function sliceArraysByIndices(arrays, indices) {
+    return tfc.tidy(function () {
+        if (arrays == null) {
+            return null;
+        }
+        else if (Array.isArray(arrays)) {
+            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
+        }
+        else {
+            return tfjs_backend_1.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
+        }
+    });
+}
+exports.sliceArraysByIndices = sliceArraysByIndices;
+function makeBatches(size, batchSize) {
+    var output = [];
+    var batchStart = 0;
+    var batchEnd = null;
+    while (batchStart < size) {
+        batchEnd = batchStart + batchSize;
+        if (batchEnd >= size) {
+            batchEnd = size;
+        }
+        output.push([batchStart, batchEnd]);
+        batchStart = batchEnd;
+    }
+    return output;
+}
+exports.makeBatches = makeBatches;
+function fitLoop(model, f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, numTrainSamples, indexArray, _a, callbackList, history, _loop_1, epoch, state_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (batchSize == null) {
+                        batchSize = 32;
+                    }
+                    if (epochs == null) {
+                        epochs = 1;
+                    }
+                    if (shuffle == null) {
+                        shuffle = true;
+                    }
+                    if (initialEpoch == null) {
+                        initialEpoch = 0;
+                    }
+                    doValidation = false;
+                    if (valF != null && valIns != null) {
+                        doValidation = true;
+                    }
+                    if (validationSteps != null) {
+                        doValidation = true;
+                        if (stepsPerEpoch == null) {
+                            throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
+                                'i.e., `stepsPerEpoch` must be set.');
+                        }
+                    }
+                    numTrainSamples = model.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
+                    if (numTrainSamples != null) {
+                        indexArray = math_utils_1.range(0, numTrainSamples);
+                    }
+                    if (verbose == null) {
+                        verbose = 1;
+                    }
+                    _a = base_callbacks_1.configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics), callbackList = _a.callbackList, history = _a.history;
+                    callbackList.setModel(model);
+                    model.history = history;
+                    return [4, callbackList.onTrainBegin()];
+                case 1:
+                    _b.sent();
+                    model.stopTraining_ = false;
+                    _loop_1 = function (epoch) {
+                        var epochLogs, epochIndexArray1D_1, batches_1, _loop_2, batchIndex, state_2;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, callbackList.onEpochBegin(epoch)];
+                                case 1:
+                                    _a.sent();
+                                    epochLogs = {};
+                                    if (!(stepsPerEpoch != null)) return [3, 2];
+                                    throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
+                                case 2:
+                                    if (shuffle === 'batch') {
+                                        throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
+                                    }
+                                    else if (shuffle) {
+                                        tfjs_core_1.util.shuffle(indexArray);
+                                    }
+                                    epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
+                                    batches_1 = makeBatches(numTrainSamples, batchSize);
+                                    _loop_2 = function (batchIndex) {
+                                        var batchLogs;
+                                        return __generator(this, function (_a) {
+                                            switch (_a.label) {
+                                                case 0:
+                                                    batchLogs = {};
+                                                    return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
+                                                case 1:
+                                                    _a.sent();
+                                                    tfc.tidy(function () {
+                                                        var batchStart = batches_1[batchIndex][0];
+                                                        var batchEnd = batches_1[batchIndex][1];
+                                                        var batchIds = tfjs_backend_1.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
+                                                        batchLogs['batch'] = batchIndex;
+                                                        batchLogs['size'] = batchEnd - batchStart;
+                                                        var insBatch = sliceArraysByIndices(ins, batchIds);
+                                                        var outs = f(insBatch);
+                                                        for (var i = 0; i < outLabels.length; ++i) {
+                                                            var label = outLabels[i];
+                                                            var out = outs[i];
+                                                            batchLogs[label] = out;
+                                                            tfc.keep(out);
+                                                        }
+                                                        if (batchIndex === batches_1.length - 1) {
+                                                            if (doValidation) {
+                                                                var valOuts = model.testLoop(valF, valIns, batchSize);
+                                                                for (var i = 0; i < outLabels.length; ++i) {
+                                                                    var label = outLabels[i];
+                                                                    var out = valOuts[i];
+                                                                    tfc.keep(out);
+                                                                    epochLogs['val_' + label] = out;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                                                case 2:
+                                                    _a.sent();
+                                                    logs_1.disposeTensorsInLogs(batchLogs);
+                                                    if (model.stopTraining_) {
+                                                        return [2, "break"];
+                                                    }
+                                                    return [2];
+                                            }
+                                        });
+                                    };
+                                    batchIndex = 0;
+                                    _a.label = 3;
+                                case 3:
+                                    if (!(batchIndex < batches_1.length)) return [3, 6];
+                                    return [5, _loop_2(batchIndex)];
+                                case 4:
+                                    state_2 = _a.sent();
+                                    if (state_2 === "break")
+                                        return [3, 6];
+                                    _a.label = 5;
+                                case 5:
+                                    ++batchIndex;
+                                    return [3, 3];
+                                case 6:
+                                    epochIndexArray1D_1.dispose();
+                                    _a.label = 7;
+                                case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                                case 8:
+                                    _a.sent();
+                                    if (model.stopTraining_) {
+                                        return [2, "break"];
+                                    }
+                                    return [2];
+                            }
+                        });
+                    };
+                    epoch = initialEpoch;
+                    _b.label = 2;
+                case 2:
+                    if (!(epoch < epochs)) return [3, 5];
+                    return [5, _loop_1(epoch)];
+                case 3:
+                    state_1 = _b.sent();
+                    if (state_1 === "break")
+                        return [3, 5];
+                    _b.label = 4;
+                case 4:
+                    ++epoch;
+                    return [3, 2];
+                case 5: return [4, callbackList.onTrainEnd()];
+                case 6:
+                    _b.sent();
+                    return [4, model.history.syncData()];
+                case 7:
+                    _b.sent();
+                    return [2, model.history];
+            }
+        });
+    });
+}
+function fitTensors(model, x, y, config) {
+    if (config === void 0) { config = {}; }
+    return __awaiter(this, void 0, void 0, function () {
+        var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, , 3, 4]);
+                    batchSize = config.batchSize == null ? 32 : config.batchSize;
+                    checkBatchSize(batchSize);
+                    standardizedOuts = model.standardizeUserData(x, y, false, batchSize);
+                    inputs = standardizedOuts[0];
+                    targets = standardizedOuts[1];
+                    doValidation = false;
+                    valX = void 0;
+                    valY = void 0;
+                    valIns = void 0;
+                    needValidationDisposal = false;
+                    if (config.validationData != null && config.validationData.length > 0) {
+                        doValidation = true;
+                        if (config.validationData.length === 2) {
+                            valX = config.validationData[0];
+                            valY = config.validationData[1];
+                        }
+                        else if (config.validationData.length === 3) {
+                            throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
+                        }
+                        else {
+                            throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
+                                "or 3 (valX, valY, valSampleWeight) items; " +
+                                (config.validationData + " is invalid."));
+                        }
+                        valStandardized = model.standardizeUserData(valX, valY, true, batchSize);
+                        valX = valStandardized[0];
+                        valY = valStandardized[1];
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSplit != null && config.validationSplit > 0 &&
+                        config.validationSplit < 1) {
+                        doValidation = true;
+                        splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
+                        originalBatchSize = inputs[0].shape[0];
+                        valX = sliceArrays(inputs, splitAt, originalBatchSize);
+                        inputs = sliceArrays(inputs, 0, splitAt);
+                        valY = sliceArrays(targets, splitAt, originalBatchSize);
+                        targets = sliceArrays(targets, 0, splitAt);
+                        needValidationDisposal = true;
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSteps != null) {
+                        doValidation = true;
+                    }
+                    ins = inputs.concat(targets);
+                    model.checkTrainableWeightsConsistency();
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    valFunction = void 0;
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        model.makeTestFunction();
+                        valFunction = model.testFunction;
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        valFunction = null;
+                        valIns = [];
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    return [4, fitLoop(model, trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
+                case 2:
+                    out = _a.sent();
+                    if (needValidationDisposal) {
+                        valIns.forEach(function (tensor) { return tensor.dispose(); });
+                        inputs.forEach(function (tensor) { return tensor.dispose(); });
+                        targets.forEach(function (tensor) { return tensor.dispose(); });
+                    }
+                    model.isTraining = false;
+                    return [2, out];
+                case 3:
+                    model.isTraining = false;
+                    return [7];
+                case 4: return [2];
+            }
+        });
+    });
+}
+exports.fitTensors = fitTensors;
+
+},{"../backend/tfjs_backend":220,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/math_utils":264,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -30741,12 +32756,13 @@ var IndexError = (function (_super) {
 }(Error));
 exports.IndexError = IndexError;
 
-},{}],211:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
 var training_1 = require("./engine/training");
 var models_1 = require("./models");
+var base_callbacks_1 = require("./base_callbacks");
 function model(config) {
     return new training_1.Model(config);
 }
@@ -30764,8 +32780,12 @@ function input(config) {
     return input_layer_1.Input(config);
 }
 exports.input = input;
+function registerCallbackConstructor(verbosityLevel, callbackConstructor) {
+    base_callbacks_1.CallbackConstructorRegistry.registerCallbackConstructor(verbosityLevel, callbackConstructor);
+}
+exports.registerCallbackConstructor = registerCallbackConstructor;
 
-},{"./engine/input_layer":207,"./engine/training":209,"./models":234}],212:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/input_layer":228,"./engine/training":230,"./models":258}],235:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints_1 = require("./constraints");
@@ -30786,7 +32806,7 @@ function minMaxNorm(config) {
 }
 exports.minMaxNorm = minMaxNorm;
 
-},{"./constraints":204}],213:[function(require,module,exports){
+},{"./constraints":224}],236:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var initializers_1 = require("./initializers");
@@ -30843,7 +32863,7 @@ function orthogonal(config) {
 }
 exports.orthogonal = orthogonal;
 
-},{"./initializers":218}],214:[function(require,module,exports){
+},{"./initializers":242}],237:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
@@ -30972,6 +32992,10 @@ function multiply(config) {
     return new merge_1.Multiply(config);
 }
 exports.multiply = multiply;
+function dot(config) {
+    return new merge_1.Dot(config);
+}
+exports.dot = dot;
 function batchNormalization(config) {
     return new normalization_1.BatchNormalization(config);
 }
@@ -31073,7 +33097,7 @@ exports.globalMaxPool2d = globalMaxPooling2d;
 exports.maxPool1d = maxPooling1d;
 exports.maxPool2d = maxPooling2d;
 
-},{"./engine/input_layer":207,"./engine/topology":208,"./exports":211,"./layers/advanced_activations":219,"./layers/convolutional":220,"./layers/convolutional_depthwise":221,"./layers/core":222,"./layers/embeddings":223,"./layers/merge":224,"./layers/normalization":225,"./layers/padding":226,"./layers/pooling":227,"./layers/recurrent":228,"./layers/wrappers":230}],215:[function(require,module,exports){
+},{"./engine/input_layer":228,"./engine/topology":229,"./exports":234,"./layers/advanced_activations":243,"./layers/convolutional":244,"./layers/convolutional_depthwise":245,"./layers/core":246,"./layers/embeddings":247,"./layers/merge":248,"./layers/normalization":249,"./layers/padding":250,"./layers/pooling":251,"./layers/recurrent":252,"./layers/wrappers":254}],238:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var losses = require("./losses");
@@ -31094,6 +33118,14 @@ function categoricalCrossentropy(yTrue, yPred) {
     return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 exports.categoricalCrossentropy = categoricalCrossentropy;
+function precision(yTrue, yPred) {
+    return metrics.precision(yTrue, yPred);
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return metrics.recall(yTrue, yPred);
+}
+exports.recall = recall;
 function cosineProximity(yTrue, yPred) {
     return losses.cosineProximity(yTrue, yPred);
 }
@@ -31127,7 +33159,13 @@ function mse(yTrue, yPred) {
 }
 exports.mse = mse;
 
-},{"./losses":232,"./metrics":233}],216:[function(require,module,exports){
+},{"./losses":256,"./metrics":257}],239:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var models_1 = require("./models");
+exports.modelFromJSON = models_1.modelFromJSON;
+
+},{"./models":258}],240:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var regularizers = require("./regularizers");
@@ -31145,7 +33183,7 @@ function l2(config) {
 }
 exports.l2 = l2;
 
-},{"./regularizers":236}],217:[function(require,module,exports){
+},{"./regularizers":260}],241:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints = require("./exports_constraints");
@@ -31154,6 +33192,8 @@ var initializers = require("./exports_initializers");
 exports.initializers = initializers;
 var layers = require("./exports_layers");
 exports.layers = layers;
+var models = require("./exports_models");
+exports.models = models;
 var metrics = require("./exports_metrics");
 exports.metrics = metrics;
 var regularizers = require("./exports_regularizers");
@@ -31165,6 +33205,7 @@ exports.History = base_callbacks_1.History;
 var callbacks_1 = require("./callbacks");
 exports.Callback = callbacks_1.Callback;
 var topology_1 = require("./engine/topology");
+exports.InputSpec = topology_1.InputSpec;
 exports.SymbolicTensor = topology_1.SymbolicTensor;
 var training_1 = require("./engine/training");
 exports.Model = training_1.Model;
@@ -31172,6 +33213,7 @@ var exports_1 = require("./exports");
 exports.input = exports_1.input;
 exports.loadModel = exports_1.loadModel;
 exports.model = exports_1.model;
+exports.registerCallbackConstructor = exports_1.registerCallbackConstructor;
 exports.sequential = exports_1.sequential;
 var recurrent_1 = require("./layers/recurrent");
 exports.RNN = recurrent_1.RNN;
@@ -31182,7 +33224,7 @@ exports.LayerVariable = variables_1.LayerVariable;
 var version_1 = require("./version");
 exports.version_layers = version_1.version;
 
-},{"./base_callbacks":201,"./callbacks":202,"./engine/topology":208,"./engine/training":209,"./exports":211,"./exports_constraints":212,"./exports_initializers":213,"./exports_layers":214,"./exports_metrics":215,"./exports_regularizers":216,"./layers/recurrent":228,"./models":234,"./variables":244,"./version":245}],218:[function(require,module,exports){
+},{"./base_callbacks":221,"./callbacks":222,"./engine/topology":229,"./engine/training":230,"./exports":234,"./exports_constraints":235,"./exports_initializers":236,"./exports_layers":237,"./exports_metrics":238,"./exports_models":239,"./exports_regularizers":240,"./layers/recurrent":252,"./models":258,"./variables":268,"./version":269}],242:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31238,7 +33280,7 @@ var Zeros = (function (_super) {
     return Zeros;
 }(Initializer));
 exports.Zeros = Zeros;
-tfjs_core_1.serialization.SerializationMap.register(Zeros);
+tfjs_core_1.serialization.registerClass(Zeros);
 var Ones = (function (_super) {
     __extends(Ones, _super);
     function Ones() {
@@ -31251,7 +33293,7 @@ var Ones = (function (_super) {
     return Ones;
 }(Initializer));
 exports.Ones = Ones;
-tfjs_core_1.serialization.SerializationMap.register(Ones);
+tfjs_core_1.serialization.registerClass(Ones);
 var Constant = (function (_super) {
     __extends(Constant, _super);
     function Constant(config) {
@@ -31278,7 +33320,7 @@ var Constant = (function (_super) {
     return Constant;
 }(Initializer));
 exports.Constant = Constant;
-tfjs_core_1.serialization.SerializationMap.register(Constant);
+tfjs_core_1.serialization.registerClass(Constant);
 var RandomUniform = (function (_super) {
     __extends(RandomUniform, _super);
     function RandomUniform(config) {
@@ -31300,7 +33342,7 @@ var RandomUniform = (function (_super) {
     return RandomUniform;
 }(Initializer));
 exports.RandomUniform = RandomUniform;
-tfjs_core_1.serialization.SerializationMap.register(RandomUniform);
+tfjs_core_1.serialization.registerClass(RandomUniform);
 var RandomNormal = (function (_super) {
     __extends(RandomNormal, _super);
     function RandomNormal(config) {
@@ -31313,8 +33355,9 @@ var RandomNormal = (function (_super) {
         return _this;
     }
     RandomNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
         }
         return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31325,7 +33368,7 @@ var RandomNormal = (function (_super) {
     return RandomNormal;
 }(Initializer));
 exports.RandomNormal = RandomNormal;
-tfjs_core_1.serialization.SerializationMap.register(RandomNormal);
+tfjs_core_1.serialization.registerClass(RandomNormal);
 var TruncatedNormal = (function (_super) {
     __extends(TruncatedNormal, _super);
     function TruncatedNormal(config) {
@@ -31338,8 +33381,9 @@ var TruncatedNormal = (function (_super) {
         return _this;
     }
     TruncatedNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("truncatedNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("truncatedNormal does not support dType " + dtype + ".");
         }
         return tfjs_core_1.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31350,7 +33394,7 @@ var TruncatedNormal = (function (_super) {
     return TruncatedNormal;
 }(Initializer));
 exports.TruncatedNormal = TruncatedNormal;
-tfjs_core_1.serialization.SerializationMap.register(TruncatedNormal);
+tfjs_core_1.serialization.registerClass(TruncatedNormal);
 var Identity = (function (_super) {
     __extends(Identity, _super);
     function Identity(config) {
@@ -31377,7 +33421,7 @@ var Identity = (function (_super) {
     return Identity;
 }(Initializer));
 exports.Identity = Identity;
-tfjs_core_1.serialization.SerializationMap.register(Identity);
+tfjs_core_1.serialization.registerClass(Identity);
 function computeFans(shape, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var fanIn;
@@ -31437,8 +33481,9 @@ var VarianceScaling = (function (_super) {
         }
         if (this.distribution === 'normal') {
             var stddev = Math.sqrt(scale);
-            if (dtype === 'bool') {
-                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType bool.");
+            dtype = dtype || 'float32';
+            if (dtype !== 'float32' && dtype !== 'int32') {
+                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType " + dtype + ".");
             }
             return tfjs_core_1.truncatedNormal(shape, 0, stddev, dtype, this.seed);
         }
@@ -31459,7 +33504,7 @@ var VarianceScaling = (function (_super) {
     return VarianceScaling;
 }(Initializer));
 exports.VarianceScaling = VarianceScaling;
-tfjs_core_1.serialization.SerializationMap.register(VarianceScaling);
+tfjs_core_1.serialization.registerClass(VarianceScaling);
 var GlorotUniform = (function (_super) {
     __extends(GlorotUniform, _super);
     function GlorotUniform(config) {
@@ -31473,9 +33518,11 @@ var GlorotUniform = (function (_super) {
     GlorotUniform.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotUniform.className = 'GlorotUniform';
     return GlorotUniform;
 }(VarianceScaling));
 exports.GlorotUniform = GlorotUniform;
+tfjs_core_1.serialization.registerClass(GlorotUniform);
 var GlorotNormal = (function (_super) {
     __extends(GlorotNormal, _super);
     function GlorotNormal(config) {
@@ -31489,9 +33536,11 @@ var GlorotNormal = (function (_super) {
     GlorotNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotNormal.className = 'GlorotNormal';
     return GlorotNormal;
 }(VarianceScaling));
 exports.GlorotNormal = GlorotNormal;
+tfjs_core_1.serialization.registerClass(GlorotNormal);
 var HeNormal = (function (_super) {
     __extends(HeNormal, _super);
     function HeNormal(config) {
@@ -31505,9 +33554,11 @@ var HeNormal = (function (_super) {
     HeNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    HeNormal.className = 'HeNormal';
     return HeNormal;
 }(VarianceScaling));
 exports.HeNormal = HeNormal;
+tfjs_core_1.serialization.registerClass(HeNormal);
 var LeCunNormal = (function (_super) {
     __extends(LeCunNormal, _super);
     function LeCunNormal(config) {
@@ -31521,9 +33572,11 @@ var LeCunNormal = (function (_super) {
     LeCunNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    LeCunNormal.className = 'LeCunNormal';
     return LeCunNormal;
 }(VarianceScaling));
 exports.LeCunNormal = LeCunNormal;
+tfjs_core_1.serialization.registerClass(LeCunNormal);
 var Orthogonal = (function (_super) {
     __extends(Orthogonal, _super);
     function Orthogonal(config) {
@@ -31566,7 +33619,7 @@ var Orthogonal = (function (_super) {
     return Orthogonal;
 }(Initializer));
 exports.Orthogonal = Orthogonal;
-tfjs_core_1.serialization.SerializationMap.register(Orthogonal);
+tfjs_core_1.serialization.registerClass(Orthogonal);
 exports.INITIALIZER_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'constant': 'Constant',
     'glorotNormal': 'GlorotNormal',
@@ -31621,7 +33674,7 @@ function getInitializer(identifier) {
 }
 exports.getInitializer = getInitializer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./common":203,"./errors":210,"./utils/generic_utils":238,"./utils/math_utils":240,"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./common":223,"./errors":233,"./utils/generic_utils":262,"./utils/math_utils":264,"@tensorflow/tfjs-core":68}],243:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31672,7 +33725,7 @@ var ReLU = (function (_super) {
     return ReLU;
 }(topology_1.Layer));
 exports.ReLU = ReLU;
-tfjs_core_1.serialization.SerializationMap.register(ReLU);
+tfjs_core_1.serialization.registerClass(ReLU);
 var LeakyReLU = (function (_super) {
     __extends(LeakyReLU, _super);
     function LeakyReLU(config) {
@@ -31701,7 +33754,7 @@ var LeakyReLU = (function (_super) {
     return LeakyReLU;
 }(topology_1.Layer));
 exports.LeakyReLU = LeakyReLU;
-tfjs_core_1.serialization.SerializationMap.register(LeakyReLU);
+tfjs_core_1.serialization.registerClass(LeakyReLU);
 var ELU = (function (_super) {
     __extends(ELU, _super);
     function ELU(config) {
@@ -31734,7 +33787,7 @@ var ELU = (function (_super) {
     return ELU;
 }(topology_1.Layer));
 exports.ELU = ELU;
-tfjs_core_1.serialization.SerializationMap.register(ELU);
+tfjs_core_1.serialization.registerClass(ELU);
 var ThresholdedReLU = (function (_super) {
     __extends(ThresholdedReLU, _super);
     function ThresholdedReLU(config) {
@@ -31764,7 +33817,7 @@ var ThresholdedReLU = (function (_super) {
     return ThresholdedReLU;
 }(topology_1.Layer));
 exports.ThresholdedReLU = ThresholdedReLU;
-tfjs_core_1.serialization.SerializationMap.register(ThresholdedReLU);
+tfjs_core_1.serialization.registerClass(ThresholdedReLU);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax(config) {
@@ -31794,9 +33847,9 @@ var Softmax = (function (_super) {
     return Softmax;
 }(topology_1.Layer));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],244:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32111,7 +34164,7 @@ var Conv2D = (function (_super) {
     return Conv2D;
 }(Conv));
 exports.Conv2D = Conv2D;
-tfjs_core_1.serialization.SerializationMap.register(Conv2D);
+tfjs_core_1.serialization.registerClass(Conv2D);
 var Conv2DTranspose = (function (_super) {
     __extends(Conv2DTranspose, _super);
     function Conv2DTranspose(config) {
@@ -32227,7 +34280,7 @@ var Conv2DTranspose = (function (_super) {
     return Conv2DTranspose;
 }(Conv2D));
 exports.Conv2DTranspose = Conv2DTranspose;
-tfjs_core_1.serialization.SerializationMap.register(Conv2DTranspose);
+tfjs_core_1.serialization.registerClass(Conv2DTranspose);
 var SeparableConv = (function (_super) {
     __extends(SeparableConv, _super);
     function SeparableConv(rank, config) {
@@ -32354,7 +34407,7 @@ var SeparableConv2D = (function (_super) {
     return SeparableConv2D;
 }(SeparableConv));
 exports.SeparableConv2D = SeparableConv2D;
-tfjs_core_1.serialization.SerializationMap.register(SeparableConv2D);
+tfjs_core_1.serialization.registerClass(SeparableConv2D);
 var Conv1D = (function (_super) {
     __extends(Conv1D, _super);
     function Conv1D(config) {
@@ -32379,7 +34432,7 @@ var Conv1D = (function (_super) {
     return Conv1D;
 }(Conv));
 exports.Conv1D = Conv1D;
-tfjs_core_1.serialization.SerializationMap.register(Conv1D);
+tfjs_core_1.serialization.registerClass(Conv1D);
 var Cropping2D = (function (_super) {
     __extends(Cropping2D, _super);
     function Cropping2D(config) {
@@ -32403,15 +34456,17 @@ var Cropping2D = (function (_super) {
     Cropping2D.prototype.computeOutputShape = function (inputShape) {
         if (this.dataFormat === 'channelsFirst')
             return [
-                inputShape[0], inputShape[1],
+                inputShape[0],
+                inputShape[1],
                 inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+                inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
             ];
         else
             return [
                 inputShape[0],
                 inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+                inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+                inputShape[3]
             ];
     };
     Cropping2D.prototype.call = function (inputs, kwargs) {
@@ -32438,7 +34493,7 @@ var Cropping2D = (function (_super) {
     return Cropping2D;
 }(topology_1.Layer));
 exports.Cropping2D = Cropping2D;
-tfjs_core_1.serialization.SerializationMap.register(Cropping2D);
+tfjs_core_1.serialization.registerClass(Cropping2D);
 var UpSampling2D = (function (_super) {
     __extends(UpSampling2D, _super);
     function UpSampling2D(config) {
@@ -32491,9 +34546,9 @@ var UpSampling2D = (function (_super) {
     return UpSampling2D;
 }(topology_1.Layer));
 exports.UpSampling2D = UpSampling2D;
-tfjs_core_1.serialization.SerializationMap.register(UpSampling2D);
+tfjs_core_1.serialization.registerClass(UpSampling2D);
 
-},{"../activations":197,"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
+},{"../activations":217,"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32624,9 +34679,9 @@ var DepthwiseConv2D = (function (_super) {
     return DepthwiseConv2D;
 }(convolutional_1.BaseConv));
 exports.DepthwiseConv2D = DepthwiseConv2D;
-tfjs_core_1.serialization.SerializationMap.register(DepthwiseConv2D);
+tfjs_core_1.serialization.registerClass(DepthwiseConv2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],246:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32709,7 +34764,7 @@ var Dropout = (function (_super) {
     return Dropout;
 }(topology_1.Layer));
 exports.Dropout = Dropout;
-tfjs_core_1.serialization.SerializationMap.register(Dropout);
+tfjs_core_1.serialization.registerClass(Dropout);
 var Dense = (function (_super) {
     __extends(Dense, _super);
     function Dense(config) {
@@ -32799,7 +34854,7 @@ var Dense = (function (_super) {
     return Dense;
 }(topology_1.Layer));
 exports.Dense = Dense;
-tfjs_core_1.serialization.SerializationMap.register(Dense);
+tfjs_core_1.serialization.registerClass(Dense);
 var Flatten = (function (_super) {
     __extends(Flatten, _super);
     function Flatten(config) {
@@ -32831,7 +34886,7 @@ var Flatten = (function (_super) {
     return Flatten;
 }(topology_1.Layer));
 exports.Flatten = Flatten;
-tfjs_core_1.serialization.SerializationMap.register(Flatten);
+tfjs_core_1.serialization.registerClass(Flatten);
 var Activation = (function (_super) {
     __extends(Activation, _super);
     function Activation(config) {
@@ -32858,7 +34913,7 @@ var Activation = (function (_super) {
     return Activation;
 }(topology_1.Layer));
 exports.Activation = Activation;
-tfjs_core_1.serialization.SerializationMap.register(Activation);
+tfjs_core_1.serialization.registerClass(Activation);
 var RepeatVector = (function (_super) {
     __extends(RepeatVector, _super);
     function RepeatVector(config) {
@@ -32889,7 +34944,7 @@ var RepeatVector = (function (_super) {
     return RepeatVector;
 }(topology_1.Layer));
 exports.RepeatVector = RepeatVector;
-tfjs_core_1.serialization.SerializationMap.register(RepeatVector);
+tfjs_core_1.serialization.registerClass(RepeatVector);
 var Reshape = (function (_super) {
     __extends(Reshape, _super);
     function Reshape(config) {
@@ -32973,7 +35028,7 @@ var Reshape = (function (_super) {
     return Reshape;
 }(topology_1.Layer));
 exports.Reshape = Reshape;
-tfjs_core_1.serialization.SerializationMap.register(Reshape);
+tfjs_core_1.serialization.registerClass(Reshape);
 var Permute = (function (_super) {
     __extends(Permute, _super);
     function Permute(config) {
@@ -33019,9 +35074,9 @@ var Permute = (function (_super) {
     return Permute;
 }(topology_1.Layer));
 exports.Permute = Permute;
-tfjs_core_1.serialization.SerializationMap.register(Permute);
+tfjs_core_1.serialization.registerClass(Permute);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],223:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],247:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33138,9 +35193,9 @@ var Embedding = (function (_super) {
     return Embedding;
 }(topology_1.Layer));
 exports.Embedding = Embedding;
-tfjs_core_1.serialization.SerializationMap.register(Embedding);
+tfjs_core_1.serialization.registerClass(Embedding);
 
-},{"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],224:[function(require,module,exports){
+},{"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],248:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33159,6 +35214,7 @@ var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
 var topology_1 = require("../engine/topology");
 var errors_1 = require("../errors");
+var losses_1 = require("../losses");
 var generic_utils = require("../utils/generic_utils");
 var mathUtils = require("../utils/math_utils");
 var types_utils_1 = require("../utils/types_utils");
@@ -33336,6 +35392,9 @@ var Merge = (function (_super) {
         }
         return outputShape;
     };
+    Merge.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Merge yet');
+    };
     return Merge;
 }(topology_1.Layer));
 exports.Merge = Merge;
@@ -33357,7 +35416,7 @@ var Add = (function (_super) {
     return Add;
 }(Merge));
 exports.Add = Add;
-tfjs_core_1.serialization.SerializationMap.register(Add);
+tfjs_core_1.serialization.registerClass(Add);
 function add(config) {
     if (Array.isArray(config)) {
         var layer = new Add({});
@@ -33386,7 +35445,7 @@ var Multiply = (function (_super) {
     return Multiply;
 }(Merge));
 exports.Multiply = Multiply;
-tfjs_core_1.serialization.SerializationMap.register(Multiply);
+tfjs_core_1.serialization.registerClass(Multiply);
 function multiply(config) {
     if (Array.isArray(config)) {
         var layer = new Multiply({});
@@ -33415,7 +35474,7 @@ var Average = (function (_super) {
     return Average;
 }(Merge));
 exports.Average = Average;
-tfjs_core_1.serialization.SerializationMap.register(Average);
+tfjs_core_1.serialization.registerClass(Average);
 function average(config) {
     if (Array.isArray(config)) {
         var layer = new Average({});
@@ -33444,7 +35503,7 @@ var Maximum = (function (_super) {
     return Maximum;
 }(Merge));
 exports.Maximum = Maximum;
-tfjs_core_1.serialization.SerializationMap.register(Maximum);
+tfjs_core_1.serialization.registerClass(Maximum);
 function maximum(config) {
     if (Array.isArray(config)) {
         var layer = new Maximum({});
@@ -33473,7 +35532,7 @@ var Minimum = (function (_super) {
     return Minimum;
 }(Merge));
 exports.Minimum = Minimum;
-tfjs_core_1.serialization.SerializationMap.register(Minimum);
+tfjs_core_1.serialization.registerClass(Minimum);
 function minimum(config) {
     if (Array.isArray(config)) {
         var layer = new Minimum({});
@@ -33560,6 +35619,9 @@ var Concatenate = (function (_super) {
         }
         return outputShape;
     };
+    Concatenate.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Concatenate yet');
+    };
     Concatenate.prototype.getConfig = function () {
         var config = {
             'axis': this.axis,
@@ -33572,7 +35634,7 @@ var Concatenate = (function (_super) {
     return Concatenate;
 }(Merge));
 exports.Concatenate = Concatenate;
-tfjs_core_1.serialization.SerializationMap.register(Concatenate);
+tfjs_core_1.serialization.registerClass(Concatenate);
 function concatenate(config) {
     if (Array.isArray(config)) {
         var layer = new Concatenate({});
@@ -33583,8 +35645,184 @@ function concatenate(config) {
     }
 }
 exports.concatenate = concatenate;
+function interpretAxis(axis, dim) {
+    while (axis < 0) {
+        axis += dim;
+    }
+    return axis;
+}
+function batchDot(x, y, axes) {
+    if (x.shape.length > 3 || y.shape.length > 3) {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for tensors of 4D or higher rank yet');
+    }
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of x to be >= 2, " +
+        ("but got " + x.shape.length));
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of y to be >= 2, " +
+        ("but got " + y.shape.length));
+    if (typeof axes === 'number') {
+        axes = [axes, axes];
+    }
+    if (x.dtype === 'complex64' || y.dtype === 'complex64') {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for complex64-type Tensors yet.');
+    }
+    var xNDim = x.shape.length;
+    var yNDim = y.shape.length;
+    if (axes == null) {
+        axes = [xNDim - 1, yNDim - 2];
+    }
+    var axesArray = axes;
+    return tfc.tidy(function () {
+        var diff;
+        if (xNDim > yNDim) {
+            diff = xNDim - yNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            y = y.reshape(y.shape.concat(diffShape));
+        }
+        else if (yNDim > xNDim) {
+            diff = yNDim - xNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            x = x.reshape(x.shape.concat(diffShape));
+        }
+        else {
+            diff = 0;
+        }
+        var out;
+        if (x.shape.length === 2 && y.shape.length === 2) {
+            if (axesArray[0] === axesArray[1]) {
+                out = x.mulStrict(y).sum(axesArray[0]);
+            }
+            else {
+                out = x.transpose([1, 0]).mulStrict(y).sum(axesArray[1]);
+            }
+        }
+        else {
+            var adjX = axesArray[0] === x.shape.length - 1 ? null : true;
+            var adjY = axesArray[1] === y.shape.length - 1 ? true : null;
+            out = x.matMul(y, adjX, adjY);
+        }
+        if (diff > 0) {
+            var idx = void 0;
+            if (xNDim > yNDim) {
+                idx = xNDim + yNDim - 3;
+            }
+            else {
+                idx = xNDim - 1;
+            }
+            var squeezeAxes = [];
+            for (var i = idx; i < idx + diff; ++i) {
+                squeezeAxes.push(i);
+            }
+            out = out.squeeze(squeezeAxes);
+        }
+        if (out.shape.length === 1) {
+            out = out.expandDims(1);
+        }
+        return out;
+    });
+}
+var Dot = (function (_super) {
+    __extends(Dot, _super);
+    function Dot(config) {
+        var _this = _super.call(this, config) || this;
+        _this.axes = config.axes;
+        _this.normalize = config.normalize == null ? false : config.normalize;
+        _this.supportsMasking = true;
+        _this.reshapeRequired = false;
+        return _this;
+    }
+    Dot.prototype.build = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0];
+        var shape2 = inputShape[1];
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        if (shape1[axes[0]] !== shape2[axes[1]]) {
+            throw new errors_1.ValueError("Dimension incompatibility: " +
+                (shape1[axes[0]] + " !== " + shape2[axes[1]]));
+        }
+    };
+    Dot.prototype.mergeFunction = function (inputs) {
+        if (inputs.length !== 2) {
+            throw new errors_1.ValueError('A `Dot` layer must be called on exactly 2 inputs, ' +
+                ("but received " + inputs.length + " input(s)."));
+        }
+        var x1 = inputs[0];
+        var x2 = inputs[1];
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, x1.shape.length),
+                interpretAxis(this.axes, x2.shape.length)
+            ];
+        }
+        else {
+            axes = this.axes.map(function (axis, i) { return interpretAxis(axis, inputs[i].shape.length); });
+        }
+        if (this.normalize) {
+            x1 = losses_1.l2Normalize(x1, axes[0]);
+            x2 = losses_1.l2Normalize(x2, axes[1]);
+        }
+        return batchDot(x1, x2, axes);
+    };
+    Dot.prototype.interpretAxes = function (shape1, shape2) {
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, shape1.length),
+                interpretAxis(this.axes, shape2.length)
+            ];
+        }
+        else {
+            axes = this.axes;
+        }
+        return axes;
+    };
+    Dot.prototype.computeOutputShape = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0].slice();
+        var shape2 = inputShape[1].slice();
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        shape1.splice(axes[0], 1);
+        shape2.splice(axes[1], 1);
+        shape2.splice(0, 1);
+        var outputShape = shape1.concat(shape2);
+        if (outputShape.length === 1) {
+            outputShape.push(1);
+        }
+        return outputShape;
+    };
+    Dot.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Dot yet');
+    };
+    Dot.prototype.getConfig = function () {
+        var config = {
+            'axes': this.axes,
+            'normalize': this.normalize
+        };
+        var baseConfig = _super.prototype.getConfig.call(this);
+        Object.assign(config, baseConfig);
+        return config;
+    };
+    Dot.className = 'Dot';
+    return Dot;
+}(Merge));
+exports.Dot = Dot;
+tfjs_core_1.serialization.registerClass(Dot);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../losses":256,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],249:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33621,7 +35859,7 @@ function batchNormalization(x, mean, variance, beta, gamma, epsilon) {
         out = tfc.batchNormalization4d(x, mean, variance, epsilon, gamma, beta);
     }
     else {
-        throw new errors_1.NotImplementedError("batchNormalization is not implememnted for array of rank " + x.rank + " " +
+        throw new errors_1.NotImplementedError("batchNormalization is not implemented for array of rank " + x.rank + " " +
             "yet");
     }
     return out;
@@ -33674,7 +35912,11 @@ exports.normalizeBatchInTraining = normalizeBatchInTraining;
 var BatchNormalization = (function (_super) {
     __extends(BatchNormalization, _super);
     function BatchNormalization(config) {
-        var _this = _super.call(this, config) || this;
+        var _this = this;
+        if (config == null) {
+            config = {};
+        }
+        _this = _super.call(this, config) || this;
         _this.supportsMasking = true;
         _this.axis = config.axis == null ? -1 : config.axis;
         _this.momentum = config.momentum == null ? 0.99 : config.momentum;
@@ -33785,9 +36027,9 @@ var BatchNormalization = (function (_super) {
     return BatchNormalization;
 }(topology_1.Layer));
 exports.BatchNormalization = BatchNormalization;
-tfjs_core_1.serialization.SerializationMap.register(BatchNormalization);
+tfjs_core_1.serialization.registerClass(BatchNormalization);
 
-},{"../backend/state":199,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+},{"../backend/state":219,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],250:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33957,9 +36199,9 @@ var ZeroPadding2D = (function (_super) {
     return ZeroPadding2D;
 }(topology_1.Layer));
 exports.ZeroPadding2D = ZeroPadding2D;
-tfjs_core_1.serialization.SerializationMap.register(ZeroPadding2D);
+tfjs_core_1.serialization.registerClass(ZeroPadding2D);
 
-},{"../backend/common":198,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],227:[function(require,module,exports){
+},{"../backend/common":218,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],251:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34101,7 +36343,7 @@ var MaxPooling1D = (function (_super) {
     return MaxPooling1D;
 }(Pooling1D));
 exports.MaxPooling1D = MaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling1D);
+tfjs_core_1.serialization.registerClass(MaxPooling1D);
 var AveragePooling1D = (function (_super) {
     __extends(AveragePooling1D, _super);
     function AveragePooling1D(config) {
@@ -34116,7 +36358,7 @@ var AveragePooling1D = (function (_super) {
     return AveragePooling1D;
 }(Pooling1D));
 exports.AveragePooling1D = AveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling1D);
+tfjs_core_1.serialization.registerClass(AveragePooling1D);
 var Pooling2D = (function (_super) {
     __extends(Pooling2D, _super);
     function Pooling2D(config) {
@@ -34200,7 +36442,7 @@ var MaxPooling2D = (function (_super) {
     return MaxPooling2D;
 }(Pooling2D));
 exports.MaxPooling2D = MaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling2D);
+tfjs_core_1.serialization.registerClass(MaxPooling2D);
 var AveragePooling2D = (function (_super) {
     __extends(AveragePooling2D, _super);
     function AveragePooling2D(config) {
@@ -34215,7 +36457,7 @@ var AveragePooling2D = (function (_super) {
     return AveragePooling2D;
 }(Pooling2D));
 exports.AveragePooling2D = AveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling2D);
+tfjs_core_1.serialization.registerClass(AveragePooling2D);
 var GlobalPooling1D = (function (_super) {
     __extends(GlobalPooling1D, _super);
     function GlobalPooling1D(config) {
@@ -34247,7 +36489,7 @@ var GlobalAveragePooling1D = (function (_super) {
     return GlobalAveragePooling1D;
 }(GlobalPooling1D));
 exports.GlobalAveragePooling1D = GlobalAveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling1D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling1D);
 var GlobalMaxPooling1D = (function (_super) {
     __extends(GlobalMaxPooling1D, _super);
     function GlobalMaxPooling1D(config) {
@@ -34263,7 +36505,7 @@ var GlobalMaxPooling1D = (function (_super) {
     return GlobalMaxPooling1D;
 }(GlobalPooling1D));
 exports.GlobalMaxPooling1D = GlobalMaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling1D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling1D);
 var GlobalPooling2D = (function (_super) {
     __extends(GlobalPooling2D, _super);
     function GlobalPooling2D(config) {
@@ -34316,7 +36558,7 @@ var GlobalAveragePooling2D = (function (_super) {
     return GlobalAveragePooling2D;
 }(GlobalPooling2D));
 exports.GlobalAveragePooling2D = GlobalAveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling2D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling2D);
 var GlobalMaxPooling2D = (function (_super) {
     __extends(GlobalMaxPooling2D, _super);
     function GlobalMaxPooling2D() {
@@ -34338,9 +36580,9 @@ var GlobalMaxPooling2D = (function (_super) {
     return GlobalMaxPooling2D;
 }(GlobalPooling2D));
 exports.GlobalMaxPooling2D = GlobalMaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling2D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],252:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34396,9 +36638,10 @@ function standardizeArgs(inputs, initialState, constants, numConstants) {
     return { inputs: inputs, initialState: initialState, constants: constants };
 }
 exports.standardizeArgs = standardizeArgs;
-function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, inputLength) {
+function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, needPerStepOutputs) {
     if (goBackwards === void 0) { goBackwards = false; }
     if (unroll === void 0) { unroll = false; }
+    if (needPerStepOutputs === void 0) { needPerStepOutputs = false; }
     var ndim = inputs.shape.length;
     if (ndim < 3) {
         throw new errors_1.ValueError("Input should be at least 3D, but is " + ndim + "D.");
@@ -34424,24 +36667,27 @@ function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, 
     var lastOutput;
     var states = initialStates;
     var timeSteps = inputs.shape[0];
-    for (var t = 0; t < timeSteps; ++t) {
+    var _loop_1 = function (t) {
         var currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
         currentInput = currentInput.reshape(currentInput.shape.slice(1));
-        var stepOutputs = stepFunction(currentInput, states);
+        var stepOutputs = tfc.tidy(function () { return stepFunction(currentInput, states); });
         lastOutput = stepOutputs[0];
-        if (t === 0) {
-            outputs = lastOutput.reshape([1].concat(lastOutput.shape));
-        }
-        else {
-            outputs = K.concatAlongFirstAxis(outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        if (needPerStepOutputs) {
+            if (t === 0) {
+                outputs = lastOutput.expandDims(1);
+            }
+            else {
+                var newOutputs = tfc.concat([outputs, lastOutput.expandDims(1)], 1);
+                outputs.dispose();
+                outputs = newOutputs;
+            }
         }
         states = stepOutputs[1];
+    };
+    for (var t = 0; t < timeSteps; ++t) {
+        _loop_1(t);
     }
-    return [
-        lastOutput,
-        tfc.transpose(outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
-        states
-    ];
+    return [lastOutput, outputs, states];
 }
 exports.rnn = rnn;
 var RNN = (function (_super) {
@@ -34690,8 +36936,6 @@ var RNN = (function (_super) {
                 throw new errors_1.ValueError("RNN Layer has " + numStates + " state(s) but was passed " +
                     (initialState.length + " initial state(s)."));
             }
-            var inputShape = inputs.shape;
-            var timesteps = inputShape[1];
             if (_this.unroll) {
                 console.warn('Ignoring unroll = true for RNN layer, due to imperative backend.');
             }
@@ -34700,7 +36944,7 @@ var RNN = (function (_super) {
                 var outputs = _this.cell.call([inputs].concat(states), cellCallKwargs);
                 return [outputs[0], outputs.slice(1)];
             };
-            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, timesteps);
+            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, _this.returnSequences);
             var lastOutput = rnnOutputs[0];
             var outputs = rnnOutputs[1];
             var states = rnnOutputs[2];
@@ -34776,7 +37020,7 @@ var RNN = (function (_super) {
     return RNN;
 }(topology_2.Layer));
 exports.RNN = RNN;
-tfjs_core_1.serialization.SerializationMap.register(RNN);
+tfjs_core_1.serialization.registerClass(RNN);
 var RNNCell = (function (_super) {
     __extends(RNNCell, _super);
     function RNNCell() {
@@ -34895,7 +37139,7 @@ var SimpleRNNCell = (function (_super) {
     return SimpleRNNCell;
 }(RNNCell));
 exports.SimpleRNNCell = SimpleRNNCell;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNNCell);
+tfjs_core_1.serialization.registerClass(SimpleRNNCell);
 var SimpleRNN = (function (_super) {
     __extends(SimpleRNN, _super);
     function SimpleRNN(config) {
@@ -35046,7 +37290,7 @@ var SimpleRNN = (function (_super) {
     return SimpleRNN;
 }(RNN));
 exports.SimpleRNN = SimpleRNN;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNN);
+tfjs_core_1.serialization.registerClass(SimpleRNN);
 var GRUCell = (function (_super) {
     __extends(GRUCell, _super);
     function GRUCell(config) {
@@ -35221,7 +37465,7 @@ var GRUCell = (function (_super) {
     return GRUCell;
 }(RNNCell));
 exports.GRUCell = GRUCell;
-tfjs_core_1.serialization.SerializationMap.register(GRUCell);
+tfjs_core_1.serialization.registerClass(GRUCell);
 var GRU = (function (_super) {
     __extends(GRU, _super);
     function GRU(config) {
@@ -35398,7 +37642,7 @@ var GRU = (function (_super) {
     return GRU;
 }(RNN));
 exports.GRU = GRU;
-tfjs_core_1.serialization.SerializationMap.register(GRU);
+tfjs_core_1.serialization.registerClass(GRU);
 var LSTMCell = (function (_super) {
     __extends(LSTMCell, _super);
     function LSTMCell(config) {
@@ -35608,7 +37852,7 @@ var LSTMCell = (function (_super) {
     return LSTMCell;
 }(RNNCell));
 exports.LSTMCell = LSTMCell;
-tfjs_core_1.serialization.SerializationMap.register(LSTMCell);
+tfjs_core_1.serialization.registerClass(LSTMCell);
 var LSTM = (function (_super) {
     __extends(LSTM, _super);
     function LSTM(config) {
@@ -35793,7 +38037,7 @@ var LSTM = (function (_super) {
     return LSTM;
 }(RNN));
 exports.LSTM = LSTM;
-tfjs_core_1.serialization.SerializationMap.register(LSTM);
+tfjs_core_1.serialization.registerClass(LSTM);
 var StackedRNNCells = (function (_super) {
     __extends(StackedRNNCells, _super);
     function StackedRNNCells(config) {
@@ -35957,7 +38201,7 @@ var StackedRNNCells = (function (_super) {
     return StackedRNNCells;
 }(RNNCell));
 exports.StackedRNNCells = StackedRNNCells;
-tfjs_core_1.serialization.SerializationMap.register(StackedRNNCells);
+tfjs_core_1.serialization.registerClass(StackedRNNCells);
 function generateDropoutMask(ones, rate, training, count) {
     if (training === void 0) { training = null; }
     if (count === void 0) { count = 1; }
@@ -35977,7 +38221,7 @@ function generateDropoutMask(ones, rate, training, count) {
     }
 }
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"../variables":244,"./serialization":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"../variables":268,"./serialization":253,"@tensorflow/tfjs-core":68}],253:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -35988,7 +38232,7 @@ function deserialize(config, customObjects) {
 }
 exports.deserialize = deserialize;
 
-},{"../utils/generic_utils":238,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
+},{"../utils/generic_utils":262,"@tensorflow/tfjs-core":68}],254:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36129,10 +38373,10 @@ var TimeDistributed = (function (_super) {
         return tfjs_core_1.tidy(function () {
             inputs = types_utils_1.getExactlyOneTensor(inputs);
             var step = function (inputs, states) {
-                var output = _this.layer.call(inputs, kwargs);
+                var output = types_utils_1.getExactlyOneTensor(_this.layer.call(inputs, kwargs));
                 return [output, []];
             };
-            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, true);
             var y = rnnOutputs[1];
             return y;
         });
@@ -36141,7 +38385,7 @@ var TimeDistributed = (function (_super) {
     return TimeDistributed;
 }(Wrapper));
 exports.TimeDistributed = TimeDistributed;
-tfjs_core_1.serialization.SerializationMap.register(TimeDistributed);
+tfjs_core_1.serialization.registerClass(TimeDistributed);
 exports.VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
 function checkBidirectionalMergeMode(value) {
     generic_utils.checkStringTypeUnionValue(exports.VALID_BIDIRECTIONAL_MERGE_MODES, 'BidirectionalMergeMode', value);
@@ -36312,7 +38556,7 @@ var Bidirectional = (function (_super) {
                 var forwardState = initialState.slice(0, initialState.length / 2);
                 var backwardState = initialState.slice(initialState.length / 2);
                 y = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: forwardState }));
-                yRev = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
+                yRev = _this.backwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
             }
             var states;
             if (_this.returnState) {
@@ -36403,9 +38647,9 @@ var Bidirectional = (function (_super) {
     return Bidirectional;
 }(Wrapper));
 exports.Bidirectional = Bidirectional;
-tfjs_core_1.serialization.SerializationMap.register(Bidirectional);
+tfjs_core_1.serialization.registerClass(Bidirectional);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"./recurrent":228,"./serialization":229,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"./recurrent":252,"./serialization":253,"@tensorflow/tfjs-core":68}],255:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36491,14 +38735,14 @@ function disposeTensorsInLogs(logs) {
 }
 exports.disposeTensorsInLogs = disposeTensorsInLogs;
 
-},{"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],256:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var common_1 = require("./backend/common");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 function l2Normalize(x, axis) {
     return tfjs_core_1.tidy(function () {
@@ -36675,7 +38919,13 @@ function get(identifierOrFn) {
         if (identifierOrFn in lossesMap) {
             return lossesMap[identifierOrFn];
         }
-        throw new errors_1.ValueError("Unknown loss " + identifierOrFn);
+        var errMsg = "Unknown loss " + identifierOrFn;
+        if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+            errMsg = "Unknown loss " + identifierOrFn + ". " +
+                'Use "categoricalCrossentropy" as the string name for ' +
+                'tf.losses.softmaxCrossEntropy';
+        }
+        throw new errors_1.ValueError(errMsg);
     }
     else {
         return identifierOrFn;
@@ -36683,13 +38933,13 @@ function get(identifierOrFn) {
 }
 exports.get = get;
 
-},{"./backend/common":198,"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"@tensorflow/tfjs-core":68}],257:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 var losses_1 = require("./losses");
 var losses_2 = require("./losses");
@@ -36705,6 +38955,54 @@ function categoricalAccuracy(yTrue, yPred) {
     return tfjs_core_1.tidy(function () { return K.cast(tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'); });
 }
 exports.categoricalAccuracy = categoricalAccuracy;
+function truePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function falseNegatives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(zero))
+            .sum()
+            .cast('float32');
+    });
+}
+function falsePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function precision(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fp = falsePositives(yTrue, yPred);
+        var denominator = tp.add(fp);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fn = falseNegatives(yTrue, yPred);
+        var denominator = tp.add(fn);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.recall = recall;
 function binaryCrossentropy(yTrue, yPred) {
     return losses_2.binaryCrossentropy(yTrue, yPred);
 }
@@ -36734,6 +39032,7 @@ function get(identifier) {
     var metricsMap = {
         binaryAccuracy: binaryAccuracy,
         categoricalAccuracy: categoricalAccuracy,
+        precision: precision,
         categoricalCrossentropy: exports.categoricalCrossentropy,
         sparseCategoricalCrossentropy: exports.sparseCategoricalCrossentropy,
         mse: exports.mse,
@@ -36756,7 +39055,7 @@ function get(identifier) {
 }
 exports.get = get;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"./losses":232,"@tensorflow/tfjs-core":68}],234:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"./losses":256,"@tensorflow/tfjs-core":68}],258:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36820,6 +39119,10 @@ function modelFromJSON(modelAndWeightsConfig, customObjects) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
+                    if (!('modelTopology' in modelAndWeightsConfig)) {
+                        modelAndWeightsConfig = { modelTopology: modelAndWeightsConfig };
+                    }
+                    modelAndWeightsConfig = modelAndWeightsConfig;
                     modelTopology = modelAndWeightsConfig.modelTopology;
                     if (modelTopology['model_config'] != null) {
                         modelTopology = modelTopology['model_config'];
@@ -36918,6 +39221,14 @@ var Sequential = (function (_super) {
         }
         return _this;
     }
+    Sequential.prototype.checkShape = function (layer) {
+        var shape = layer.inboundNodes[0].outputTensors[0].shape;
+        if (shape.some(function (x) { return x < 0; })) {
+            throw new errors_1.ValueError('Negative dimension size caused by adding layer ' +
+                (layer.name + " with input shape [") +
+                (layer.inboundNodes[0].inputTensors[0].shape + "]"));
+        }
+    };
     Sequential.prototype.add = function (layer) {
         var isLayerModelInstance = layer instanceof Sequential || layer instanceof training_1.Model;
         var modelLayer;
@@ -36966,6 +39277,7 @@ var Sequential = (function (_super) {
                         'For multi-output layers, ' +
                         'use the functional API.');
                 }
+                this.checkShape(layer);
                 this.outputs = [layer.inboundNodes[0].outputTensors[0]];
                 this.inputs = topology_1.getSourceInputs(this.outputs[0]);
             }
@@ -36991,6 +39303,7 @@ var Sequential = (function (_super) {
                     'For multi-output layers, ' +
                     'use the functional API.');
             }
+            this.checkShape(layer);
             this.outputs = [outputTensor];
             this.inboundNodes[0].outputTensors = this.outputs;
             this.inboundNodes[0].outputShapes = [this.outputs[0].shape];
@@ -37087,6 +39400,16 @@ var Sequential = (function (_super) {
         }
         return this.model.evaluate(x, y, config);
     };
+    Sequential.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before being used.');
+                }
+                return [2, this.model.evaluateDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.prototype.predict = function (x, config) {
         if (config === void 0) { config = {}; }
         if (this.model == null) {
@@ -37121,19 +39444,40 @@ var Sequential = (function (_super) {
             });
         });
     };
+    Sequential.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before ' +
+                        'being used.');
+                }
+                return [2, this.model.fitDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.fromConfig = function (cls, config) {
-        var model = new cls({});
+        var configArray;
+        var extraModelConfig = {};
+        if (config instanceof Array) {
+            if (!(config[0].className != null) ||
+                config[0]['className'] === 'Merge') {
+                throw new errors_1.ValueError('Legacy serialization format not supported yet.');
+            }
+            configArray = config;
+        }
+        else {
+            tfjs_core_1.util.assert(config['layers'] != null, "When the config data for a Sequential model is not an Array, " +
+                "it must be an Object that contains the 'layers' field.");
+            configArray = config['layers'];
+            delete config['layers'];
+            extraModelConfig = config;
+        }
+        var model = new cls(extraModelConfig);
         if (!(model instanceof Sequential)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called on non-Sequential input: " + model);
+            throw new errors_1.NotImplementedError("Sequential.fromConfig called on non-Sequential input: " + model);
         }
-        if (!(config instanceof Array)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called without an array of configs");
-        }
-        if (!(config[0].className != null) || config[0]['className'] === 'Merge') {
-            throw new errors_1.ValueError('Legacy serialization format not supported yet.');
-        }
-        for (var _i = 0, _a = config; _i < _a.length; _i++) {
-            var conf = _a[_i];
+        for (var _i = 0, configArray_1 = configArray; _i < configArray_1.length; _i++) {
+            var conf = configArray_1[_i];
             var layer = serialization_1.deserialize(conf);
             model.add(layer);
         }
@@ -37161,9 +39505,9 @@ var Sequential = (function (_super) {
     return Sequential;
 }(training_1.Model));
 exports.Sequential = Sequential;
-tfjs_core_1.serialization.SerializationMap.register(Sequential);
+tfjs_core_1.serialization.registerClass(Sequential);
 
-},{"./backend/state":199,"./engine/input_layer":207,"./engine/topology":208,"./engine/training":209,"./errors":210,"./layers/serialization":229,"./utils/generic_utils":238,"./utils/serialization_utils":241,"./utils/types_utils":242,"@tensorflow/tfjs-core":68}],235:[function(require,module,exports){
+},{"./backend/state":219,"./engine/input_layer":228,"./engine/topology":229,"./engine/training":230,"./errors":233,"./layers/serialization":253,"./utils/generic_utils":262,"./utils/serialization_utils":265,"./utils/types_utils":266,"@tensorflow/tfjs-core":68}],259:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -37191,7 +39535,7 @@ function getOptimizer(identifier) {
 }
 exports.getOptimizer = getOptimizer;
 
-},{"./backend/common":198,"./errors":210,"@tensorflow/tfjs-core":68}],236:[function(require,module,exports){
+},{"./backend/common":218,"./errors":233,"@tensorflow/tfjs-core":68}],260:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37253,7 +39597,7 @@ var L1L2 = (function (_super) {
     return L1L2;
 }(Regularizer));
 exports.L1L2 = L1L2;
-tfjs_core_1.serialization.SerializationMap.register(L1L2);
+tfjs_core_1.serialization.registerClass(L1L2);
 function l1(config) {
     return new L1L2({ l1: config != null ? config.l1 : null, l2: 0 });
 }
@@ -37294,7 +39638,7 @@ function getRegularizer(identifier) {
 }
 exports.getRegularizer = getRegularizer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],237:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],261:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37354,7 +39698,7 @@ function deconvLength(dimSize, strideSize, kernelSize, padding) {
 }
 exports.deconvLength = deconvLength;
 
-},{"../errors":210,"./generic_utils":238,"./math_utils":240}],238:[function(require,module,exports){
+},{"../errors":233,"./generic_utils":262,"./math_utils":264}],262:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -37623,7 +39967,7 @@ function checkArrayTypeAndLength(x, expectedType, minLength, maxLength) {
 }
 exports.checkArrayTypeAndLength = checkArrayTypeAndLength;
 
-},{"../errors":210}],239:[function(require,module,exports){
+},{"../errors":233}],263:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var variable_utils_1 = require("./variable_utils");
@@ -37783,7 +40127,7 @@ function printLayerSummaryWithConnections(layer, positions, relevantNodes, print
     }
 }
 
-},{"./variable_utils":243}],240:[function(require,module,exports){
+},{"./variable_utils":267}],264:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -37855,7 +40199,7 @@ function range(begin, end) {
 }
 exports.range = range;
 
-},{"../errors":210,"@tensorflow/tfjs-core":68}],241:[function(require,module,exports){
+},{"../errors":233,"@tensorflow/tfjs-core":68}],265:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils = require("../utils/generic_utils");
@@ -37949,7 +40293,7 @@ function convertTsToPythonic(tsConfig, key) {
 }
 exports.convertTsToPythonic = convertTsToPythonic;
 
-},{"../utils/generic_utils":238}],242:[function(require,module,exports){
+},{"../utils/generic_utils":262}],266:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37997,7 +40341,7 @@ function getExactlyOneShape(shapes) {
 }
 exports.getExactlyOneShape = getExactlyOneShape;
 
-},{"../errors":210}],243:[function(require,module,exports){
+},{"../errors":233}],267:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function countParamsInWeights(weights) {
@@ -38015,7 +40359,7 @@ function countParamsInWeights(weights) {
 }
 exports.countParamsInWeights = countParamsInWeights;
 
-},{}],244:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38108,8 +40452,9 @@ function truncatedNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'truncatedNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38118,8 +40463,9 @@ function randomNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'randomNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38154,13 +40500,13 @@ function gradients(lossFn, variables) {
 }
 exports.gradients = gradients;
 
-},{"./backend/state":199,"./common":203,"./errors":210,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
+},{"./backend/state":219,"./common":223,"./errors":233,"@tensorflow/tfjs-core":68}],269:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.7.5';
+var version = '0.8.3';
 exports.version = version;
 
-},{}],246:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -38180,13 +40526,13 @@ exports.version = {
     'tfjs': version_1.version
 };
 
-},{"./version":247,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":217}],247:[function(require,module,exports){
+},{"./version":271,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":241}],271:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.7';
+var version = '0.13.3';
 exports.version = version;
 
-},{}],248:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -38304,7 +40650,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],249:[function(require,module,exports){
+},{}],273:[function(require,module,exports){
 /**
  * Bit twiddling hacks for JavaScript.
  *
@@ -38510,9 +40856,9 @@ exports.nextCombination = function(v) {
 }
 
 
-},{}],250:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 
-},{}],251:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -40250,7 +42596,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":248,"ieee754":259}],252:[function(require,module,exports){
+},{"base64-js":272,"ieee754":283}],276:[function(require,module,exports){
 "use strict"
 
 var createThunk = require("./lib/thunk.js")
@@ -40361,7 +42707,7 @@ function compileCwise(user_args) {
 
 module.exports = compileCwise
 
-},{"./lib/thunk.js":254}],253:[function(require,module,exports){
+},{"./lib/thunk.js":278}],277:[function(require,module,exports){
 "use strict"
 
 var uniq = require("uniq")
@@ -40721,7 +43067,7 @@ function generateCWiseOp(proc, typesig) {
 }
 module.exports = generateCWiseOp
 
-},{"uniq":300}],254:[function(require,module,exports){
+},{"uniq":324}],278:[function(require,module,exports){
 "use strict"
 
 // The function below is called when constructing a cwise function object, and does the following:
@@ -40809,9 +43155,9 @@ function createThunk(proc) {
 
 module.exports = createThunk
 
-},{"./compile.js":253}],255:[function(require,module,exports){
+},{"./compile.js":277}],279:[function(require,module,exports){
 module.exports = require("cwise-compiler")
-},{"cwise-compiler":252}],256:[function(require,module,exports){
+},{"cwise-compiler":276}],280:[function(require,module,exports){
 "use strict"
 
 function dupe_array(count, value, i) {
@@ -40861,7 +43207,7 @@ function dupe(count, value) {
 }
 
 module.exports = dupe
-},{}],257:[function(require,module,exports){
+},{}],281:[function(require,module,exports){
 'use strict';
 
 function FFT(size) {
@@ -41370,7 +43716,7 @@ FFT.prototype._singleRealTransform4 = function _singleRealTransform4(outOff,
   out[outOff + 7] = FDi;
 };
 
-},{}],258:[function(require,module,exports){
+},{}],282:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 1.3.2
@@ -41560,7 +43906,7 @@ if (typeof module !== "undefined" && module.exports) {
   });
 }
 
-},{}],259:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -41646,7 +43992,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],260:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 "use strict"
 
 function iota(n) {
@@ -41658,7 +44004,7 @@ function iota(n) {
 }
 
 module.exports = iota
-},{}],261:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -41681,10 +44027,10 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],262:[function(require,module,exports){
+},{}],286:[function(require,module,exports){
 !function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.MidiConvert=e():t.MidiConvert=e()}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="",e(e.s=7)}([function(t,e,n){"use strict";n.d(e,"a",function(){return r}),n.d(e,"b",function(){return i}),n.d(e,"c",function(){return a});var r=["acoustic grand piano","bright acoustic piano","electric grand piano","honky-tonk piano","electric piano 1","electric piano 2","harpsichord","clavi","celesta","glockenspiel","music box","vibraphone","marimba","xylophone","tubular bells","dulcimer","drawbar organ","percussive organ","rock organ","church organ","reed organ","accordion","harmonica","tango accordion","acoustic guitar (nylon)","acoustic guitar (steel)","electric guitar (jazz)","electric guitar (clean)","electric guitar (muted)","overdriven guitar","distortion guitar","guitar harmonics","acoustic bass","electric bass (finger)","electric bass (pick)","fretless bass","slap bass 1","slap bass 2","synth bass 1","synth bass 2","violin","viola","cello","contrabass","tremolo strings","pizzicato strings","orchestral harp","timpani","string ensemble 1","string ensemble 2","synthstrings 1","synthstrings 2","choir aahs","voice oohs","synth voice","orchestra hit","trumpet","trombone","tuba","muted trumpet","french horn","brass section","synthbrass 1","synthbrass 2","soprano sax","alto sax","tenor sax","baritone sax","oboe","english horn","bassoon","clarinet","piccolo","flute","recorder","pan flute","blown bottle","shakuhachi","whistle","ocarina","lead 1 (square)","lead 2 (sawtooth)","lead 3 (calliope)","lead 4 (chiff)","lead 5 (charang)","lead 6 (voice)","lead 7 (fifths)","lead 8 (bass + lead)","pad 1 (new age)","pad 2 (warm)","pad 3 (polysynth)","pad 4 (choir)","pad 5 (bowed)","pad 6 (metallic)","pad 7 (halo)","pad 8 (sweep)","fx 1 (rain)","fx 2 (soundtrack)","fx 3 (crystal)","fx 4 (atmosphere)","fx 5 (brightness)","fx 6 (goblins)","fx 7 (echoes)","fx 8 (sci-fi)","sitar","banjo","shamisen","koto","kalimba","bag pipe","fiddle","shanai","tinkle bell","agogo","steel drums","woodblock","taiko drum","melodic tom","synth drum","reverse cymbal","guitar fret noise","breath noise","seashore","bird tweet","telephone ring","helicopter","applause","gunshot"],i=["piano","chromatic percussion","organ","guitar","bass","strings","ensemble","brass","reed","pipe","synth lead","synth pad","synth effects","ethnic","percussive","sound effects"],a={0:"standard kit",8:"room kit",16:"power kit",24:"electronic kit",25:"tr-808 kit",32:"jazz kit",40:"brush kit",48:"orchestra kit",56:"sound fx kit"}},function(t,e,n){"use strict";function r(t){return t.replace(/\u0000/g,"")}function i(t,e){return 60/e.bpm*(t/e.PPQ)}function a(t){return"number"==typeof t}function o(t){return"string"==typeof t}function s(t){return["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"][t%12]+(Math.floor(t/12)-1)}e.b=r,e.a=i,e.c=a,n.d(e,"d",function(){return u}),e.e=s,n.d(e,"f",function(){return c});var u=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i;return function(e){return o(e)&&t.test(e)}}(),c=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,e={cbb:-2,cb:-1,c:0,"c#":1,cx:2,dbb:0,db:1,d:2,"d#":3,dx:4,ebb:2,eb:3,e:4,"e#":5,ex:6,fbb:3,fb:4,f:5,"f#":6,fx:7,gbb:5,gb:6,g:7,"g#":8,gx:9,abb:7,ab:8,a:9,"a#":10,ax:11,bbb:9,bb:10,b:11,"b#":12,bx:13};return function(n){var r=t.exec(n),i=r[1],a=r[2];return e[i.toLowerCase()]+12*(parseInt(a)+1)}}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(11),a=(n.n(i),n(10)),o=(n.n(a),n(1)),s=n(9),u=n(5),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(){r(this,t),this.header={bpm:120,timeSignature:[4,4],PPQ:480},this.tracks=[]}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t;return n.header=e.header,e.tracks.forEach(function(t){var e=s.a.fromJSON(t);n.tracks.push(e)}),n}}]),c(t,[{key:"load",value:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:null,r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"GET";return new Promise(function(i,a){var o=new XMLHttpRequest;o.open(r,t),o.responseType="arraybuffer",o.addEventListener("load",function(){4===o.readyState&&200===o.status?i(e.decode(o.response)):a(o.status)}),o.addEventListener("error",a),o.send(n)}).catch(function(t){console.log(t)})}},{key:"decode",value:function(t){var e=this;if(t instanceof ArrayBuffer){var r=new Uint8Array(t);t=String.fromCharCode.apply(null,r)}var a=i(t);return this.header=n.i(u.a)(a),this.tracks=[],a.tracks.forEach(function(t,n){var r=new s.a;r.id=n,e.tracks.push(r);var i=0;t.forEach(function(t){i+=o.a(t.deltaTime,e.header),"meta"===t.type&&"trackName"===t.subtype?r.name=o.b(t.text):"noteOn"===t.subtype?(r.noteOn(t.noteNumber,i,t.velocity/127),-1===r.channelNumber&&(r.channelNumber=t.channel)):"noteOff"===t.subtype?r.noteOff(t.noteNumber,i):"controller"===t.subtype&&t.controllerType?r.cc(t.controllerType,i,t.value/127):"meta"===t.type&&"instrumentName"===t.subtype?r.instrument=t.text:"channel"===t.type&&"programChange"===t.subtype&&(r.patch(t.programNumber),r.channelNumber=t.channel)}),e.header.name||r.length||!r.name||(e.header.name=r.name)}),this}},{key:"encode",value:function(){var t=this,e=new a.File({ticks:this.header.PPQ}),n=this.tracks.filter(function(t){return!t.length})[0];if(this.header.name&&(!n||n.name!==this.header.name)){e.addTrack().addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:this.header.name}))}return this.tracks.forEach(function(n){var r=e.addTrack();r.setTempo(t.bpm),n.name&&r.addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:n.name})),n.encode(r,t.header)}),e.toBytes()}},{key:"toArray",value:function(){for(var t=this.encode(),e=new Array(t.length),n=0;n<t.length;n++)e[n]=t.charCodeAt(n);return e}},{key:"toJSON",value:function(){var t={header:this.header,startTime:this.startTime,duration:this.duration,tracks:(this.tracks||[]).map(function(t){return t.toJSON()})};return t.header.name||(t.header.name=""),t}},{key:"track",value:function(t){var e=new s.a(t);return this.tracks.push(e),e}},{key:"get",value:function(t){return o.c(t)?this.tracks[t]:this.tracks.find(function(e){return e.name===t})}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=new t;return r.header=this.header,r.tracks=this.tracks.map(function(t){return t.slice(e,n)}),r}},{key:"startTime",get:function(){var t=this.tracks.map(function(t){return t.startTime});return t.length?Math.min.apply(Math,t)||0:0}},{key:"bpm",get:function(){return this.header.bpm},set:function(t){var e=this.header.bpm;this.header.bpm=t;var n=e/t;this.tracks.forEach(function(t){return t.scale(n)})}},{key:"timeSignature",get:function(){return this.header.timeSignature},set:function(t){this.header.timeSignature=t}},{key:"duration",get:function(){var t=this.tracks.map(function(t){return t.duration});return t.length?Math.max.apply(Math,t)||0:0}}]),t}()},function(t,e,n){"use strict";function r(t,e){var n=0,r=t.length,i=r;if(r>0&&t[r-1].time<=e)return r-1;for(;n<i;){var a=Math.floor(n+(i-n)/2),o=t[a],s=t[a+1];if(o.time===e){for(var u=a;u<t.length;u++){t[u].time===e&&(a=u)}return a}if(o.time<e&&s.time>e)return a;o.time>e?i=a:o.time<e&&(n=a+1)}return-1}function i(t,e){if(t.length){var n=r(t,e.time);t.splice(n+1,0,e)}else t.push(e)}n.d(e,"a",function(){return i})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),a={1:"modulationWheel",2:"breath",4:"footController",5:"portamentoTime",7:"volume",8:"balance",10:"pan",64:"sustain",65:"portamentoTime",66:"sostenuto",67:"softPedal",68:"legatoFootswitch",84:"portamentoContro"},o=function(){function t(e,n,i){r(this,t),this.number=e,this.time=n,this.value=i}return i(t,[{key:"name",get:function(){if(a.hasOwnProperty(this.number))return a[this.number]}}]),t}()},function(t,e,n){"use strict";function r(t){for(var e={PPQ:t.header.ticksPerBeat},n=0;n<t.tracks.length;n++)for(var r=t.tracks[n],i=0;i<r.length;i++){var a=r[i];"meta"===a.type&&("timeSignature"===a.subtype?e.timeSignature=[a.numerator,a.denominator]:"setTempo"===a.subtype&&(e.bpm||(e.bpm=6e7/a.microsecondsPerBeat)))}return e.bpm=e.bpm||120,e}n.d(e,"a",function(){return r})},function(t,e,n){"use strict";function r(t,e){for(var n=0;n<t.length;n++){var r=t[n],i=e[n];if(r.length>i)return!0}return!1}function i(t,e,n){for(var r=0,i=1/0,a=0;a<t.length;a++){var o=t[a],s=e[a];o[s]&&o[s].time<i&&(r=a,i=o[s].time)}n[r](t[r][e[r]]),e[r]+=1}function a(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];for(var a=e.filter(function(t,e){return e%2==0}),o=new Uint32Array(a.length),s=e.filter(function(t,e){return e%2==1});r(a,o);)i(a,o,s)}n.d(e,"a",function(){return a})},function(t,e,n){"use strict";function r(t){return(new s.a).decode(t)}function i(t,e){var n=(new s.a).load(t);return e&&n.then(e),n}function a(){return new s.a}function o(t){return s.a.fromJSON(t)}Object.defineProperty(e,"__esModule",{value:!0}),e.parse=r,e.load=i,e.create=a,e.fromJSON=o;var s=n(2),u=n(0);n.d(e,"instrumentByPatchID",function(){return u.a}),n.d(e,"instrumentFamilyByID",function(){return u.b}),n.d(e,"drumKitByPatchID",function(){return u.c})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=n(1),a=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),o=function(){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1;if(r(this,t),i.c(e))this.midi=e;else{if(!i.d(e))throw new Error("the midi value must either be in Pitch Notation (e.g. C#4) or a midi value");this.name=e}this.time=n,this.duration=a,this.velocity=o}return a(t,null,[{key:"fromJSON",value:function(e){return new t(e.midi,e.time,e.duration,e.velocity)}}]),a(t,[{key:"match",value:function(t){return i.c(t)?this.midi===t:i.d(t)?this.name.toLowerCase()===t.toLowerCase():void 0}},{key:"toJSON",value:function(){return{name:this.name,midi:this.midi,time:this.time,velocity:this.velocity,duration:this.duration}}},{key:"name",get:function(){return i.e(this.midi)},set:function(t){this.midi=i.f(t)}},{key:"noteOn",get:function(){return this.time},set:function(t){this.time=t}},{key:"noteOff",get:function(){return this.time+this.duration},set:function(t){this.duration=t-this.time}}]),t}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(3),a=n(4),o=n(6),s=n(8),u=n(0),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:-1,i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:-1;r(this,t),this.name=e,this.channelNumber=i,this.notes=[],this.controlChanges={},this.instrumentNumber=n}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t(e.name,e.instrumentNumber,e.channelNumber);return n.id=e.id,e.notes&&e.notes.forEach(function(t){var e=s.a.fromJSON(t);n.notes.push(e)}),e.controlChanges&&(n.controlChanges=e.controlChanges),n}}]),c(t,[{key:"note",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,a=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1,o=new s.a(t,e,r,a);return n.i(i.a)(this.notes,o),this}},{key:"noteOn",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:1,a=new s.a(t,e,0,r);return n.i(i.a)(this.notes,a),this}},{key:"noteOff",value:function(t,e){for(var n=0;n<this.notes.length;n++){var r=this.notes[n];if(r.match(t)&&0===r.duration){r.noteOff=e;break}}return this}},{key:"cc",value:function(t,e,r){this.controlChanges.hasOwnProperty(t)||(this.controlChanges[t]=[]);var o=new a.a(t,e,r);return n.i(i.a)(this.controlChanges[t],o),this}},{key:"patch",value:function(t){return this.instrumentNumber=t,this}},{key:"channel",value:function(t){return this.channelNumber=t,this}},{key:"scale",value:function(t){return this.notes.forEach(function(e){e.time*=t,e.duration*=t}),this}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=Math.max(this.notes.findIndex(function(t){return t.time>=e}),0),i=this.notes.findIndex(function(t){return t.noteOff>=n})+1,a=new t(this.name);return a.notes=this.notes.slice(r,i),a.notes.forEach(function(t){return t.time=t.time-e}),a}},{key:"encode",value:function(t,e){function r(t){var e=Math.floor(i*t),n=Math.max(e-a,0);return a=e,n}var i=e.PPQ/(60/e.bpm),a=0,s=Math.max(0,this.channelNumber);-1!==this.instrumentNumber&&t.instrument(s,this.instrumentNumber),n.i(o.a)(this.noteOns.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOn(s,e.name,r(e.time),Math.floor(127*e.velocity))},this.noteOffs.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOff(s,e.name,r(e.time))})}},{key:"toJSON",value:function(){var t={startTime:this.startTime,duration:this.duration,length:this.length,notes:[],controlChanges:{}};return void 0!==this.id&&(t.id=this.id),t.name=this.name,-1!==this.instrumentNumber&&(t.instrumentNumber=this.instrumentNumber,t.instrument=this.instrument,t.instrumentFamily=this.instrumentFamily),-1!==this.channelNumber&&(t.channelNumber=this.channelNumber,t.isPercussion=this.isPercussion),this.notes.length&&(t.notes=this.notes.map(function(t){return t.toJSON()})),Object.keys(this.controlChanges).length&&(t.controlChanges=this.controlChanges),t}},{key:"noteOns",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOn,midi:e.midi,name:e.name,velocity:e.velocity})}),t}},{key:"noteOffs",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOff,midi:e.midi,name:e.name})}),t}},{key:"length",get:function(){return this.notes.length}},{key:"startTime",get:function(){if(this.notes.length){return this.notes[0].noteOn}return 0}},{key:"duration",get:function(){if(this.notes.length){return this.notes[this.notes.length-1].noteOff}return 0}},{key:"instrument",get:function(){return this.isPercussion?u.c[this.instrumentNumber]:u.a[this.instrumentNumber]},set:function(t){var e=u.a.indexOf(t);-1!==e&&(this.instrumentNumber=e)}},{key:"isPercussion",get:function(){return[9,10].includes(this.channelNumber)}},{key:"instrumentFamily",get:function(){return this.isPercussion?"drums":u.b[Math.floor(this.instrumentNumber/8)]}}]),t}()},function(t,e,n){(function(t){var n={};!function(t){var e=t.DEFAULT_VOLUME=90,n=(t.DEFAULT_DURATION=128,t.DEFAULT_CHANNEL=0,{midi_letter_pitches:{a:21,b:23,c:12,d:14,e:16,f:17,g:19},midiPitchFromNote:function(t){var e=/([a-g])(#+|b+)?([0-9]+)$/i.exec(t),r=e[1].toLowerCase(),i=e[2]||"";return 12*parseInt(e[3],10)+n.midi_letter_pitches[r]+("#"==i.substr(0,1)?1:-1)*i.length},ensureMidiPitch:function(t){return"number"!=typeof t&&/[^0-9]/.test(t)?n.midiPitchFromNote(t):parseInt(t,10)},midi_pitches_letter:{12:"c",13:"c#",14:"d",15:"d#",16:"e",17:"f",18:"f#",19:"g",20:"g#",21:"a",22:"a#",23:"b"},midi_flattened_notes:{"a#":"bb","c#":"db","d#":"eb","f#":"gb","g#":"ab"},noteFromMidiPitch:function(t,e){var r,i=0,a=t,e=e||!1;return t>23&&(i=Math.floor(t/12)-1,a=t-12*i),r=n.midi_pitches_letter[a],e&&r.indexOf("#")>0&&(r=n.midi_flattened_notes[r]),r+i},mpqnFromBpm:function(t){var e=Math.floor(6e7/t),n=[];do{n.unshift(255&e),e>>=8}while(e);for(;n.length<3;)n.push(0);return n},bpmFromMpqn:function(t){var e=t;if(void 0!==t[0]){e=0;for(var n=0,r=t.length-1;r>=0;++n,--r)e|=t[n]<<r}return Math.floor(6e7/t)},codes2Str:function(t){return String.fromCharCode.apply(null,t)},str2Bytes:function(t,e){if(e)for(;t.length/2<e;)t="0"+t;for(var n=[],r=t.length-1;r>=0;r-=2){var i=0===r?t[r]:t[r-1]+t[r];n.unshift(parseInt(i,16))}return n},translateTickTime:function(t){for(var e=127&t;t>>=7;)e<<=8,e|=127&t|128;for(var n=[];;){if(n.push(255&e),!(128&e))break;e>>=8}return n}}),r=function(t){if(!this)return new r(t);!t||null===t.type&&void 0===t.type||null===t.channel&&void 0===t.channel||null===t.param1&&void 0===t.param1||(this.setTime(t.time),this.setType(t.type),this.setChannel(t.channel),this.setParam1(t.param1),this.setParam2(t.param2))};r.NOTE_OFF=128,r.NOTE_ON=144,r.AFTER_TOUCH=160,r.CONTROLLER=176,r.PROGRAM_CHANGE=192,r.CHANNEL_AFTERTOUCH=208,r.PITCH_BEND=224,r.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},r.prototype.setType=function(t){if(t<r.NOTE_OFF||t>r.PITCH_BEND)throw new Error("Trying to set an unknown event: "+t);this.type=t},r.prototype.setChannel=function(t){if(t<0||t>15)throw new Error("Channel is out of bounds.");this.channel=t},r.prototype.setParam1=function(t){this.param1=t},r.prototype.setParam2=function(t){this.param2=t},r.prototype.toBytes=function(){var t=[],e=this.type|15&this.channel;return t.push.apply(t,this.time),t.push(e),t.push(this.param1),void 0!==this.param2&&null!==this.param2&&t.push(this.param2),t};var i=function(t){if(!this)return new i(t);this.setTime(t.time),this.setType(t.type),this.setData(t.data)};i.SEQUENCE=0,i.TEXT=1,i.COPYRIGHT=2,i.TRACK_NAME=3,i.INSTRUMENT=4,i.LYRIC=5,i.MARKER=6,i.CUE_POINT=7,i.CHANNEL_PREFIX=32,i.END_OF_TRACK=47,i.TEMPO=81,i.SMPTE=84,i.TIME_SIG=88,i.KEY_SIG=89,i.SEQ_EVENT=127,i.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},i.prototype.setType=function(t){this.type=t},i.prototype.setData=function(t){this.data=t},i.prototype.toBytes=function(){if(!this.type)throw new Error("Type for meta-event not specified.");var t=[];if(t.push.apply(t,this.time),t.push(255,this.type),Array.isArray(this.data))t.push(this.data.length),t.push.apply(t,this.data);else if("number"==typeof this.data)t.push(1,this.data);else if(null!==this.data&&void 0!==this.data){t.push(this.data.length);var e=this.data.split("").map(function(t){return t.charCodeAt(0)});t.push.apply(t,e)}else t.push(0);return t};var a=function(t){if(!this)return new a(t);var e=t||{};this.events=e.events||[]};a.START_BYTES=[77,84,114,107],a.END_BYTES=[0,255,47,0],a.prototype.addEvent=function(t){return this.events.push(t),this},a.prototype.addNoteOn=a.prototype.noteOn=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_ON,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNoteOff=a.prototype.noteOff=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_OFF,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNote=a.prototype.note=function(t,e,n,r,i){return this.noteOn(t,e,r,i),n&&this.noteOff(t,e,n,i),this},a.prototype.addChord=a.prototype.chord=function(t,e,n,r){if(!Array.isArray(e)&&!e.length)throw new Error("Chord must be an array of pitches");return e.forEach(function(e){this.noteOn(t,e,0,r)},this),e.forEach(function(e,r){0===r?this.noteOff(t,e,n):this.noteOff(t,e)},this),this},a.prototype.setInstrument=a.prototype.instrument=function(t,e,n){return this.events.push(new r({type:r.PROGRAM_CHANGE,channel:t,param1:e,time:n||0})),this},a.prototype.setTempo=a.prototype.tempo=function(t,e){return this.events.push(new i({type:i.TEMPO,data:n.mpqnFromBpm(t),time:e||0})),this},a.prototype.toBytes=function(){var t=0,e=[],r=a.START_BYTES,i=a.END_BYTES,o=function(n){var r=n.toBytes();t+=r.length,e.push.apply(e,r)};this.events.forEach(o),t+=i.length;var s=n.str2Bytes(t.toString(16),4);return r.concat(s,e,i)};var o=function(t){if(!this)return new o(t);var e=t||{};if(e.ticks){if("number"!=typeof e.ticks)throw new Error("Ticks per beat must be a number!");if(e.ticks<=0||e.ticks>=32768||e.ticks%1!=0)throw new Error("Ticks per beat must be an integer between 1 and 32767!")}this.ticks=e.ticks||128,this.tracks=e.tracks||[]};o.HDR_CHUNKID="MThd",o.HDR_CHUNK_SIZE="\0\0\0",o.HDR_TYPE0="\0\0",o.HDR_TYPE1="\0",o.prototype.addTrack=function(t){return t?(this.tracks.push(t),this):(t=new a,this.tracks.push(t),t)},o.prototype.toBytes=function(){var t=this.tracks.length.toString(16),e=o.HDR_CHUNKID+o.HDR_CHUNK_SIZE;return parseInt(t,16)>1?e+=o.HDR_TYPE1:e+=o.HDR_TYPE0,e+=n.codes2Str(n.str2Bytes(t,2)),e+=String.fromCharCode(this.ticks/256,this.ticks%256),this.tracks.forEach(function(t){e+=n.codes2Str(t.toBytes())}),e},t.Util=n,t.File=o,t.Track=a,t.Event=r,t.MetaEvent=i}(n),void 0!==t&&null!==t?t.exports=n:void 0!==e&&null!==e?e=n:this.Midi=n}).call(e,n(12)(t))},function(t,e){function n(t){function e(t){var e=t.read(4),n=t.readInt32();return{id:e,length:n,data:t.read(n)}}var n;stream=r(t);var i=e(stream);if("MThd"!=i.id||6!=i.length)throw"Bad .mid file - header not found";var a=r(i.data),o=a.readInt16(),s=a.readInt16(),u=a.readInt16();if(32768&u)throw"Expressing time division in SMTPE frames is not supported yet";ticksPerBeat=u;for(var c={formatType:o,trackCount:s,ticksPerBeat:ticksPerBeat},h=[],f=0;f<c.trackCount;f++){h[f]=[];var d=e(stream);if("MTrk"!=d.id)throw"Unexpected chunk - expected MTrk, got "+d.id;for(var l=r(d.data);!l.eof();){var p=function(t){var e={};e.deltaTime=t.readVarInt();var r=t.readInt8();if(240==(240&r)){if(255==r){e.type="meta";var i=t.readInt8(),a=t.readVarInt();switch(i){case 0:if(e.subtype="sequenceNumber",2!=a)throw"Expected length for sequenceNumber event is 2, got "+a;return e.number=t.readInt16(),e;case 1:return e.subtype="text",e.text=t.read(a),e;case 2:return e.subtype="copyrightNotice",e.text=t.read(a),e;case 3:return e.subtype="trackName",e.text=t.read(a),e;case 4:return e.subtype="instrumentName",e.text=t.read(a),e;case 5:return e.subtype="lyrics",e.text=t.read(a),e;case 6:return e.subtype="marker",e.text=t.read(a),e;case 7:return e.subtype="cuePoint",e.text=t.read(a),e;case 32:if(e.subtype="midiChannelPrefix",1!=a)throw"Expected length for midiChannelPrefix event is 1, got "+a;return e.channel=t.readInt8(),e;case 47:if(e.subtype="endOfTrack",0!=a)throw"Expected length for endOfTrack event is 0, got "+a;return e;case 81:if(e.subtype="setTempo",3!=a)throw"Expected length for setTempo event is 3, got "+a;return e.microsecondsPerBeat=(t.readInt8()<<16)+(t.readInt8()<<8)+t.readInt8(),e;case 84:if(e.subtype="smpteOffset",5!=a)throw"Expected length for smpteOffset event is 5, got "+a;var o=t.readInt8();return e.frameRate={0:24,32:25,64:29,96:30}[96&o],e.hour=31&o,e.min=t.readInt8(),e.sec=t.readInt8(),e.frame=t.readInt8(),e.subframe=t.readInt8(),e;case 88:if(e.subtype="timeSignature",4!=a)throw"Expected length for timeSignature event is 4, got "+a;return e.numerator=t.readInt8(),e.denominator=Math.pow(2,t.readInt8()),e.metronome=t.readInt8(),e.thirtyseconds=t.readInt8(),e;case 89:if(e.subtype="keySignature",2!=a)throw"Expected length for keySignature event is 2, got "+a;return e.key=t.readInt8(!0),e.scale=t.readInt8(),e;case 127:return e.subtype="sequencerSpecific",e.data=t.read(a),e;default:return e.subtype="unknown",e.data=t.read(a),e}return e.data=t.read(a),e}if(240==r){e.type="sysEx";var a=t.readVarInt();return e.data=t.read(a),e}if(247==r){e.type="dividedSysEx";var a=t.readVarInt();return e.data=t.read(a),e}throw"Unrecognised MIDI event type byte: "+r}var s;0==(128&r)?(s=r,r=n):(s=t.readInt8(),n=r);var u=r>>4;switch(e.channel=15&r,e.type="channel",u){case 8:return e.subtype="noteOff",e.noteNumber=s,e.velocity=t.readInt8(),e;case 9:return e.noteNumber=s,e.velocity=t.readInt8(),0==e.velocity?e.subtype="noteOff":e.subtype="noteOn",e;case 10:return e.subtype="noteAftertouch",e.noteNumber=s,e.amount=t.readInt8(),e;case 11:return e.subtype="controller",e.controllerType=s,e.value=t.readInt8(),e;case 12:return e.subtype="programChange",e.programNumber=s,e;case 13:return e.subtype="channelAftertouch",e.amount=s,e;case 14:return e.subtype="pitchBend",e.value=s+(t.readInt8()<<7),e;default:throw"Unrecognised MIDI event type: "+u}}(l);h[f].push(p)}}return{header:c,tracks:h}}function r(t){function e(e){var n=t.substr(s,e);return s+=e,n}function n(){var e=(t.charCodeAt(s)<<24)+(t.charCodeAt(s+1)<<16)+(t.charCodeAt(s+2)<<8)+t.charCodeAt(s+3);return s+=4,e}function r(){var e=(t.charCodeAt(s)<<8)+t.charCodeAt(s+1);return s+=2,e}function i(e){var n=t.charCodeAt(s);return e&&n>127&&(n-=256),s+=1,n}function a(){return s>=t.length}function o(){for(var t=0;;){var e=i();if(!(128&e))return t+e;t+=127&e,t<<=7}}var s=0;return{eof:a,read:e,readInt32:n,readInt16:r,readInt8:i,readVarInt:o}}t.exports=function(t){return n(t)}},function(t,e){t.exports=function(t){return t.webpackPolyfill||(t.deprecate=function(){},t.paths=[],t.children||(t.children=[]),Object.defineProperty(t,"loaded",{enumerable:!0,get:function(){return t.l}}),Object.defineProperty(t,"id",{enumerable:!0,get:function(){return t.i}}),t.webpackPolyfill=1),t}}])});
 
-},{}],263:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 'use strict'
 
 var ops = require('ndarray-ops')
@@ -41767,7 +44113,7 @@ function ndfft(dir, x, y) {
 }
 
 module.exports = ndfft
-},{"./lib/fft-matrix.js":264,"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],264:[function(require,module,exports){
+},{"./lib/fft-matrix.js":288,"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],288:[function(require,module,exports){
 var bits = require('bit-twiddle')
 
 function fft(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
@@ -41986,7 +44332,7 @@ function fftBluestein(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
   }
 }
 
-},{"bit-twiddle":249}],265:[function(require,module,exports){
+},{"bit-twiddle":273}],289:[function(require,module,exports){
 "use strict"
 
 var compile = require("cwise-compiler")
@@ -42449,7 +44795,7 @@ exports.equals = compile({
 
 
 
-},{"cwise-compiler":252}],266:[function(require,module,exports){
+},{"cwise-compiler":276}],290:[function(require,module,exports){
 "use strict"
 
 var fft = require("ndarray-fft")
@@ -42553,7 +44899,7 @@ function resample(out, inp, clamp_lo, clamp_hi) {
 }
 
 module.exports = resample
-},{"cwise/lib/wrapper":255,"ndarray-fft":263,"ndarray-ops":265,"ndarray-scratch":267}],267:[function(require,module,exports){
+},{"cwise/lib/wrapper":279,"ndarray-fft":287,"ndarray-ops":289,"ndarray-scratch":291}],291:[function(require,module,exports){
 "use strict"
 
 var ndarray = require("ndarray")
@@ -42661,7 +45007,7 @@ function eye(shape, dtype) {
 }
 exports.eye = eye
 
-},{"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],268:[function(require,module,exports){
+},{"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],292:[function(require,module,exports){
 var iota = require("iota-array")
 var isBuffer = require("is-buffer")
 
@@ -43006,7 +45352,7 @@ function wrappedNDArrayCtor(data, shape, stride, offset) {
 
 module.exports = wrappedNDArrayCtor
 
-},{"iota-array":260,"is-buffer":261}],269:[function(require,module,exports){
+},{"iota-array":284,"is-buffer":285}],293:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -43192,9 +45538,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],270:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 arguments[4][50][0].apply(exports,arguments)
-},{"./src/index-minimal":271,"dup":50}],271:[function(require,module,exports){
+},{"./src/index-minimal":295,"dup":50}],295:[function(require,module,exports){
 "use strict";
 var protobuf = exports;
 
@@ -43232,7 +45578,7 @@ function configure() {
 protobuf.Writer._configure(protobuf.BufferWriter);
 configure();
 
-},{"./reader":272,"./reader_buffer":273,"./roots":274,"./rpc":275,"./util/minimal":278,"./writer":279,"./writer_buffer":280}],272:[function(require,module,exports){
+},{"./reader":296,"./reader_buffer":297,"./roots":298,"./rpc":299,"./util/minimal":302,"./writer":303,"./writer_buffer":304}],296:[function(require,module,exports){
 "use strict";
 module.exports = Reader;
 
@@ -43641,17 +45987,17 @@ Reader._configure = function(BufferReader_) {
     });
 };
 
-},{"./util/minimal":278}],273:[function(require,module,exports){
+},{"./util/minimal":302}],297:[function(require,module,exports){
 arguments[4][53][0].apply(exports,arguments)
-},{"./reader":272,"./util/minimal":278,"dup":53}],274:[function(require,module,exports){
+},{"./reader":296,"./util/minimal":302,"dup":53}],298:[function(require,module,exports){
 arguments[4][54][0].apply(exports,arguments)
-},{"dup":54}],275:[function(require,module,exports){
+},{"dup":54}],299:[function(require,module,exports){
 arguments[4][55][0].apply(exports,arguments)
-},{"./rpc/service":276,"dup":55}],276:[function(require,module,exports){
+},{"./rpc/service":300,"dup":55}],300:[function(require,module,exports){
 arguments[4][56][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":56}],277:[function(require,module,exports){
+},{"../util/minimal":302,"dup":56}],301:[function(require,module,exports){
 arguments[4][57][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":57}],278:[function(require,module,exports){
+},{"../util/minimal":302,"dup":57}],302:[function(require,module,exports){
 (function (global){
 "use strict";
 var util = exports;
@@ -44060,11 +46406,11 @@ util._configure = function() {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./longbits":277,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],279:[function(require,module,exports){
+},{"./longbits":301,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],303:[function(require,module,exports){
 arguments[4][59][0].apply(exports,arguments)
-},{"./util/minimal":278,"dup":59}],280:[function(require,module,exports){
+},{"./util/minimal":302,"dup":59}],304:[function(require,module,exports){
 arguments[4][60][0].apply(exports,arguments)
-},{"./util/minimal":278,"./writer":279,"dup":60}],281:[function(require,module,exports){
+},{"./util/minimal":302,"./writer":303,"dup":60}],305:[function(require,module,exports){
 // A library of seedable RNGs implemented in Javascript.
 //
 // Usage:
@@ -44126,7 +46472,7 @@ sr.tychei = tychei;
 
 module.exports = sr;
 
-},{"./lib/alea":282,"./lib/tychei":283,"./lib/xor128":284,"./lib/xor4096":285,"./lib/xorshift7":286,"./lib/xorwow":287,"./seedrandom":288}],282:[function(require,module,exports){
+},{"./lib/alea":306,"./lib/tychei":307,"./lib/xor128":308,"./lib/xor4096":309,"./lib/xorshift7":310,"./lib/xorwow":311,"./seedrandom":312}],306:[function(require,module,exports){
 // A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
 // http://baagoe.com/en/RandomMusings/javascript/
 // https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
@@ -44242,7 +46588,7 @@ if (module && module.exports) {
 
 
 
-},{}],283:[function(require,module,exports){
+},{}],307:[function(require,module,exports){
 // A Javascript implementaion of the "Tyche-i" prng algorithm by
 // Samuel Neves and Filipe Araujo.
 // See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
@@ -44347,7 +46693,7 @@ if (module && module.exports) {
 
 
 
-},{}],284:[function(require,module,exports){
+},{}],308:[function(require,module,exports){
 // A Javascript implementaion of the "xor128" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44430,7 +46776,7 @@ if (module && module.exports) {
 
 
 
-},{}],285:[function(require,module,exports){
+},{}],309:[function(require,module,exports){
 // A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
 //
 // This fast non-cryptographic random number generator is designed for
@@ -44578,7 +46924,7 @@ if (module && module.exports) {
   (typeof define) == 'function' && define   // present with an AMD loader
 );
 
-},{}],286:[function(require,module,exports){
+},{}],310:[function(require,module,exports){
 // A Javascript implementaion of the "xorshift7" algorithm by
 // François Panneton and Pierre L'ecuyer:
 // "On the Xorgshift Random Number Generators"
@@ -44677,7 +47023,7 @@ if (module && module.exports) {
 );
 
 
-},{}],287:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 // A Javascript implementaion of the "xorwow" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44765,7 +47111,7 @@ if (module && module.exports) {
 
 
 
-},{}],288:[function(require,module,exports){
+},{}],312:[function(require,module,exports){
 /*
 Copyright 2014 David Bau.
 
@@ -45014,7 +47360,7 @@ if ((typeof module) == 'object' && module.exports) {
   Math    // math: package containing random, pow, and seedrandom
 );
 
-},{"crypto":250}],289:[function(require,module,exports){
+},{"crypto":274}],313:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45170,7 +47516,7 @@ exports.unique = unique;
 exports.shuffle = shuffle;
 exports.permutations = permutations;
 
-},{"tonal-note":294}],290:[function(require,module,exports){
+},{"tonal-note":318}],314:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45362,7 +47708,7 @@ exports.supersets = supersets;
 exports.subsets = subsets;
 exports.tokenize = tokenize$1;
 
-},{"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],291:[function(require,module,exports){
+},{"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],315:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45734,7 +48080,7 @@ exports.scale = scale;
 exports.chord = chord;
 exports.pcset = pcset;
 
-},{"tonal-pcset":295}],292:[function(require,module,exports){
+},{"tonal-pcset":319}],316:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46013,7 +48359,7 @@ exports.subtract = subtract;
 exports.interval = interval;
 exports.semitones = semitones;
 
-},{"tonal-interval":293,"tonal-note":294}],293:[function(require,module,exports){
+},{"tonal-interval":317,"tonal-note":318}],317:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46354,7 +48700,7 @@ exports.simplify = simplify;
 exports.invert = invert;
 exports.fromSemitones = fromSemitones;
 
-},{}],294:[function(require,module,exports){
+},{}],318:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46769,7 +49115,7 @@ exports.fromMidi = fromMidi;
 exports.simplify = simplify;
 exports.enharmonic = enharmonic;
 
-},{}],295:[function(require,module,exports){
+},{}],319:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46998,7 +49344,7 @@ exports.isSupersetOf = isSupersetOf;
 exports.includes = includes;
 exports.filter = filter;
 
-},{"tonal-array":289,"tonal-interval":293,"tonal-note":294}],296:[function(require,module,exports){
+},{"tonal-array":313,"tonal-interval":317,"tonal-note":318}],320:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47235,7 +49581,7 @@ exports.toScale = toScale;
 exports.supersets = supersets;
 exports.subsets = subsets;
 
-},{"tonal-array":289,"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],297:[function(require,module,exports){
+},{"tonal-array":313,"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],321:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47373,7 +49719,7 @@ exports.freq = freq$1;
 exports.chord = chord$1;
 exports.scale = scale$1;
 
-},{"tonal-array":289,"tonal-chord":290,"tonal-dictionary":291,"tonal-distance":292,"tonal-interval":293,"tonal-note":294,"tonal-pcset":295,"tonal-scale":296}],298:[function(require,module,exports){
+},{"tonal-array":313,"tonal-chord":314,"tonal-dictionary":315,"tonal-distance":316,"tonal-interval":317,"tonal-note":318,"tonal-pcset":319,"tonal-scale":320}],322:[function(require,module,exports){
 (function(root, factory){
 
 	//UMD
@@ -71756,7 +74102,7 @@ exports.scale = scale$1;
 	
 	return Tone;
 }));
-},{}],299:[function(require,module,exports){
+},{}],323:[function(require,module,exports){
 (function (global,Buffer){
 'use strict'
 
@@ -71973,7 +74319,7 @@ exports.clearCache = function clearCache() {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"bit-twiddle":249,"buffer":251,"dup":256}],300:[function(require,module,exports){
+},{"bit-twiddle":273,"buffer":275,"dup":280}],324:[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -72032,7 +74378,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],301:[function(require,module,exports){
+},{}],325:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72080,7 +74426,7 @@ var BinaryCounter = (function (_super) {
 }(AuxiliaryInput));
 exports.BinaryCounter = BinaryCounter;
 
-},{"@tensorflow/tfjs-core":68}],302:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],326:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72274,7 +74620,7 @@ var PitchChordEncoder = (function (_super) {
 }(ChordEncoder));
 exports.PitchChordEncoder = PitchChordEncoder;
 
-},{"./constants":303,"@tensorflow/tfjs-core":68,"tonal":297}],303:[function(require,module,exports){
+},{"./constants":327,"@tensorflow/tfjs-core":68,"tonal":321}],327:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 null;
@@ -72302,7 +74648,7 @@ exports.HI_CLICK_PITCH = 90;
 exports.LO_CLICK_CLASS = 9;
 exports.HI_CLICK_CLASS = 10;
 
-},{}],304:[function(require,module,exports){
+},{}],328:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72874,7 +75220,7 @@ var MultitrackConverter = (function (_super) {
 }(DataConverter));
 exports.MultitrackConverter = MultitrackConverter;
 
-},{"../protobuf/index":320,"./constants":303,"./performance":308,"./sequences":311,"@tensorflow/tfjs-core":68}],305:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./performance":332,"./sequences":335,"@tensorflow/tfjs-core":68}],329:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -72899,7 +75245,7 @@ __export(require("./player"));
 __export(require("./recorder"));
 __export(require("./visualizer"));
 
-},{"./aux_inputs":301,"./chords":302,"./constants":303,"./data":304,"./logging":306,"./midi_io":307,"./performance":308,"./player":309,"./recorder":310,"./sequences":311,"./visualizer":313}],306:[function(require,module,exports){
+},{"./aux_inputs":325,"./chords":326,"./constants":327,"./data":328,"./logging":330,"./midi_io":331,"./performance":332,"./player":333,"./recorder":334,"./sequences":335,"./visualizer":337}],330:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Level;
@@ -72930,7 +75276,7 @@ function logWithDuration(msg, startTime, prefix, level) {
 }
 exports.logWithDuration = logWithDuration;
 
-},{}],307:[function(require,module,exports){
+},{}],331:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73076,7 +75422,7 @@ function sequenceProtoToMidi(ns) {
 }
 exports.sequenceProtoToMidi = sequenceProtoToMidi;
 
-},{"../protobuf":320,"./constants":303,"./sequences":311,"midiconvert":262}],308:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"./sequences":335,"midiconvert":286}],332:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var index_1 = require("../protobuf/index");
@@ -73279,7 +75625,7 @@ var Performance = (function () {
 }());
 exports.Performance = Performance;
 
-},{"../protobuf/index":320,"./constants":303,"./sequences":311}],309:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./sequences":335}],333:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73691,7 +76037,7 @@ var PlayerWithClick = (function (_super) {
 }(Player));
 exports.PlayerWithClick = PlayerWithClick;
 
-},{".":305,"./constants":303,"./data":304,"./soundfont":312,"tone":298}],310:[function(require,module,exports){
+},{".":329,"./constants":327,"./data":328,"./soundfont":336,"tone":322}],334:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -73917,7 +76263,7 @@ var Recorder = (function () {
 }());
 exports.Recorder = Recorder;
 
-},{"../protobuf":320,"./constants":303,"tone":298}],311:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"tone":322}],335:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74188,7 +76534,7 @@ function mergeInstruments(ns) {
 }
 exports.mergeInstruments = mergeInstruments;
 
-},{"../protobuf/index":320,"./constants":303}],312:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327}],336:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74446,7 +76792,7 @@ var SoundFont = (function () {
 }());
 exports.SoundFont = SoundFont;
 
-},{"./constants":303,"tone":298}],313:[function(require,module,exports){
+},{"./constants":327,"tone":322}],337:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require(".");
@@ -74538,7 +76884,7 @@ var Visualizer = (function () {
 }());
 exports.Visualizer = Visualizer;
 
-},{".":305,"./constants":303}],314:[function(require,module,exports){
+},{".":329,"./constants":327}],338:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -74552,7 +76898,7 @@ __export(require("./music_vae"));
 __export(require("./protobuf"));
 __export(require("./transcription"));
 
-},{"./core":305,"./music_rnn":316,"./music_vae":318,"./protobuf":320,"./transcription":324,"@tensorflow/tfjs":246}],315:[function(require,module,exports){
+},{"./core":329,"./music_rnn":340,"./music_vae":342,"./protobuf":344,"./transcription":348,"@tensorflow/tfjs":270}],339:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tf = require("@tensorflow/tfjs-core");
@@ -74616,13 +76962,13 @@ var AttentionWrapper = (function () {
 }());
 exports.AttentionWrapper = AttentionWrapper;
 
-},{"@tensorflow/tfjs-core":68}],316:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],340:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.MusicRNN = model_1.MusicRNN;
 
-},{"./model":317}],317:[function(require,module,exports){
+},{"./model":341}],341:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74921,7 +77267,7 @@ var MusicRNN = (function () {
 }());
 exports.MusicRNN = MusicRNN;
 
-},{"../core/aux_inputs":301,"../core/chords":302,"../core/data":304,"../core/logging":306,"../core/sequences":311,"./attention":315,"@tensorflow/tfjs-core":68}],318:[function(require,module,exports){
+},{"../core/aux_inputs":325,"../core/chords":326,"../core/data":328,"../core/logging":330,"../core/sequences":335,"./attention":339,"@tensorflow/tfjs-core":68}],342:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
@@ -74929,7 +77275,7 @@ exports.Decoder = model_1.Decoder;
 exports.Encoder = model_1.Encoder;
 exports.MusicVAE = model_1.MusicVAE;
 
-},{"./model":319}],319:[function(require,module,exports){
+},{"./model":343}],343:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -75673,14 +78019,14 @@ var MusicVAE = (function () {
 }());
 exports.MusicVAE = MusicVAE;
 
-},{"../core/chords":302,"../core/constants":303,"../core/data":304,"../core/logging":306,"@tensorflow/tfjs-core":68}],320:[function(require,module,exports){
+},{"../core/chords":326,"../core/constants":327,"../core/data":328,"../core/logging":330,"@tensorflow/tfjs-core":68}],344:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var proto_1 = require("./proto");
 var NoteSequence = proto_1.tensorflow.magenta.NoteSequence;
 exports.NoteSequence = NoteSequence;
 
-},{"./proto":321}],321:[function(require,module,exports){
+},{"./proto":345}],345:[function(require,module,exports){
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
@@ -81391,7 +83737,7 @@ $root.tensorflow = (function() {
 
 module.exports = $root;
 
-},{"protobufjs/minimal":270}],322:[function(require,module,exports){
+},{"protobufjs/minimal":294}],346:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -81770,7 +84116,7 @@ function max(arr) {
     return arr.reduce(function (a, b) { return Math.max(a, b); });
 }
 
-},{"../core/logging":306,"./constants":323,"fft.js":257,"ndarray":268,"ndarray-resample":266}],323:[function(require,module,exports){
+},{"../core/logging":330,"./constants":347,"fft.js":281,"ndarray":292,"ndarray-resample":290}],347:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SAMPLE_RATE = 16000;
@@ -81781,13 +84127,13 @@ exports.MIN_MIDI_PITCH = 21;
 exports.MAX_MIDI_PITCH = 108;
 exports.MIDI_PITCHES = exports.MAX_MIDI_PITCH - exports.MIN_MIDI_PITCH + 1;
 
-},{}],324:[function(require,module,exports){
+},{}],348:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.OnsetsAndFrames = model_1.OnsetsAndFrames;
 
-},{"./model":325}],325:[function(require,module,exports){
+},{"./model":349}],349:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82153,7 +84499,7 @@ var Lstm = (function () {
     return Lstm;
 }());
 
-},{"../core/logging":306,"./audio_utils":322,"./constants":323,"./transcription_utils":326,"@tensorflow/tfjs":246}],326:[function(require,module,exports){
+},{"../core/logging":330,"./audio_utils":346,"./constants":347,"./transcription_utils":350,"@tensorflow/tfjs":270}],350:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82323,4 +84669,4 @@ function pianorollToNoteSequence(frameProbs, onsetProbs, velocityValues, onsetTh
 }
 exports.pianorollToNoteSequence = pianorollToNoteSequence;
 
-},{"../protobuf":320,"./constants":323,"@tensorflow/tfjs":246}]},{},[2]);
+},{"../protobuf":344,"./constants":347,"@tensorflow/tfjs":270}]},{},[2]);

--- a/docs/music/demos/recorder_bundle.js
+++ b/docs/music/demos/recorder_bundle.js
@@ -418,7 +418,7 @@ function notesMatch(aNotes, bNotes) {
 }
 exports.notesMatch = notesMatch;
 
-},{"../src/index":314,"file-saver":258}],2:[function(require,module,exports){
+},{"../src/index":338,"file-saver":282}],2:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var mm = require("../src/index");
@@ -478,7 +478,7 @@ stopStreamBtnBtn.addEventListener('click', function () {
     }
 });
 
-},{"../src/index":314,"./common":1}],3:[function(require,module,exports){
+},{"../src/index":338,"./common":1}],3:[function(require,module,exports){
 "use strict";
 module.exports = asPromise;
 
@@ -3228,7 +3228,7 @@ var FrozenModel = (function () {
         });
     };
     FrozenModel.prototype.predict = function (inputs, config) {
-        return this.execute(inputs, this.outputNodes);
+        return this.execute_(inputs, true, this.outputNodes);
     };
     FrozenModel.prototype.constructTensorMap = function (inputs) {
         var inputArray = inputs instanceof tfc.Tensor ? [inputs] : inputs;
@@ -3243,6 +3243,10 @@ var FrozenModel = (function () {
         }, {});
     };
     FrozenModel.prototype.execute = function (inputs, outputs) {
+        return this.execute_(inputs, false, outputs);
+    };
+    FrozenModel.prototype.execute_ = function (inputs, strictInputCheck, outputs) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         outputs = outputs || this.outputNodes;
         if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
             inputs = this.constructTensorMap(inputs);
@@ -3251,7 +3255,7 @@ var FrozenModel = (function () {
             throw new Error('The model contains control flow or dynamic shape ops, ' +
                 'please use executeAsync method');
         }
-        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), outputs);
+        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
         var keys = Object.keys(result);
         return (Array.isArray(outputs) && outputs.length > 1) ?
             outputs.map(function (node) { return result[node]; }) :
@@ -3365,8 +3369,9 @@ var execution_context_1 = require("./execution_context");
 var GraphExecutor = (function () {
     function GraphExecutor(graph) {
         this.graph = graph;
-        this.compiledOrder = [];
+        this.compiledMap = new Map();
         this._weightMap = {};
+        this.SEPERATOR = ',';
         this.placeholders = graph.placeholders;
         this._outputs = graph.outputs;
         this.compile();
@@ -3441,16 +3446,23 @@ var GraphExecutor = (function () {
         enumerable: true,
         configurable: true
     });
-    GraphExecutor.prototype.compile = function () {
+    GraphExecutor.prototype.compile = function (startNodes) {
         if (this.graph.withControlFlow || this.graph.withDynamicShape) {
             return;
         }
-        var stack = this.graph.inputs.slice();
+        var compiledOrder = [];
+        var inputs = startNodes || this.graph.placeholders;
+        var sortedNodeNames = inputs.map(function (node) { return node.name; }).sort();
+        var nameKey = sortedNodeNames.join(this.SEPERATOR);
+        if (this.compiledMap.get(nameKey)) {
+            return;
+        }
+        var stack = inputs.concat(this.graph.weights);
         var visited = {};
         while (stack.length > 0) {
             var node = stack.pop();
             visited[node.name] = true;
-            this.compiledOrder.push(node);
+            compiledOrder.push(node);
             node.children.forEach(function (childNode) {
                 if (!visited[childNode.name] && childNode.inputNames.every(function (name) {
                     var nodeName = utils_1.getNodeNameAndIndex(name)[0];
@@ -3460,19 +3472,33 @@ var GraphExecutor = (function () {
                 }
             });
         }
+        this.compiledMap.set(nameKey, compiledOrder);
     };
-    GraphExecutor.prototype.execute = function (inputs, outputs) {
+    GraphExecutor.prototype.execute = function (inputs, strictInputCheck, outputs) {
         var _this = this;
-        this.checkInput(inputs);
-        this.checkInputShapeAndType(inputs);
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
+        var names = Object.keys(inputs).sort();
+        this.checkInput(inputs, strictInputCheck);
+        this.checkInputShapeAndType(inputs, strictInputCheck);
+        this.compile(names.map(function (name) { return _this.graph.nodes[name]; }));
+        var outputNames = this.calculateOutputs(outputs);
+        this.checkOutput(this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
         var tensorArrayMap = {};
         var result = tfjs_core_1.tidy(function () {
             var context = new execution_context_1.ExecutionContext(_this._weightMap, tensorArrayMap);
-            var tensors = _this.compiledOrder.reduce(function (map, node) {
-                map[node.name] = operation_executor_1.executeOp(node, map, context);
-                return map;
-            }, __assign({}, _this.weightMap, inputs));
-            return _this.findOutputs(tensors, context, outputs);
+            var tensorMap = __assign({}, _this.weightMap, inputs);
+            var compiledNodes = _this.compiledMap.get(names.join(_this.SEPERATOR));
+            for (var i = 0; i < compiledNodes.length; i++) {
+                var node = compiledNodes[i];
+                if (!tensorMap[node.name]) {
+                    tensorMap[node.name] =
+                        operation_executor_1.executeOp(node, tensorMap, context);
+                }
+                if (outputNames.every(function (name) { return !!tensorMap[name]; })) {
+                    break;
+                }
+            }
+            return _this.findOutputs(tensorMap, context, outputNames);
         });
         return result;
     };
@@ -3483,8 +3509,8 @@ var GraphExecutor = (function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        this.checkInput(inputs);
-                        this.checkInputShapeAndType(inputs);
+                        this.checkInput(inputs, false);
+                        this.checkInputShapeAndType(inputs, false);
                         tensorArrayMap = {};
                         context = new execution_context_1.ExecutionContext(this._weightMap, tensorArrayMap);
                         return [4, this.executeWithControlFlow(inputs, context)];
@@ -3511,11 +3537,14 @@ var GraphExecutor = (function () {
     };
     GraphExecutor.prototype.executeWithControlFlow = function (inputs, context) {
         return __awaiter(this, void 0, void 0, function () {
-            var stack, tensorMap, added, promises;
+            var _this = this;
+            var names, inputNodes, stack, tensorMap, added, promises;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        stack = this.graph.inputs.map(function (node) {
+                        names = Object.keys(inputs);
+                        inputNodes = names.map(function (name) { return _this.graph.nodes[name]; });
+                        stack = inputNodes.concat(this.graph.weights).map(function (node) {
                             return { node: node, contexts: context.currentContext };
                         });
                         tensorMap = __assign({}, this.weightMap, inputs);
@@ -3523,7 +3552,7 @@ var GraphExecutor = (function () {
                         _a.label = 1;
                     case 1:
                         if (!(stack.length > 0)) return [3, 3];
-                        promises = this.processStack(stack, context, tensorMap, added);
+                        promises = this.processStack(inputNodes, stack, context, tensorMap, added);
                         return [4, Promise.all(promises)];
                     case 2:
                         _a.sent();
@@ -3533,7 +3562,7 @@ var GraphExecutor = (function () {
             });
         });
     };
-    GraphExecutor.prototype.processStack = function (stack, context, tensorMap, added) {
+    GraphExecutor.prototype.processStack = function (inputNodes, stack, context, tensorMap, added) {
         var _this = this;
         var promises = [];
         var _loop_1 = function () {
@@ -3544,21 +3573,26 @@ var GraphExecutor = (function () {
                 utils_1.getParamValue('isConstant', item.node, tensorMap, context)) {
                 nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
             }
-            var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
-            if (!nodeName) {
-                nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
-            }
-            var currentContext = context.currentContext;
-            if (tensors instanceof Promise) {
-                promises.push(tensors.then(function (t) {
-                    tensorMap[nodeName] = t;
-                    context.currentContext = currentContext;
-                    _this.processChildNodes(item.node, stack, context, tensorMap, added);
-                    return t;
-                }));
+            if (inputNodes.indexOf(item.node) === -1) {
+                var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
+                if (!nodeName) {
+                    nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
+                }
+                var currentContext_1 = context.currentContext;
+                if (tensors instanceof Promise) {
+                    promises.push(tensors.then(function (t) {
+                        tensorMap[nodeName] = t;
+                        context.currentContext = currentContext_1;
+                        _this.processChildNodes(item.node, stack, context, tensorMap, added);
+                        return t;
+                    }));
+                }
+                else {
+                    tensorMap[nodeName] = tensors;
+                    this_1.processChildNodes(item.node, stack, context, tensorMap, added);
+                }
             }
             else {
-                tensorMap[nodeName] = tensors;
                 this_1.processChildNodes(item.node, stack, context, tensorMap, added);
             }
         };
@@ -3589,11 +3623,14 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+    GraphExecutor.prototype.calculateOutputs = function (outputs) {
         if (outputs && !(outputs instanceof Array)) {
             outputs = [outputs];
         }
-        var requestedOutputs = (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+        return (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+    };
+    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+        var requestedOutputs = this.calculateOutputs(outputs);
         return requestedOutputs.reduce(function (map, name) {
             map[name] = utils_1.getTensor(name, tensorMap, context);
             return map;
@@ -3604,9 +3641,14 @@ var GraphExecutor = (function () {
         Object.keys(this.weightMap)
             .forEach(function (key) { return _this.weightMap[key].forEach(function (tensor) { return tensor.dispose(); }); });
     };
-    GraphExecutor.prototype.checkInputShapeAndType = function (inputs) {
+    GraphExecutor.prototype.checkInputShapeAndType = function (inputs, strictInputCheck) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         this.placeholders.forEach(function (node) {
-            var input = inputs[node.name][0];
+            var inputTensors = inputs[node.name];
+            if (!strictInputCheck && !inputTensors) {
+                return;
+            }
+            var input = inputTensors[0];
             if (node.params['shape'] && node.params['shape'].value) {
                 var shape_1 = node.params['shape'].value;
                 var match = shape_1.length === input.shape.length &&
@@ -3618,8 +3660,9 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.checkInput = function (inputs) {
+    GraphExecutor.prototype.checkInput = function (inputs, strictInputCheck) {
         var _this = this;
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         var inputKeys = Object.keys(inputs);
         var missing = [];
         var extra = [];
@@ -3631,14 +3674,31 @@ var GraphExecutor = (function () {
             if (_this.inputNodes.indexOf(name) === -1)
                 extra.push(name);
         });
-        if (missing.length > 0) {
+        var notInGraph = extra.filter(function (name) { return !_this.graph.nodes[name]; });
+        if (missing.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has the keys " +
                 ("[" + inputKeys + "], but is missing the required keys: [" + missing + "]."));
         }
-        if (extra.length > 0) {
+        if (extra.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has " +
                 ("unused keys: [" + extra + "]. Please provide only the following keys: ") +
                 ("[" + this.inputNodes + "]."));
+        }
+        if (notInGraph.length > 0) {
+            throw new Error("The dict provided in model.execute(dict) has " +
+                ("keys: [" + notInGraph + "] not part of model graph."));
+        }
+    };
+    GraphExecutor.prototype.checkOutput = function (compiledNodes, outputs) {
+        var compiledNodeNames = compiledNodes.map(function (node) { return node.name; });
+        var extra = [];
+        outputs.forEach(function (name) {
+            if (compiledNodeNames.indexOf(name) === -1)
+                extra.push(name);
+        });
+        if (extra.length > 0) {
+            throw new Error("The following outputs are not be generated by the execution: " +
+                ("[" + extra + "]."));
         }
     };
     return GraphExecutor;
@@ -4354,6 +4414,9 @@ exports.executeOp = function (node, tensorMap, context) {
             return [snapshot.clone()];
         case 'shape':
             return [tfc.tensor1d(utils_1.getParamValue('x', node, tensorMap, context).shape, 'int32')];
+        case 'shapeN':
+            return utils_1.getParamValue('x', node, tensorMap, context)
+                .map(function (t) { return tfc.tensor1d(t.shape); });
         case 'size':
             return [tfc.scalar(utils_1.getParamValue('x', node, tensorMap, context).size, 'int32')];
         case 'rank':
@@ -4396,6 +4459,15 @@ exports.executeOp = function (node, tensorMap, context) {
             var size = utils_1.getParamValue('size', node, tensorMap, context);
             var alignCorners = utils_1.getParamValue('alignCorners', node, tensorMap, context);
             return [tfc.image.resizeNearestNeighbor(images, [size[0], size[1]], alignCorners)];
+        }
+        case 'cropAndResize': {
+            var image = utils_1.getParamValue('image', node, tensorMap, context);
+            var boxes = utils_1.getParamValue('boxes', node, tensorMap, context);
+            var boxInd = utils_1.getParamValue('boxInd', node, tensorMap, context);
+            var cropSize = utils_1.getParamValue('cropSize', node, tensorMap, context);
+            var method = utils_1.getParamValue('method', node, tensorMap, context);
+            var extrapolationValue = utils_1.getParamValue('extrapolationValue', node, tensorMap, context);
+            return [tfc.image.cropAndResize(image, boxes, boxInd, cropSize, method, extrapolationValue)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4529,6 +4601,11 @@ exports.executeOp = function (node, tensorMap, context) {
         case 'argMin': {
             var axis = utils_1.getParamValue('axis', node, tensorMap, context);
             return [tfc.argMin(utils_1.getParamValue('x', node, tensorMap, context), axis)];
+        }
+        case 'prod': {
+            var axis = utils_1.getParamValue('axis', node, tensorMap, context);
+            var keepDims = utils_1.getParamValue('keepDims', node, tensorMap, context);
+            return [tfc.prod(utils_1.getParamValue('x', node, tensorMap, context), axis, keepDims)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4885,6 +4962,20 @@ exports.json = [
     },
     {
         'tfOpName': 'Mod',
+        'dlOpName': 'mod',
+        'category': 'arithmetic',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'FloorMod',
         'dlOpName': 'mod',
         'category': 'arithmetic',
         'params': [
@@ -6044,6 +6135,17 @@ exports.json = [
         'params': [{ 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' }]
     },
     {
+        'tfOpName': 'ShapeN',
+        'dlOpName': 'shapeN',
+        'category': 'graph',
+        'params': [{
+                'tfInputIndex': 0,
+                'tfInputParamLength': 0,
+                'dlParamName': 'x',
+                'type': 'tensors'
+            }]
+    },
+    {
         'tfOpName': 'Print',
         'dlOpName': 'print',
         'category': 'graph',
@@ -6125,6 +6227,22 @@ exports.json = [
                 'dlParamName': 'dtype',
                 'type': 'dtype',
                 'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'CropAndResize',
+        'dlOpName': 'cropAndResize',
+        'category': 'image',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'image', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'boxes', 'type': 'tensor' },
+            { 'tfInputIndex': 2, 'dlParamName': 'boxInd', 'type': 'tensor' },
+            { 'tfInputIndex': 3, 'dlParamName': 'cropSize', 'type': 'number[]' },
+            { 'tfParamName': 'method', 'dlParamName': 'method', 'type': 'string' }, {
+                'tfParamName': 'extrapolation_value',
+                'dlParamName': 'extrapolationValue',
+                'type': 'number'
             }
         ]
     }
@@ -6294,6 +6412,32 @@ exports.json = [
             },
             {
                 'tfParamName': 'transpose_b',
+                'dlParamName': 'transposeB',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'BatchMatMul',
+        'dlOpName': 'matMul',
+        'category': 'matrices',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'adj_x',
+                'dlParamName': 'transposeA',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'adj_y',
                 'dlParamName': 'transposeB',
                 'type': 'bool',
                 'defaultValue': false
@@ -6491,6 +6635,19 @@ exports.json = [
         'params': [
             { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
             { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number' }
+        ]
+    },
+    {
+        'tfOpName': 'Prod',
+        'dlOpName': 'prod',
+        'category': 'reduction',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number[]' }, {
+                'tfParamName': 'keep_dims',
+                'dlParamName': 'keepDims',
+                'type': 'bool'
+            }
         ]
     }
 ];
@@ -6699,6 +6856,21 @@ exports.json = [
                 'dlParamName': 'numOrSizeSplits',
                 'type': 'number',
                 'defaultValue': 1
+            }
+        ]
+    },
+    {
+        'tfOpName': 'SplitV',
+        'dlOpName': 'split',
+        'category': 'slice_join',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'numOrSizeSplits', 'type': 'number[]' },
+            {
+                'tfInputIndex': 2,
+                'dlParamName': 'axis',
+                'type': 'number',
+                'defaultValue': 0
             }
         ]
     }
@@ -6917,6 +7089,7 @@ var OperationMapper = (function () {
         var withControlFlow = false;
         var withDynamicShape = false;
         var placeholders = [];
+        var weights = [];
         var nodes = tfNodes.reduce(function (map, node) {
             map[node.name] = _this.mapNode(node);
             if (_this.isControlFlow(node))
@@ -6925,6 +7098,8 @@ var OperationMapper = (function () {
                 withDynamicShape = true;
             if (node.op === 'Placeholder')
                 placeholders.push(map[node.name]);
+            if (node.op === 'Const')
+                weights.push(map[node.name]);
             return map;
         }, {});
         var inputs = [];
@@ -6948,6 +7123,7 @@ var OperationMapper = (function () {
             nodes: nodes,
             inputs: inputs,
             outputs: outputs,
+            weights: weights,
             placeholders: placeholders,
             withControlFlow: withControlFlow,
             withDynamicShape: withDynamicShape
@@ -7085,7 +7261,7 @@ exports.OperationMapper = OperationMapper;
 },{"../data/compiled_api":10,"./executors/utils":31,"./op_list/arithmetic":32,"./op_list/basic_math":33,"./op_list/control":34,"./op_list/convolution":35,"./op_list/creation":36,"./op_list/dynamic":37,"./op_list/evaluation":38,"./op_list/graph":39,"./op_list/image":40,"./op_list/logical":41,"./op_list/matrices":42,"./op_list/normalization":43,"./op_list/reduction":44,"./op_list/slice_join":45,"./op_list/transformation":46}],49:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.5.9';
+var version = '0.6.5';
 exports.version = version;
 
 },{}],50:[function(require,module,exports){
@@ -9024,18 +9200,24 @@ var Engine = (function () {
         this.safeMode = safeMode;
         this.debugMode = debugMode;
         this.registeredVariables = {};
-        this.refCounter = new WeakMap();
         this.nextTapeNodeId = 0;
         this.numBytes = 0;
         this.numTensors = 0;
         this.numDataBuffers = 0;
+        this.profiling = false;
         this.gradientScopeCount = 0;
         this.customGradientDepth = 0;
         this.keepTensors = new Set();
+        this.tensorInfo = new WeakMap();
         this.activeScope = { track: [], name: 'default scope' };
         this.scopeStack = [this.activeScope];
         this.profiler = new profiler_1.Profiler(backend);
+        this.activeProfile =
+            { newBytes: 0, newTensors: 0, peakBytes: 0, kernels: [], result: null };
     }
+    Engine.prototype.moveData = function (dataId) {
+        this.write(dataId, this.readSync(dataId));
+    };
     Engine.prototype.tidy = function (nameOrFn, fn, gradMode) {
         var _this = this;
         if (gradMode === void 0) { gradMode = false; }
@@ -9087,6 +9269,8 @@ var Engine = (function () {
             return x;
         };
         var scopeName = this.activeScope.name;
+        var startingBytecount = this.numBytes;
+        var startingNumTensors = this.numTensors;
         this.scopedRun(function () { return _this.customGradientDepth++; }, function () { return _this.customGradientDepth--; }, function () {
             if (!_this.debugMode()) {
                 result = forwardFunc(_this.backend, saveFunc);
@@ -9108,10 +9292,25 @@ var Engine = (function () {
             }
             this.activeTape.push(tapeNode);
         }
+        if (this.profiling) {
+            this.activeProfile.kernels.push({
+                name: scopeName,
+                bytesAdded: this.numBytes - startingBytecount,
+                totalBytesSnapshot: this.numBytes,
+                tensorsAdded: this.numTensors - startingNumTensors,
+                totalTensorsSnapshot: this.numTensors,
+                inputShapes: Object.keys(inputs).map(function (key) { return inputs[key].shape; }),
+                outputShape: Array.isArray(result) ?
+                    result.map(function (item) { return item.shape; }) :
+                    result.shape
+            });
+        }
         return result;
     };
     Engine.prototype.registerTensor = function (a) {
-        var refCount = this.refCounter.has(a.dataId) ? this.refCounter.get(a.dataId) : 0;
+        var refCount = this.tensorInfo.has(a.dataId) ?
+            this.tensorInfo.get(a.dataId).refCount :
+            0;
         this.numTensors++;
         if (refCount === 0) {
             this.numDataBuffers++;
@@ -9119,9 +9318,10 @@ var Engine = (function () {
                 this.numBytes +=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.set(a.dataId, { backend: this.backend, dtype: a.dtype, shape: a.shape, refCount: 0 });
             this.backend.register(a.dataId, a.shape, a.dtype);
         }
-        this.refCounter.set(a.dataId, refCount + 1);
+        this.tensorInfo.get(a.dataId).refCount++;
         if (!(a instanceof tensor_1.Variable)) {
             this.track(a);
         }
@@ -9133,25 +9333,26 @@ var Engine = (function () {
         this.registeredVariables[v.name] = v;
     };
     Engine.prototype.disposeTensor = function (a) {
-        if (!this.refCounter.has(a.dataId)) {
+        if (!this.tensorInfo.has(a.dataId)) {
             return;
         }
         if (this.keepTensors.has(a.id)) {
             this.keepTensors.delete(a.id);
         }
         this.numTensors--;
-        var refCount = this.refCounter.get(a.dataId);
+        var refCount = this.tensorInfo.get(a.dataId).refCount;
         if (refCount <= 1) {
-            this.refCounter.delete(a.dataId);
-            this.backend.disposeData(a.dataId);
+            var info = this.tensorInfo.get(a.dataId);
+            info.backend.disposeData(a.dataId);
             this.numDataBuffers--;
             if (a.dtype !== 'complex64') {
                 this.numBytes -=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.delete(a.dataId);
         }
         else {
-            this.refCounter.set(a.dataId, refCount - 1);
+            this.tensorInfo.get(a.dataId).refCount--;
         }
     };
     Engine.prototype.disposeVariables = function () {
@@ -9167,6 +9368,23 @@ var Engine = (function () {
         info.numDataBuffers = this.numDataBuffers;
         info.numBytes = this.numBytes;
         return info;
+    };
+    Engine.prototype.profile = function (query) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startBytes, startNumTensors;
+            return __generator(this, function (_a) {
+                this.profiling = true;
+                startBytes = this.numBytes;
+                startNumTensors = this.numTensors;
+                this.activeProfile.kernels = [];
+                this.activeProfile.result = query();
+                this.profiling = false;
+                this.activeProfile.peakBytes = Math.max.apply(Math, this.activeProfile.kernels.map(function (d) { return d.totalBytesSnapshot; }));
+                this.activeProfile.newBytes = this.numBytes - startBytes;
+                this.activeProfile.newTensors = this.numTensors - startNumTensors;
+                return [2, this.activeProfile];
+            });
+        });
     };
     Engine.prototype.shouldRecord = function () {
         return this.activeTape != null && this.customGradientDepth === 0;
@@ -9312,13 +9530,21 @@ var Engine = (function () {
         };
     };
     Engine.prototype.write = function (dataId, values) {
+        var info = this.tensorInfo.get(dataId);
+        if (this.backend !== info.backend) {
+            info.backend.disposeData(dataId);
+            info.backend = this.backend;
+            this.backend.register(dataId, info.shape, info.dtype);
+        }
         this.backend.write(dataId, values);
     };
     Engine.prototype.readSync = function (dataId) {
-        return this.backend.readSync(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.readSync(dataId);
     };
     Engine.prototype.read = function (dataId) {
-        return this.backend.read(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.read(dataId);
     };
     Engine.prototype.fromPixels = function (pixels, numChannels) {
         return this.backend.fromPixels(pixels, numChannels);
@@ -9355,7 +9581,7 @@ function ones(shape) {
     return tensor_1.Tensor.make(shape, { values: values });
 }
 
-},{"./profiler":184,"./tape":186,"./tensor":187,"./tensor_util":189,"./util":194}],64:[function(require,module,exports){
+},{"./profiler":204,"./tape":206,"./tensor":207,"./tensor_util":209,"./util":214}],64:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -9371,7 +9597,6 @@ var TEST_EPSILON_FLOAT32 = 1e-3;
 var Environment = (function () {
     function Environment(features) {
         this.features = {};
-        this.engines = {};
         this.registry = {};
         if (features != null) {
             this.features = features;
@@ -9387,10 +9612,11 @@ var Environment = (function () {
         if (!(backendName in exports.ENV.registry)) {
             throw new Error("Backend name '" + backendName + "' not found in registry");
         }
-        exports.ENV.initBackend(backendName, safeMode);
+        exports.ENV.engine.backend = exports.ENV.findBackend(backendName);
+        exports.ENV.backendName = backendName;
     };
     Environment.getBackend = function () {
-        exports.ENV.initDefaultBackend();
+        exports.ENV.initEngine();
         return exports.ENV.backendName;
     };
     Environment.disposeVariables = function () {
@@ -9398,6 +9624,9 @@ var Environment = (function () {
     };
     Environment.memory = function () {
         return exports.ENV.engine.memory();
+    };
+    Environment.profile = function (f) {
+        return exports.ENV.engine.profile(f);
     };
     Environment.tidy = function (nameOrFn, fn, gradMode) {
         if (gradMode === void 0) { gradMode = false; }
@@ -9454,6 +9683,18 @@ var Environment = (function () {
         else if (feature === 'IS_CHROME') {
             return environment_util_1.isChrome();
         }
+        else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+            return false;
+        }
+        else if (feature === 'WEBGL_CONV_IM2COL') {
+            return false;
+        }
+        else if (feature === 'WEBGL_PAGING_ENABLED') {
+            return this.get('IS_BROWSER') && !this.get('PROD');
+        }
+        else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
+            return environment_util_1.getWebGLMaxTextureSize(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+        }
         else if (feature === 'IS_TEST') {
             return false;
         }
@@ -9463,9 +9704,6 @@ var Environment = (function () {
         else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
             var webGLVersion = this.get('WEBGL_VERSION');
             if (webGLVersion === 0) {
-                return 0;
-            }
-            if (webGLVersion > 0) {
                 return 0;
             }
             return environment_util_1.getWebGLDisjointQueryTimerVersion(webGLVersion, this.get('IS_BROWSER'));
@@ -9495,6 +9733,10 @@ var Environment = (function () {
         else if (feature === 'WEBGL_FENCE_API_ENABLED') {
             return environment_util_1.isWebGLFenceEnabled(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
         }
+        else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
+            var useUniforms = this.get('WEBGL_RENDER_FLOAT32_ENABLED');
+            return useUniforms ? 4 : 0;
+        }
         else if (feature === 'TEST_EPSILON') {
             return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
                 TEST_EPSILON_FLOAT16;
@@ -9502,6 +9744,12 @@ var Environment = (function () {
         else if (feature === 'EPSILON') {
             return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
                 EPSILON_FLOAT16;
+        }
+        else if (feature === 'PROD') {
+            return false;
+        }
+        else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
+            return !this.get('PROD');
         }
         throw new Error("Unknown feature " + feature + ".");
     };
@@ -9512,20 +9760,6 @@ var Environment = (function () {
         this.features = environment_util_1.getFeaturesFromURL();
         if (this.globalEngine != null) {
             this.globalEngine = null;
-        }
-    };
-    Environment.prototype.initBackend = function (backendName, safeMode) {
-        var _this = this;
-        if (safeMode === void 0) { safeMode = false; }
-        this.backendName = backendName;
-        if (this.engines[backendName]) {
-            this.globalEngine = this.engines[backendName];
-        }
-        else {
-            var backend = this.findBackend(backendName);
-            this.globalEngine =
-                new engine_1.Engine(backend, safeMode, function () { return _this.get('DEBUG'); });
-            this.engines[backendName] = this.globalEngine;
         }
     };
     Object.defineProperty(Environment.prototype, "backend", {
@@ -9553,6 +9787,7 @@ var Environment = (function () {
         }
         try {
             var backend = factory();
+            backend.setDataMover({ moveData: function (dataId) { return _this.engine.moveData(dataId); } });
             this.registry[name] = { backend: backend, priority: priority };
             return true;
         }
@@ -9568,21 +9803,22 @@ var Environment = (function () {
         }
         this.registry[name].backend.dispose();
         delete this.registry[name];
-        if (name in this.engines) {
-            delete this.engines[name];
-        }
     };
     Object.defineProperty(Environment.prototype, "engine", {
         get: function () {
-            this.initDefaultBackend();
+            this.initEngine();
             return this.globalEngine;
         },
         enumerable: true,
         configurable: true
     });
-    Environment.prototype.initDefaultBackend = function () {
+    Environment.prototype.initEngine = function () {
+        var _this = this;
         if (this.globalEngine == null) {
-            this.initBackend(this.get('BACKEND'), false);
+            this.backendName = this.get('BACKEND');
+            var backend = this.findBackend(this.backendName);
+            this.globalEngine =
+                new engine_1.Engine(backend, false, function () { return _this.get('DEBUG'); });
         }
     };
     return Environment;
@@ -9612,7 +9848,7 @@ function getOrMakeEnvironment() {
 exports.ENV = getOrMakeEnvironment();
 
 }).call(this,require('_process'))
-},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":187,"./tensor_util":189,"_process":269}],65:[function(require,module,exports){
+},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":207,"./tensor_util":209,"_process":293}],65:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Type;
@@ -9622,14 +9858,23 @@ var Type;
     Type[Type["STRING"] = 2] = "STRING";
 })(Type = exports.Type || (exports.Type = {}));
 exports.URL_PROPERTIES = [
-    { name: 'DEBUG', type: Type.BOOLEAN }, { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'DEBUG', type: Type.BOOLEAN },
+    { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN },
+    { name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN },
+    { name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER },
+    { name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN },
     { name: 'WEBGL_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_RENDER_FLOAT32_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DOWNLOAD_FLOAT_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_FENCE_API_ENABLED', type: Type.BOOLEAN },
-    { name: 'BACKEND', type: Type.STRING }, { name: 'EPSILON', type: Type.NUMBER }
+    { name: 'WEBGL_SIZE_UPLOAD_UNIFORM', type: Type.NUMBER },
+    { name: 'BACKEND', type: Type.STRING },
+    { name: 'EPSILON', type: Type.NUMBER },
+    { name: 'PROD', type: Type.BOOLEAN },
+    { name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN },
 ];
 function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     var gl;
@@ -9646,6 +9891,15 @@ function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     return false;
 }
 exports.isWebGLVersionEnabled = isWebGLVersionEnabled;
+var MAX_TEXTURE_SIZE;
+function getWebGLMaxTextureSize(webGLVersion, isBrowser) {
+    if (MAX_TEXTURE_SIZE == null) {
+        var gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+        MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    }
+    return MAX_TEXTURE_SIZE;
+}
+exports.getWebGLMaxTextureSize = getWebGLMaxTextureSize;
 function getWebGLDisjointQueryTimerVersion(webGLVersion, isBrowser) {
     if (webGLVersion === 0) {
         return 0;
@@ -9834,6 +10088,7 @@ exports.tidy = environment_1.Environment.tidy;
 exports.keep = environment_1.Environment.keep;
 exports.dispose = environment_1.Environment.dispose;
 exports.time = environment_1.Environment.time;
+exports.profile = environment_1.Environment.profile;
 
 },{"./environment":64,"./gradients":67}],67:[function(require,module,exports){
 "use strict";
@@ -9948,7 +10203,7 @@ function checkGrads(grads) {
     }
 }
 
-},{"./environment":64,"./tensor":187,"./util":194}],68:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],68:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -9963,6 +10218,8 @@ exports.environment = environment;
 var environment_1 = require("./environment");
 var io = require("./io/io");
 exports.io = io;
+var math = require("./math");
+exports.math = math;
 var serialization = require("./serialization");
 exports.serialization = serialization;
 var tensor_1 = require("./tensor");
@@ -10009,10 +10266,12 @@ exports.setBackend = environment_1.Environment.setBackend;
 exports.getBackend = environment_1.Environment.getBackend;
 exports.disposeVariables = environment_1.Environment.disposeVariables;
 exports.memory = environment_1.Environment.memory;
+var backend_1 = require("./kernels/backend");
+exports.DataStorage = backend_1.DataStorage;
 var ops = require("./ops/ops");
 tensor_1.setOpHandler(ops);
 
-},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend_cpu":80,"./kernels/backend_webgl":82,"./ops/loss_ops":150,"./ops/ops":157,"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer":180,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183,"./serialization":185,"./tensor":187,"./test_util":191,"./train":192,"./types":193,"./util":194,"./version":195,"./webgl":196}],69:[function(require,module,exports){
+},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend":80,"./kernels/backend_cpu":81,"./kernels/backend_webgl":83,"./math":145,"./ops/loss_ops":165,"./ops/ops":172,"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer":200,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203,"./serialization":205,"./tensor":207,"./test_util":211,"./train":212,"./types":213,"./util":214,"./version":215,"./webgl":216}],69:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10504,7 +10763,7 @@ function browserHTTPRequest(path, requestInit) {
 }
 exports.browserHTTPRequest = browserHTTPRequest;
 
-},{"../util":194,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11085,7 +11344,7 @@ function getModelArtifactsInfoForJSON(modelArtifacts) {
 exports.getModelArtifactsInfoForJSON = getModelArtifactsInfoForJSON;
 
 }).call(this,require("buffer").Buffer)
-},{"../ops/tensor_ops":171,"../util":194,"./types":78,"buffer":251}],74:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214,"./types":78,"buffer":275}],74:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11333,7 +11592,7 @@ if (environment_1.ENV.get('IS_BROWSER')) {
     }
 }
 
-},{"../environment":64,"../util":194,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
+},{"../environment":64,"../util":214,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11537,7 +11796,7 @@ function moveModel(sourceURL, destURL) {
 }
 exports.moveModel = moveModel;
 
-},{"../util":194,"./router_registry":77}],76:[function(require,module,exports){
+},{"../util":214,"./router_registry":77}],76:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -11846,7 +12105,34 @@ function loadWeights(manifest, filePathPrefix, weightNames, requestOptions) {
 }
 exports.loadWeights = loadWeights;
 
-},{"../util":194,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var DataStorage = (function () {
+    function DataStorage(dataMover) {
+        this.dataMover = dataMover;
+        this.data = new WeakMap();
+    }
+    DataStorage.prototype.get = function (dataId) {
+        if (!this.data.has(dataId)) {
+            this.dataMover.moveData(dataId);
+        }
+        return this.data.get(dataId);
+    };
+    DataStorage.prototype.set = function (dataId, value) {
+        this.data.set(dataId, value);
+    };
+    DataStorage.prototype.has = function (dataId) {
+        return this.data.has(dataId);
+    };
+    DataStorage.prototype.delete = function (dataId) {
+        return this.data.delete(dataId);
+    };
+    return DataStorage;
+}());
+exports.DataStorage = DataStorage;
+
+},{}],81:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11892,14 +12178,17 @@ var axis_util = require("../ops/axis_util");
 var broadcast_util = require("../ops/broadcast_util");
 var concat_util = require("../ops/concat_util");
 var erf_util = require("../ops/erf_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var ops = require("../ops/ops");
 var ops_1 = require("../ops/ops");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var selu_util = require("../ops/selu_util");
 var slice_util_1 = require("../ops/slice_util");
 var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -11909,12 +12198,14 @@ var where_impl_1 = require("./where_impl");
 var MathBackendCPU = (function () {
     function MathBackendCPU() {
         this.blockSize = 48;
-        this.data = new WeakMap();
         this.firstUse = true;
         if (environment_1.ENV.get('IS_BROWSER')) {
             this.canvas = document.createElement('canvas');
         }
     }
+    MathBackendCPU.prototype.setDataMover = function (dataMover) {
+        this.data = new backend_1.DataStorage(dataMover);
+    };
     MathBackendCPU.prototype.register = function (dataId, shape, dtype) {
         if (this.firstUse) {
             this.firstUse = false;
@@ -11940,7 +12231,6 @@ var MathBackendCPU = (function () {
         if (values == null) {
             throw new Error('MathBackendCPU.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         this.data.get(dataId).values = values;
     };
     MathBackendCPU.prototype.fromPixels = function (pixels, numChannels) {
@@ -12003,7 +12293,6 @@ var MathBackendCPU = (function () {
         });
     };
     MathBackendCPU.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var _a = this.data.get(dataId), dtype = _a.dtype, complexTensors = _a.complexTensors;
         if (dtype === 'complex64') {
             var realValues = complexTensors.real.dataSync();
@@ -12037,13 +12326,6 @@ var MathBackendCPU = (function () {
         return {
             unreliable: true
         };
-    };
-    MathBackendCPU.prototype.throwIfNoData = function (dataId) {
-        if (!this.data.has(dataId)) {
-            throw new Error("CPU backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
     };
     MathBackendCPU.prototype.complex = function (real, imag) {
         var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
@@ -12264,6 +12546,24 @@ var MathBackendCPU = (function () {
                 sum += aVals[offset + j];
             }
             vals[i] = sum;
+        }
+        return result;
+    };
+    MathBackendCPU.prototype.prod = function (x, axes) {
+        this.assertNotComplex(x, 'sum');
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var resultDtype = types_1.upcastType(x.dtype, 'int32');
+        var result = ops.zeros(outShape, resultDtype);
+        var reduceSize = util.sizeFromShape(reduceShape);
+        var vals = result.dataSync();
+        var aVals = x.dataSync();
+        for (var i = 0; i < vals.length; ++i) {
+            var offset = i * reduceSize;
+            var prod = 1;
+            for (var j = 0; j < reduceSize; ++j) {
+                prod *= aVals[offset + j];
+            }
+            vals[i] = prod;
         }
         return result;
     };
@@ -12760,11 +13060,19 @@ var MathBackendCPU = (function () {
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
     MathBackendCPU.prototype.abs = function (x) {
-        this.assertNotComplex(x, 'abs');
         var resultValues = new Float32Array(x.size);
         var values = x.dataSync();
-        for (var i = 0; i < values.length; ++i) {
-            resultValues[i] = Math.abs(values[i]);
+        if (x.dtype === 'complex64') {
+            for (var i = 0; i < x.size; ++i) {
+                var real = values[i * 2];
+                var imag = values[i * 2 + 1];
+                resultValues[i] = Math.sqrt(real * real + imag * imag);
+            }
+        }
+        else {
+            for (var i = 0; i < values.length; ++i) {
+                resultValues[i] = Math.abs(values[i]);
+            }
         }
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
@@ -13323,8 +13631,10 @@ var MathBackendCPU = (function () {
         this.assertNotComplex(x, 'pool');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var y = ops.buffer(convInfo.outShape, 'float32');
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
@@ -13335,16 +13645,16 @@ var MathBackendCPU = (function () {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
                     var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
                         var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var minMaxValue = initialValue;
                         var avgValue = 0;
                         var count = 0;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var pixel = x.get(b, xR, xC, d);
                                 if ((poolType === 'max' && pixel > minMaxValue)) {
                                     minMaxValue = pixel;
@@ -13372,30 +13682,38 @@ var MathBackendCPU = (function () {
         var maxPositions = ops.buffer(convInfo.outShape, 'int32');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
-                    var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMin = xRCorner;
+                    while (xRMin < 0) {
+                        xRMin += dilationHeight;
+                    }
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
-                        var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMin = xCCorner;
+                        while (xCMin < 0) {
+                            xCMin += dilationWidth;
+                        }
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var maxValue = Number.NEGATIVE_INFINITY;
                         var maxPosition = -1;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
                             var wR = xR - xRCorner;
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var wC = xC - xCCorner;
                                 var pixel = x.get(b, xR, xC, d);
                                 if (pixel > maxValue) {
                                     maxValue = pixel;
-                                    maxPosition = wR * filterWidth + wC;
+                                    maxPosition = wR * effectiveFilterWidth + wC;
                                 }
                             }
                         }
@@ -13411,10 +13729,12 @@ var MathBackendCPU = (function () {
         var maxPositions = this.maxPoolPositions(x, convInfo);
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
@@ -13423,21 +13743,21 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
                                     continue;
                                 }
-                                var maxPos = filterHeight * filterWidth - 1 -
-                                    maxPositions.get(b, dyR, dyC, d);
-                                var curPos = wR * filterWidth + wC;
+                                var maxPos = effectiveFilterHeight * effectiveFilterWidth -
+                                    1 - maxPositions.get(b, dyR, dyC, d);
+                                var curPos = wR * effectiveFilterWidth + wC;
                                 var mask = maxPos === curPos ? 1 : 0;
                                 if (mask === 0) {
                                     continue;
@@ -13459,8 +13779,12 @@ var MathBackendCPU = (function () {
         var strideWidth = convInfo.strideWidth;
         var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         var avgMultiplier = 1 / (filterHeight * filterWidth);
         for (var b = 0; b < convInfo.batchSize; ++b) {
@@ -13470,13 +13794,13 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
@@ -13506,7 +13830,8 @@ var MathBackendCPU = (function () {
     MathBackendCPU.prototype.resizeBilinear = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeBilinear');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var result = new Float32Array(util.sizeFromShape([batch, newHeight, newWidth, numChannels]));
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13515,37 +13840,46 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var outputIdx = 0;
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
         for (var b = 0; b < batch; b++) {
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceRowFloor = Math.floor(sourceFracRow);
+                var rowFrac = sourceFracRow - sourceRowFloor;
+                var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
+                var topRowOffset = b * x.strides[0] + sourceRowFloor * x.strides[1];
+                var botRowOffset = b * x.strides[0] + sourceRowCeil * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceColFloor = Math.floor(sourceFracCol);
+                    var colFrac = sourceFracCol - sourceColFloor;
+                    var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
+                    var topLeftOffest = topRowOffset + sourceColFloor * x.strides[2];
+                    var botLeftOffset = botRowOffset + sourceColFloor * x.strides[2];
+                    var topRightOffset = topRowOffset + +sourceColCeil * x.strides[2];
+                    var botRightOffest = botRowOffset + sourceColCeil * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceRowFloor = Math.floor(sourceFracRow);
-                        var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
-                        var sourceColFloor = Math.floor(sourceFracCol);
-                        var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
-                        var topLeft = x.get(b, sourceRowFloor, sourceColFloor, d);
-                        var bottomLeft = x.get(b, sourceRowCeil, sourceColFloor, d);
-                        var topRight = x.get(b, sourceRowFloor, sourceColCeil, d);
-                        var bottomRight = x.get(b, sourceRowCeil, sourceColCeil, d);
-                        var rowFrac = sourceFracRow - sourceRowFloor;
-                        var colFrac = sourceFracCol - sourceColFloor;
+                        var topLeft = xValues[topLeftOffest + d];
+                        var bottomLeft = xValues[botLeftOffset + d];
+                        var topRight = xValues[topRightOffset + d];
+                        var bottomRight = xValues[botRightOffest + d];
                         var top_1 = topLeft + (topRight - topLeft) * colFrac;
                         var bottom = bottomLeft + (bottomRight - bottomLeft) * colFrac;
                         var newValue = top_1 + (bottom - top_1) * rowFrac;
-                        output.set(newValue, b, r, c, d);
+                        result[outputIdx++] = newValue;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(result, [batch, newHeight, newWidth, numChannels]);
     };
     MathBackendCPU.prototype.resizeBilinearBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeBilinearBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13556,11 +13890,16 @@ var MathBackendCPU = (function () {
         ];
         var heightScale = effectiveXSize[0] / effectiveYSize[0];
         var widthScale = effectiveXSize[1] / effectiveYSize[1];
+        var dyValues = dy.dataSync();
+        var offset = 0;
         for (var b = 0; b < batch; b++) {
+            var bOffset = b * x.strides[0];
             for (var r = 0; r < yHeight; r++) {
                 var dxR = r * heightScale;
                 var topDxRIndex = Math.floor(dxR);
                 var bottomDxRIndex = Math.min(Math.ceil(dxR), xHeight - 1);
+                var topDxROffset = bOffset + topDxRIndex * x.strides[1];
+                var bottomDxROffset = bOffset + bottomDxRIndex * x.strides[1];
                 var dxRLerp = dxR - topDxRIndex;
                 var inverseDxRLerp = 1.0 - dxRLerp;
                 for (var c = 0; c < yWidth; c++) {
@@ -13569,30 +13908,33 @@ var MathBackendCPU = (function () {
                     var rightDxCIndex = Math.min(Math.ceil(dxC), xWidth - 1);
                     var dxCLerp = dxC - leftDxCIndex;
                     var inverseDxCLerp = 1.0 - dxCLerp;
+                    var topLeftRCOffset = topDxROffset + leftDxCIndex * x.strides[2];
+                    var topRightRCOffset = topDxROffset + rightDxCIndex * x.strides[2];
+                    var bottomLeftRCOffset = bottomDxROffset + leftDxCIndex * x.strides[2];
+                    var bottomRightRCOffset = bottomDxROffset + rightDxCIndex * x.strides[2];
+                    var inverseDxRLerpTimesInverseDxCLerp = inverseDxRLerp * inverseDxCLerp;
+                    var inverseDxRLerpTimesDxCLerp = inverseDxRLerp * dxCLerp;
+                    var dxRLerpTimesInverseDxCLerp = dxRLerp * inverseDxCLerp;
+                    var dxRLerpTimesDxCLerp = dxRLerp * dxCLerp;
                     for (var d = 0; d < depth; d++) {
-                        var dyVal = dy.get(b, r, c, d);
-                        var topLeft = output.get(b, topDxRIndex, leftDxCIndex, d);
-                        topLeft += dyVal * inverseDxRLerp * inverseDxCLerp;
-                        output.set(topLeft, b, topDxRIndex, leftDxCIndex, d);
-                        var topRight = output.get(b, topDxRIndex, rightDxCIndex, d);
-                        topRight += dyVal * inverseDxRLerp * dxCLerp;
-                        output.set(topRight, b, topDxRIndex, rightDxCIndex, d);
-                        var bottomLeft = output.get(b, bottomDxRIndex, leftDxCIndex, d);
-                        bottomLeft += dyVal * dxRLerp * inverseDxCLerp;
-                        output.set(bottomLeft, b, bottomDxRIndex, leftDxCIndex, d);
-                        var bottomRight = output.get(b, bottomDxRIndex, rightDxCIndex, d);
-                        bottomRight += dyVal * dxRLerp * dxCLerp;
-                        output.set(bottomRight, b, bottomDxRIndex, rightDxCIndex, d);
+                        var dyVal = dyValues[offset++];
+                        output[topLeftRCOffset + d] +=
+                            dyVal * inverseDxRLerpTimesInverseDxCLerp;
+                        output[topRightRCOffset + d] += dyVal * inverseDxRLerpTimesDxCLerp;
+                        output[bottomLeftRCOffset + d] +=
+                            dyVal * dxRLerpTimesInverseDxCLerp;
+                        output[bottomRightRCOffset + d] += dyVal * dxRLerpTimesDxCLerp;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, [batch, xWidth, xHeight, depth], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighbor = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeNearestNeighbor');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var output = new Float32Array(batch * newHeight * newWidth * numChannels);
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13601,29 +13943,36 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
+        var outputOffset = 0;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                    Math.floor(sourceFracRow));
+                var rowOffset = batchOffset + sourceNearestRow * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
+                        Math.floor(sourceFracCol));
+                    var colOffset = rowOffset + sourceNearestCol * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                            Math.floor(sourceFracRow));
-                        var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
-                            Math.floor(sourceFracCol));
-                        var newValue = x.get(b, sourceNearestRow, sourceNearestCol, d);
-                        output.set(newValue, b, r, c, d);
+                        var newVal = xValues[colOffset + d];
+                        output[outputOffset++] = newVal;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(output, [batch, newHeight, newWidth, numChannels], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighborBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeNearestNeighborBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
+        var dyValues = dy.dataSync();
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13639,41 +13988,49 @@ var MathBackendCPU = (function () {
         var winHeight = (Math.ceil(invHeightScale) * 2) + 2;
         var winWidth = (Math.ceil(invWidthScale) * 2) + 2;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < xHeight; r++) {
+                var rowOffset = batchOffset + r * x.strides[1];
+                var startRLerp = Math.floor(r * invHeightScale);
+                var startDyR = Math.floor(startRLerp - (winHeight / 2));
                 for (var c = 0; c < xWidth; c++) {
-                    var startRLerp = Math.floor(r * invHeightScale);
-                    var startDyR = Math.floor(startRLerp - (winHeight / 2));
+                    var colOffset = rowOffset + c * x.strides[2];
                     var startCLerp = Math.floor(c * invWidthScale);
                     var startDyC = Math.floor(startCLerp - (winWidth / 2));
                     for (var d = 0; d < depth; d++) {
                         var accum = 0;
-                        for (var dyROffset = 0; dyROffset < winHeight; dyROffset++) {
-                            var dyR = dyROffset + startDyR;
+                        for (var dyRIndex = 0; dyRIndex < winHeight; dyRIndex++) {
+                            var dyR = dyRIndex + startDyR;
                             if (dyR < 0 || dyR >= yHeight) {
                                 continue;
                             }
-                            for (var dyCOffSet = 0; dyCOffSet < winWidth; dyCOffSet++) {
-                                var dyC = dyCOffSet + startDyC;
+                            var dyROffset = batchOffset + dyR * dy.strides[1];
+                            var sourceFracRow = dyR * heightScale;
+                            var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                                Math.floor(sourceFracRow));
+                            if (r !== sourceNearestRow) {
+                                continue;
+                            }
+                            for (var dyCIndex = 0; dyCIndex < winWidth; dyCIndex++) {
+                                var dyC = dyCIndex + startDyC;
                                 if (dyC < 0 || dyC >= yWidth) {
                                     continue;
                                 }
-                                var sourceFracRow = effectiveXSize[0] * (dyR / effectiveYSize[0]);
-                                var sourceFracCol = effectiveXSize[1] * (dyC / effectiveYSize[1]);
-                                var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                                    Math.floor(sourceFracRow));
+                                var dyCOffset = dyROffset + dyC * dy.strides[2];
+                                var sourceFracCol = dyC * widthScale;
                                 var sourceNearestCol = Math.min(xWidth - 1, alignCorners ? Math.round(sourceFracCol) :
                                     Math.floor(sourceFracCol));
-                                if (r === sourceNearestRow && c === sourceNearestCol) {
-                                    accum += dy.get(b, dyR, dyC, d);
+                                if (c === sourceNearestCol) {
+                                    accum += dyValues[dyCOffset + d];
                                 }
                             }
                         }
-                        output.set(accum, b, r, c, d);
+                        output[colOffset + d] = accum;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, x.shape, x.dtype);
     };
     MathBackendCPU.prototype.batchNormalization = function (x, mean, variance, varianceEpsilon, scale, offset) {
         this.assertNotComplex([x, mean, variance, scale, offset], 'batchNormalization');
@@ -13813,6 +14170,61 @@ var MathBackendCPU = (function () {
         var scoresVals = scores.dataSync();
         return non_max_suppression_impl_1.nonMaxSuppressionImpl(boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
     };
+    MathBackendCPU.prototype.fft = function (input) {
+        if (input.shape[0] !== 1) {
+            throw new Error("tf.fft() on CPU only supports vectors.");
+        }
+        var input1D = input.as1D();
+        var n = input1D.size;
+        if (this.isExponentOf2(n)) {
+            return this.fftRadix2(input1D, n).as2D(input.shape[0], input.shape[1]);
+        }
+        else {
+            var data = input.dataSync();
+            var rawOutput = this.fourierTransformByMatmul(data, n);
+            var output = complex_util.splitRealAndImagArrays(rawOutput);
+            return ops.complex(output.real, output.imag)
+                .as2D(input.shape[0], input.shape[1]);
+        }
+    };
+    MathBackendCPU.prototype.isExponentOf2 = function (size) {
+        return (size & size - 1) === 0;
+    };
+    MathBackendCPU.prototype.fftRadix2 = function (input, size) {
+        if (size === 1) {
+            return input;
+        }
+        var data = input.dataSync();
+        var half = size / 2;
+        var evenComplex = complex_util.complexWithEvenIndex(data);
+        var evenTensor = ops.complex(evenComplex.real, evenComplex.imag).as1D();
+        var oddComplex = complex_util.complexWithOddIndex(data);
+        var oddTensor = ops.complex(oddComplex.real, oddComplex.imag).as1D();
+        evenTensor = this.fftRadix2(evenTensor, half);
+        oddTensor = this.fftRadix2(oddTensor, half);
+        var e = complex_util.exponents(size);
+        var exponent = ops.complex(e.real, e.imag).mul(oddTensor);
+        var addPart = evenTensor.add(exponent);
+        var subPart = evenTensor.sub(exponent);
+        var realTensor = ops.real(addPart).concat(ops.real(subPart));
+        var imagTensor = ops.imag(addPart).concat(ops.imag(subPart));
+        return ops.complex(realTensor, imagTensor).as1D();
+    };
+    MathBackendCPU.prototype.fourierTransformByMatmul = function (data, size) {
+        var ret = new Float32Array(size * 2);
+        for (var r = 0; r < size; r++) {
+            var real = 0.0;
+            var imag = 0.0;
+            for (var c = 0; c < size; c++) {
+                var e = complex_util.exponent(r * c, size);
+                var term = complex_util.getComplexWithIndex(data, c);
+                real += term.real * e.real - term.imag * e.imag;
+                imag += term.real * e.imag + term.imag * e.real;
+            }
+            complex_util.assignToTypedArray(ret, real, imag, r);
+        }
+        return ret;
+    };
     MathBackendCPU.prototype.depthToSpace = function (x, blockSize, dataFormat) {
         util.assert(dataFormat === 'NHWC', "Only NHWC dataFormat supported on CPU for depthToSpace. Got " + dataFormat);
         util.assert(blockSize > 1, "blockSize should be > 1 for depthToSpace, but was: " + blockSize);
@@ -13946,9 +14358,7 @@ var MathBackendCPU = (function () {
             var heightScale = (cropHeight > 1) ?
                 (y2 - y1) * (imageHeight - 1) / (cropHeight - 1) :
                 0;
-            var widthScale = (cropWidth > 1) ?
-                (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) :
-                0;
+            var widthScale = (cropWidth > 1) ? (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) : 0;
             for (var y = 0; y < cropHeight; y++) {
                 var yInd = (cropHeight > 1) ?
                     y1 * (imageHeight - 1) + y * (heightScale) :
@@ -13956,8 +14366,7 @@ var MathBackendCPU = (function () {
                 if (yInd < 0 || yInd > imageHeight - 1) {
                     for (var x = 0; x < cropWidth; x++) {
                         for (var c = 0; c < numChannels; c++) {
-                            var ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = extrapolationValue;
                         }
                     }
@@ -13973,8 +14382,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -13997,8 +14405,7 @@ var MathBackendCPU = (function () {
                             var bottomRight = imageVals[ind];
                             var top_2 = topLeft + (topRight - topLeft) * xLerp;
                             var bottom = bottomLeft + (bottomRight - bottomLeft) * xLerp;
-                            ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = top_2 + ((bottom - top_2) * yLerp);
                         }
                     }
@@ -14010,8 +14417,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14019,10 +14425,9 @@ var MathBackendCPU = (function () {
                         var closestX = Math.round(xInd);
                         var closestY = Math.round(yInd);
                         for (var c = 0; c < numChannels; c++) {
-                            var inInd = c + closestX * inStride[2]
-                                + closestY * inStride[1] + bInd * inStride[0];
-                            var outInd = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var inInd = c + closestX * inStride[2] +
+                                closestY * inStride[1] + bInd * inStride[0];
+                            var outInd = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[outInd] = imageVals[inInd];
                         }
                     }
@@ -14031,12 +14436,84 @@ var MathBackendCPU = (function () {
         }
         return output.toTensor();
     };
+    MathBackendCPU.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        return this.scatter(sparseIndices, sparseValues, outputShape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        if (numSlices === 0) {
+            return ops_1.tensor([], resultShape, x.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer([numSlices, sliceSize], x.dtype);
+        var indicesData = indices.dataSync();
+        var xData = x.dataSync();
+        for (var i = 0; i < numSlices; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                flattenIndex += dim * strides[j];
+                index.push(dim);
+            }
+            if (flattenIndex < 0 || flattenIndex >= x.size / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + x.shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                buffer.values[i * sliceSize + k] = xData[flattenIndex * sliceSize + k];
+            }
+        }
+        return buffer.toTensor().reshape(resultShape);
+    };
+    MathBackendCPU.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var defaultValue = ops_1.scalar(0);
+        var sumDupeIndices = true;
+        return this.scatter(indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.scatter = function (indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices) {
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var indicesData = indices.dataSync();
+        var updatesData = updates.dataSync();
+        if (outputSize === 0) {
+            return ops_1.tensor([], shape, updates.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer(flattenShape, updates.dtype);
+        buffer.values.fill(defaultValue.dataSync()[0]);
+        for (var i = 0; i < numUpdates; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                index.push(dim);
+                flattenIndex += dim * strides[j];
+            }
+            if (flattenIndex < 0 || flattenIndex >= outputSize / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                if (sumDupeIndices) {
+                    buffer.values[flattenIndex * sliceSize + k] +=
+                        updatesData[i * sliceSize + k];
+                }
+                else {
+                    buffer.values[flattenIndex * sliceSize + k] = updates.rank === 0 ?
+                        updatesData[0] :
+                        updatesData[i * sliceSize + k];
+                }
+            }
+        }
+        return buffer.toTensor().reshape(shape);
+    };
     return MathBackendCPU;
 }());
 exports.MathBackendCPU = MathBackendCPU;
 environment_1.ENV.registerBackend('cpu', function () { return new MathBackendCPU(); }, 1, tensor_1.setTensorTracker);
 
-},{"../environment":64,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/broadcast_util":139,"../ops/concat_util":143,"../ops/erf_util":146,"../ops/ops":157,"../ops/selu_util":166,"../ops/slice_util":168,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./where_impl":132,"seedrandom":281}],81:[function(require,module,exports){
+},{"../environment":64,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/broadcast_util":151,"../ops/concat_util":155,"../ops/erf_util":159,"../ops/gather_nd_util":161,"../ops/ops":172,"../ops/scatter_nd_util":180,"../ops/selu_util":183,"../ops/slice_util":185,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./where_impl":143,"seedrandom":305}],82:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -14082,7 +14559,7 @@ function reshapeTensor(x, shape) {
 }
 exports.reshapeTensor = reshapeTensor;
 
-},{"../ops/tensor_ops":171,"../tensor":187,"../util":194}],82:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../tensor":207,"../util":214}],83:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14126,7 +14603,9 @@ var log_1 = require("../log");
 var array_ops_util = require("../ops/array_ops_util");
 var axis_util = require("../ops/axis_util");
 var concat_util_1 = require("../ops/concat_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var reduce_util = require("../ops/reduce_util");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var segment_util = require("../ops/segment_util");
 var slice_util_1 = require("../ops/slice_util");
 var softmax_1 = require("../ops/softmax");
@@ -14135,6 +14614,7 @@ var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util_1 = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -14143,31 +14623,39 @@ var topk_impl_1 = require("./topk_impl");
 var argminmax_gpu_1 = require("./webgl/argminmax_gpu");
 var avg_pool_backprop_gpu_1 = require("./webgl/avg_pool_backprop_gpu");
 var batchnorm_gpu_1 = require("./webgl/batchnorm_gpu");
+var batchnorm_packed_gpu_1 = require("./webgl/batchnorm_packed_gpu");
 var binaryop_complex_gpu = require("./webgl/binaryop_complex_gpu");
 var binaryop_complex_gpu_1 = require("./webgl/binaryop_complex_gpu");
 var binaryop_gpu = require("./webgl/binaryop_gpu");
 var binaryop_gpu_1 = require("./webgl/binaryop_gpu");
 var clip_gpu_1 = require("./webgl/clip_gpu");
+var complex_abs_gpu_1 = require("./webgl/complex_abs_gpu");
 var concat_gpu_1 = require("./webgl/concat_gpu");
 var conv_backprop_gpu_1 = require("./webgl/conv_backprop_gpu");
 var conv_backprop_gpu_depthwise_1 = require("./webgl/conv_backprop_gpu_depthwise");
 var conv_gpu_1 = require("./webgl/conv_gpu");
-var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var conv_gpu_depthwise_1 = require("./webgl/conv_gpu_depthwise");
+var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var cumsum_gpu_1 = require("./webgl/cumsum_gpu");
 var depth_to_space_gpu_1 = require("./webgl/depth_to_space_gpu");
 var encode_float_gpu_1 = require("./webgl/encode_float_gpu");
+var fft_gpu = require("./webgl/fft_gpu");
+var fft_gpu_1 = require("./webgl/fft_gpu");
 var from_pixels_gpu_1 = require("./webgl/from_pixels_gpu");
 var gather_gpu_1 = require("./webgl/gather_gpu");
+var gather_nd_gpu_1 = require("./webgl/gather_nd_gpu");
 var gpgpu_context_1 = require("./webgl/gpgpu_context");
 var gpgpu_math = require("./webgl/gpgpu_math");
 var gpgpu_util = require("./webgl/gpgpu_util");
+var im2col_gpu_1 = require("./webgl/im2col_gpu");
 var lrn_gpu_1 = require("./webgl/lrn_gpu");
 var lrn_grad_gpu_1 = require("./webgl/lrn_grad_gpu");
 var max_pool_backprop_gpu_1 = require("./webgl/max_pool_backprop_gpu");
 var mulmat_gpu_1 = require("./webgl/mulmat_gpu");
+var mulmat_packed_gpu_1 = require("./webgl/mulmat_packed_gpu");
 var multinomial_gpu_1 = require("./webgl/multinomial_gpu");
 var onehot_gpu_1 = require("./webgl/onehot_gpu");
+var pack_gpu_1 = require("./webgl/pack_gpu");
 var pad_gpu_1 = require("./webgl/pad_gpu");
 var pool_gpu_1 = require("./webgl/pool_gpu");
 var reduce_gpu_1 = require("./webgl/reduce_gpu");
@@ -14176,6 +14664,7 @@ var resize_bilinear_gpu_1 = require("./webgl/resize_bilinear_gpu");
 var resize_nearest_neighbor_backprop_gpu_1 = require("./webgl/resize_nearest_neighbor_backprop_gpu");
 var resize_nearest_neighbor_gpu_1 = require("./webgl/resize_nearest_neighbor_gpu");
 var reverse_gpu_1 = require("./webgl/reverse_gpu");
+var scatter_gpu_1 = require("./webgl/scatter_gpu");
 var segment_gpu_1 = require("./webgl/segment_gpu");
 var select_gpu_1 = require("./webgl/select_gpu");
 var slice_gpu_1 = require("./webgl/slice_gpu");
@@ -14186,16 +14675,16 @@ var tile_gpu_1 = require("./webgl/tile_gpu");
 var transpose_gpu_1 = require("./webgl/transpose_gpu");
 var unary_op = require("./webgl/unaryop_gpu");
 var unaryop_gpu_1 = require("./webgl/unaryop_gpu");
+var unpack_gpu_1 = require("./webgl/unpack_gpu");
 var webgl_util = require("./webgl/webgl_util");
 var where_impl_1 = require("./where_impl");
 var BEFORE_PAGING_CONSTANT = 300;
-exports.SIZE_UPLOAD_UNIFORM = 32;
+exports.SIZE_UPLOAD_UNIFORM = 4;
 var MathBackendWebGL = (function () {
     function MathBackendWebGL(gpgpu, delayedStorage) {
         if (delayedStorage === void 0) { delayedStorage = true; }
         this.gpgpu = gpgpu;
         this.delayedStorage = delayedStorage;
-        this.texData = new WeakMap();
         this.pendingRead = new WeakMap();
         this.pendingDisposal = new WeakSet();
         this.lruDataGPU = [];
@@ -14217,9 +14706,12 @@ var MathBackendWebGL = (function () {
         else {
             this.gpgpuCreatedLocally = false;
         }
-        this.NUM_BYTES_BEFORE_PAGING =
-            (window.screen.height * window.screen.width * window.devicePixelRatio) *
-                BEFORE_PAGING_CONSTANT;
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.NUM_BYTES_BEFORE_PAGING =
+                (window.screen.height * window.screen.width *
+                    window.devicePixelRatio) *
+                    BEFORE_PAGING_CONSTANT;
+        }
         this.textureManager = new texture_manager_1.TextureManager(this.gpgpu);
     }
     MathBackendWebGL.prototype.register = function (dataId, shape, dtype) {
@@ -14233,8 +14725,12 @@ var MathBackendWebGL = (function () {
             texture: null,
             complexTensors: null,
             texShape: null,
-            usage: tex_util_1.TextureUsage.RENDER
+            usage: tex_util_1.TextureUsage.RENDER,
+            isPacked: false
         });
+    };
+    MathBackendWebGL.prototype.setDataMover = function (dataMover) {
+        this.texData = new backend_1.DataStorage(dataMover);
     };
     MathBackendWebGL.prototype.fromPixels = function (pixels, numChannels) {
         if (pixels == null) {
@@ -14267,27 +14763,31 @@ var MathBackendWebGL = (function () {
             this.fromPixelsCanvas.getContext('2d').drawImage(pixels, 0, 0, pixels.width, pixels.height);
             pixels = this.fromPixelsCanvas;
         }
-        var tempPixelArray = tensor_1.Tensor.make(texShape, {}, 'int32');
-        this.texData.get(tempPixelArray.dataId).usage = tex_util_1.TextureUsage.PIXELS;
-        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelArray.dataId), pixels);
+        var tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
+        this.texData.get(tempPixelHandle.dataId).usage = tex_util_1.TextureUsage.PIXELS;
+        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelHandle.dataId), pixels);
         var program = new from_pixels_gpu_1.FromPixelsProgram(outShape);
-        var res = this.compileAndRun(program, [tempPixelArray]);
-        tempPixelArray.dispose();
+        var res = this.compileAndRun(program, [tempPixelHandle]);
+        this.disposeData(tempPixelHandle.dataId);
         return res;
+    };
+    MathBackendWebGL.prototype.makeTensorHandle = function (shape, dtype) {
+        var dataId = {};
+        this.register(dataId, shape, dtype);
+        return { dataId: dataId, shape: shape, dtype: dtype };
     };
     MathBackendWebGL.prototype.write = function (dataId, values) {
         if (values == null) {
             throw new Error('MathBackendWebGL.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype;
+        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype, isPacked = texData.isPacked;
         if (dtype === 'complex64') {
             throw new Error("Cannot write to a complex64 dtype. " +
                 "Please use tf.complex(real, imag).");
         }
         if (texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -14298,9 +14798,8 @@ var MathBackendWebGL = (function () {
         }
     };
     MathBackendWebGL.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype, complexTensors = texData.complexTensors;
+        var values = texData.values, dtype = texData.dtype, complexTensors = texData.complexTensors;
         if (values != null) {
             this.cacheOnCPU(dataId);
             return values;
@@ -14317,8 +14816,7 @@ var MathBackendWebGL = (function () {
             result = complex_util_1.mergeRealAndImagArrays(realValues, imagValues);
         }
         else {
-            result =
-                this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+            result = this.getValuesFromTexture(dataId);
         }
         if (shouldTimeProgram) {
             this.downloadWaitMs += performance.now() - start;
@@ -14328,7 +14826,7 @@ var MathBackendWebGL = (function () {
     };
     MathBackendWebGL.prototype.read = function (dataId) {
         return __awaiter(this, void 0, void 0, function () {
-            var subscribers_1, texData, shape, texture, values, texShape, dtype, bufferOrTexture, vals, subscribers;
+            var subscribers_1, texData, texture, values, texShape, bufferOrTexture, vals, subscribers;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14336,9 +14834,8 @@ var MathBackendWebGL = (function () {
                             subscribers_1 = this.pendingRead.get(dataId);
                             return [2, new Promise(function (resolve) { return subscribers_1.push(resolve); })];
                         }
-                        this.throwIfNoData(dataId);
                         texData = this.texData.get(dataId);
-                        shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype;
+                        texture = texData.texture, values = texData.values, texShape = texData.texShape;
                         if (values != null) {
                             this.cacheOnCPU(dataId);
                             return [2, values];
@@ -14354,7 +14851,7 @@ var MathBackendWebGL = (function () {
                     case 1:
                         _a.sent();
                         if (bufferOrTexture instanceof WebGLTexture) {
-                            vals = this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+                            vals = this.getValuesFromTexture(dataId);
                         }
                         else {
                             vals = this.gpgpu.downloadFloat32MatrixFromBuffer(bufferOrTexture, texShape[0], texShape[1]);
@@ -14372,25 +14869,33 @@ var MathBackendWebGL = (function () {
             });
         });
     };
-    MathBackendWebGL.prototype.getValuesFromTexture = function (texture, dataId, dtype, texShape, shape) {
+    MathBackendWebGL.prototype.getValuesFromTexture = function (dataId) {
+        var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype, texture = _a.texture, texShape = _a.texShape;
         if (environment_1.ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
-            return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            if (this.texData.get(dataId).isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                return this.gpgpu.downloadMatrixFromPackedTexture(texture, batch, rows, cols, texShape[0], texShape[1]);
+            }
+            else {
+                return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            }
         }
-        var tmpTarget = tensor_1.Tensor.make(shape, {});
+        var tmpTarget = this.makeTensorHandle(shape, 'float32');
+        tmpTarget.size = util_1.sizeFromShape(shape);
         this.texData.get(tmpTarget.dataId).usage = tex_util_1.TextureUsage.DOWNLOAD;
-        var tmpInput = tensor_1.Tensor.make(shape, { dataId: dataId }, dtype);
         var program = new encode_float_gpu_1.EncodeFloatProgram(shape);
         var pageToCpu = false;
-        this.compileAndRun(program, [tmpInput], tmpTarget, null, pageToCpu);
+        this.compileAndRun(program, [{ shape: shape, dtype: dtype, dataId: dataId }], tmpTarget, null, pageToCpu);
         var tmpData = this.texData.get(tmpTarget.dataId);
         var vals = this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
-        tmpInput.dispose();
-        tmpTarget.dispose();
+        this.disposeData(tmpTarget.dataId);
         return vals;
     };
     MathBackendWebGL.prototype.time = function (f) {
         return __awaiter(this, void 0, void 0, function () {
-            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimers, kernelMs, res;
+            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimerQueries, flattenedActiveTimerNames, kernelMs, res;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14406,22 +14911,26 @@ var MathBackendWebGL = (function () {
                         }
                         this.activeTimers = newActiveTimers;
                         f();
-                        flattenedActiveTimers = util.flatten(this.activeTimers);
+                        flattenedActiveTimerQueries = util.flatten(this.activeTimers.map(function (d) { return d.query; }))
+                            .filter(function (d) { return d != null; });
+                        flattenedActiveTimerNames = util.flatten(this.activeTimers.map(function (d) { return d.name; }))
+                            .filter(function (d) { return d != null; });
                         this.activeTimers = oldActiveTimers;
                         if (outerMostTime) {
                             this.programTimersStack = null;
                         }
-                        return [4, Promise.all(flattenedActiveTimers).then(function (results) {
-                                var sum = 0;
-                                results.forEach(function (result) { return sum += result; });
-                                return sum;
-                            })];
+                        return [4, Promise.all(flattenedActiveTimerQueries)];
                     case 1:
                         kernelMs = _a.sent();
                         res = {
                             uploadWaitMs: this.uploadWaitMs,
                             downloadWaitMs: this.downloadWaitMs,
-                            kernelMs: kernelMs,
+                            kernelMs: util.sum(kernelMs),
+                            getExtraProfileInfo: function () {
+                                return kernelMs.map(function (d, i) { return ({ name: flattenedActiveTimerNames[i], ms: d }); })
+                                    .map(function (d) { return d.name + ": " + d.ms; })
+                                    .join(', ');
+                            },
                             wallMs: null
                         };
                         this.uploadWaitMs = 0;
@@ -14469,9 +14978,9 @@ var MathBackendWebGL = (function () {
             return;
         }
         if (this.texData.has(dataId)) {
-            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors;
+            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors, isPacked = _a.isPacked;
             if (texture != null) {
-                this.releaseTexture(dataId, texture, texShape, usage);
+                this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             }
             if (complexTensors != null) {
                 complexTensors.real.dispose();
@@ -14491,7 +15000,7 @@ var MathBackendWebGL = (function () {
         return this.canvas;
     };
     MathBackendWebGL.prototype.complex = function (real, imag) {
-        var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
+        var result = this.makeOutputArray(real.shape, 'complex64');
         var resultData = this.texData.get(result.dataId);
         resultData.complexTensors = {
             real: environment_1.ENV.engine.keep(real.clone()),
@@ -14548,8 +15057,18 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.batchMatMul = function (a, b, transposeA, transposeB) {
-        var program = new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-        return this.compileAndRun(program, [a, b]);
+        var outerShapeA = transposeA ? a.shape[2] : a.shape[1];
+        var outerShapeB = transposeB ? b.shape[1] : b.shape[2];
+        if (a.shape[0] === 1 && b.shape[0] === 1) {
+            var aSqueezed = a.as2D(a.shape[1], a.shape[2]);
+            var bSqueezed = b.as2D(b.shape[1], b.shape[2]);
+            var program = new mulmat_packed_gpu_1.MatMulPackedProgram(aSqueezed.shape, bSqueezed.shape, [outerShapeA, outerShapeB], transposeA, transposeB);
+            var result = this.unpackTensor(this.compileAndRun(program, [aSqueezed, bSqueezed], this.makePackedTensor(program.outputShape)));
+            return result.reshape([1, result.shape[0], result.shape[1]]);
+        }
+        else {
+            return this.compileAndRun(new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB), [a, b]);
+        }
     };
     MathBackendWebGL.prototype.multiply = function (a, b) {
         if (a.dtype === 'complex64') {
@@ -14586,8 +15105,14 @@ var MathBackendWebGL = (function () {
             scaleShape = scale.shape;
             inputs.push(scale);
         }
-        var program = new batchnorm_gpu_1.BatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
-        return this.compileAndRun(program, inputs);
+        var output = null;
+        var envSpecificBatchNormProgram = batchnorm_gpu_1.BatchNormProgram;
+        if (environment_1.ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
+            output = this.makePackedTensor(x.shape);
+            envSpecificBatchNormProgram = batchnorm_packed_gpu_1.BatchNormPackedProgram;
+        }
+        var program = new envSpecificBatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
+        return this.compileAndRun(program, inputs, output);
     };
     MathBackendWebGL.prototype.localResponseNormalization4D = function (x, radius, bias, alpha, beta) {
         var program = new lrn_gpu_1.LRNProgram(x.shape, radius, bias, alpha, beta);
@@ -14686,6 +15211,13 @@ var MathBackendWebGL = (function () {
         var a2D = x.as2D(-1, inSize);
         var outputDType = types_1.sumOutType(x.dtype);
         return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+    };
+    MathBackendWebGL.prototype.prod = function (x, axes) {
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var inSize = util.sizeFromShape(reduceShape);
+        var a2D = x.as2D(-1, inSize);
+        var outputDType = types_1.sumOutType(x.dtype);
+        return this.reduce(a2D, 'prod', outputDType).reshape(outShape);
     };
     MathBackendWebGL.prototype.unsortedSegmentSum = function (x, segmentIds, numSegments) {
         var axis = 0;
@@ -14994,6 +15526,15 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.abs = function (x) {
+        if (x.dtype === 'complex64') {
+            var xData = this.texData.get(x.dataId);
+            var program_1 = new complex_abs_gpu_1.ComplexAbsProgram(x.shape);
+            var inputs = [
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+            ];
+            return this.compileAndRun(program_1, inputs);
+        }
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.ABS);
         return this.compileAndRun(program, [x]);
     };
@@ -15067,7 +15608,23 @@ var MathBackendWebGL = (function () {
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.STEP(alpha));
         return this.compileAndRun(program, [x]);
     };
+    MathBackendWebGL.prototype.conv2dWithIm2Row = function (x, filter, convInfo) {
+        var filterWidth = convInfo.filterWidth, filterHeight = convInfo.filterHeight, inChannels = convInfo.inChannels, outWidth = convInfo.outWidth, outHeight = convInfo.outHeight;
+        var sharedDim = filterWidth * filterHeight * inChannels;
+        var numCols = outHeight * outWidth;
+        var x2ColShape = [sharedDim, numCols];
+        var xSqueezed = x.squeeze([0]);
+        var w2Row = filter.reshape([sharedDim, -1]);
+        var im2ColProgram = new im2col_gpu_1.Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
+        var im2Col = this.compileAndRun(im2ColProgram, [xSqueezed], this.makePackedTensor(x2ColShape));
+        var matmulProgram = new mulmat_packed_gpu_1.MatMulPackedProgram(im2Col.shape, w2Row.shape, [numCols, convInfo.outChannels], true, false);
+        var product = this.unpackTensor(this.compileAndRun(matmulProgram, [im2Col, w2Row], this.makePackedTensor(matmulProgram.outputShape)));
+        return product.reshape([1, outHeight, outWidth, convInfo.outChannels]);
+    };
     MathBackendWebGL.prototype.conv2d = function (x, filter, convInfo) {
+        if (environment_1.ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
+            return this.conv2dWithIm2Row(x, filter, convInfo);
+        }
         var program = new conv_gpu_1.Conv2DProgram(convInfo);
         return this.compileAndRun(program, [x, filter]);
     };
@@ -15180,14 +15737,69 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.split = function (x, sizeSplits, axis) {
         return split_shared_1.split(x, sizeSplits, axis);
     };
+    MathBackendWebGL.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var flattenIndices = indices.reshape([numUpdates, sliceRank]);
+        var flattenX = updates.reshape([numUpdates, sliceSize]);
+        if (outputSize === 0) {
+            return backend_util.reshapeTensor(tensor_ops_1.tensor([]), shape);
+        }
+        var defaultValue = tensor_ops_1.scalar(0);
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, flattenIndices.rank, flattenX.rank, strides, flattenShape);
+        return this.compileAndRun(program, [flattenX, flattenIndices, defaultValue])
+            .reshape(shape);
+    };
+    MathBackendWebGL.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, sparseIndices.rank, sparseValues.rank, strides, [outputSize, 1], sumDupeIndices);
+        return this.compileAndRun(program, [sparseValues, sparseIndices, defaultValue])
+            .reshape(outputShape);
+    };
+    MathBackendWebGL.prototype.fft = function (x) {
+        var xData = this.texData.get(x.dataId);
+        var realProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
+        var imagProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+        var inputs = [
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+        ];
+        var real = this.compileAndRun(realProgram, inputs);
+        var imag = this.compileAndRun(imagProgram, inputs);
+        var complex = this.complex(real, imag).as2D(x.shape[0], x.shape[1]);
+        real.dispose();
+        imag.dispose();
+        return complex;
+    };
+    MathBackendWebGL.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        var flattenIndices = indices.reshape([numSlices, sliceRank]);
+        var flattenX = x.reshape([x.size / sliceSize, sliceSize]);
+        var program = new gather_nd_gpu_1.GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+        return this.compileAndRun(program, [flattenX, flattenIndices])
+            .reshape(resultShape);
+    };
     MathBackendWebGL.prototype.makeOutputArray = function (shape, dtype) {
         return tensor_1.Tensor.make(shape, {}, dtype);
+    };
+    MathBackendWebGL.prototype.makePackedTensor = function (shape) {
+        var packedTensor = tensor_1.Tensor.make(shape, {});
+        this.texData.get(packedTensor.dataId).isPacked = true;
+        return packedTensor;
+    };
+    MathBackendWebGL.prototype.unpackTensor = function (input) {
+        var program = new unpack_gpu_1.UnpackProgram(input.shape);
+        return this.compileAndRun(program, [input]);
     };
     MathBackendWebGL.prototype.compileAndRun = function (program, inputs, output, customSetup, pageToCpu) {
         var _this = this;
         if (pageToCpu === void 0) { pageToCpu = true; }
         if (output == null) {
-            output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+            output =
+                this.makeOutputArray(program.outputShape, inputs[0].dtype);
         }
         if (output.size === 0) {
             this.texData.get(output.dataId).values =
@@ -15202,13 +15814,29 @@ var MathBackendWebGL = (function () {
             }
             var texData = _this.texData.get(input.dataId);
             if (texData.texture == null &&
-                util.sizeFromShape(input.shape) <= exports.SIZE_UPLOAD_UNIFORM) {
+                !(!texData.isPacked && program.usesPackedTextures) &&
+                util.sizeFromShape(input.shape) <=
+                    environment_1.ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
                 return {
                     shape: input.shape,
                     texData: null,
                     isUniform: true,
                     uniformValues: _this.readSync(input.dataId)
                 };
+            }
+            if (texData.isPacked !== !!program.usesPackedTextures) {
+                var preProcessProgram = void 0;
+                var processedInput = void 0;
+                if (texData.isPacked) {
+                    preProcessProgram = new unpack_gpu_1.UnpackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input]);
+                }
+                else {
+                    preProcessProgram = new pack_gpu_1.PackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input], _this.makePackedTensor(input.shape));
+                }
+                texData = _this.texData.get(processedInput.dataId);
+                input = processedInput;
             }
             _this.uploadToGPU(input.dataId);
             return { shape: input.shape, texData: texData, isUniform: false };
@@ -15229,7 +15857,8 @@ var MathBackendWebGL = (function () {
             query = this.startTimer();
         }
         gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-        if (pageToCpu && this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED') && pageToCpu &&
+            this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
             var numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
             while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
                 var dataId = this.lruDataGPU.shift();
@@ -15240,7 +15869,7 @@ var MathBackendWebGL = (function () {
         }
         if (shouldTimeProgram) {
             query = this.endTimer(query);
-            this.activeTimers.push(this.getQueryTime(query));
+            this.activeTimers.push({ name: program.constructor.name, query: this.getQueryTime(query) });
         }
         return output;
     };
@@ -15279,22 +15908,16 @@ var MathBackendWebGL = (function () {
             return 16;
         });
     };
-    MathBackendWebGL.prototype.throwIfNoData = function (dataId) {
-        if (!this.texData.has(dataId)) {
-            throw new Error("WebGL backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
-    };
     MathBackendWebGL.prototype.uploadToGPU = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage;
+        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (texture != null) {
-            var index = this.lruDataGPU.indexOf(dataId);
-            if (index >= 0) {
-                this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
-                this.lruDataGPU.push(dataId);
+            if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+                var index = this.lruDataGPU.indexOf(dataId);
+                if (index >= 0) {
+                    this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
+                    this.lruDataGPU.push(dataId);
+                }
             }
             return;
         }
@@ -15303,12 +15926,20 @@ var MathBackendWebGL = (function () {
         if (shouldTimeProgram) {
             start = performance.now();
         }
-        var texShape = webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        var texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
         texData.texShape = texShape;
-        var newTexture = this.acquireTexture(dataId, texShape, usage);
+        var newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
         texData.texture = newTexture;
         if (values != null) {
-            this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            if (isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                this.gpgpu.uploadMatrixToPackedTexture(newTexture, batch, rows, cols, typedArrayToFloat32(values, dtype));
+            }
+            else {
+                this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            }
             texData.values = null;
             if (shouldTimeProgram) {
                 this.uploadWaitMs += performance.now() - start;
@@ -15318,9 +15949,9 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.cacheOnCPU = function (dataId, float32Values) {
         var dontKeepCopyOnGPU = this.delayedStorage;
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage;
+        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (dontKeepCopyOnGPU && texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -15329,20 +15960,24 @@ var MathBackendWebGL = (function () {
             texData.values = float32ToTypedArray(float32Values, dtype);
         }
     };
-    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType) {
+    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        var idx = this.lruDataGPU.indexOf(dataId);
-        if (idx >= 0) {
-            this.lruDataGPU.splice(idx, 1);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            var idx = this.lruDataGPU.indexOf(dataId);
+            if (idx >= 0) {
+                this.lruDataGPU.splice(idx, 1);
+            }
         }
         this.numBytesInGPU -= this.computeBytes(shape, dtype);
-        this.textureManager.releaseTexture(texture, texShape, texType);
+        this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
     };
-    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType) {
+    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        this.lruDataGPU.push(dataId);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.lruDataGPU.push(dataId);
+        }
         this.numBytesInGPU += this.computeBytes(shape, dtype);
-        return this.textureManager.acquireTexture(texShape, texType);
+        return this.textureManager.acquireTexture(texShape, texType, isPacked);
     };
     MathBackendWebGL.prototype.computeBytes = function (shape, dtype) {
         return util.sizeFromShape(shape) * util.bytesPerElement(dtype);
@@ -15373,7 +16008,7 @@ function typedArrayToFloat32(a, dtype) {
     return (a instanceof Float32Array) ? a : new Float32Array(a);
 }
 
-},{"../environment":64,"../globals":66,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/concat_util":143,"../ops/reduce_util":160,"../ops/segment_util":165,"../ops/slice_util":168,"../ops/softmax":169,"../ops/tensor_ops":171,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./webgl/argminmax_gpu":87,"./webgl/avg_pool_backprop_gpu":88,"./webgl/batchnorm_gpu":89,"./webgl/binaryop_complex_gpu":90,"./webgl/binaryop_gpu":91,"./webgl/clip_gpu":92,"./webgl/concat_gpu":93,"./webgl/conv_backprop_gpu":94,"./webgl/conv_backprop_gpu_depthwise":95,"./webgl/conv_gpu":96,"./webgl/conv_gpu_depthwise":97,"./webgl/crop_and_resize_gpu":98,"./webgl/cumsum_gpu":99,"./webgl/depth_to_space_gpu":100,"./webgl/encode_float_gpu":101,"./webgl/from_pixels_gpu":102,"./webgl/gather_gpu":103,"./webgl/gpgpu_context":104,"./webgl/gpgpu_math":105,"./webgl/gpgpu_util":106,"./webgl/lrn_gpu":107,"./webgl/lrn_grad_gpu":108,"./webgl/max_pool_backprop_gpu":109,"./webgl/mulmat_gpu":110,"./webgl/multinomial_gpu":111,"./webgl/onehot_gpu":112,"./webgl/pad_gpu":113,"./webgl/pool_gpu":114,"./webgl/reduce_gpu":115,"./webgl/resize_bilinear_backprop_gpu":116,"./webgl/resize_bilinear_gpu":117,"./webgl/resize_nearest_neighbor_backprop_gpu":118,"./webgl/resize_nearest_neighbor_gpu":119,"./webgl/reverse_gpu":120,"./webgl/segment_gpu":121,"./webgl/select_gpu":122,"./webgl/slice_gpu":124,"./webgl/strided_slice_gpu":125,"./webgl/tex_util":126,"./webgl/texture_manager":127,"./webgl/tile_gpu":128,"./webgl/transpose_gpu":129,"./webgl/unaryop_gpu":130,"./webgl/webgl_util":131,"./where_impl":132}],83:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/concat_util":155,"../ops/gather_nd_util":161,"../ops/reduce_util":175,"../ops/scatter_nd_util":180,"../ops/segment_util":182,"../ops/slice_util":185,"../ops/softmax":186,"../ops/tensor_ops":191,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./webgl/argminmax_gpu":89,"./webgl/avg_pool_backprop_gpu":90,"./webgl/batchnorm_gpu":91,"./webgl/batchnorm_packed_gpu":92,"./webgl/binaryop_complex_gpu":93,"./webgl/binaryop_gpu":94,"./webgl/clip_gpu":95,"./webgl/complex_abs_gpu":96,"./webgl/concat_gpu":97,"./webgl/conv_backprop_gpu":98,"./webgl/conv_backprop_gpu_depthwise":99,"./webgl/conv_gpu":100,"./webgl/conv_gpu_depthwise":101,"./webgl/crop_and_resize_gpu":102,"./webgl/cumsum_gpu":103,"./webgl/depth_to_space_gpu":104,"./webgl/encode_float_gpu":105,"./webgl/fft_gpu":106,"./webgl/from_pixels_gpu":107,"./webgl/gather_gpu":108,"./webgl/gather_nd_gpu":109,"./webgl/gpgpu_context":110,"./webgl/gpgpu_math":111,"./webgl/gpgpu_util":112,"./webgl/im2col_gpu":113,"./webgl/lrn_gpu":114,"./webgl/lrn_grad_gpu":115,"./webgl/max_pool_backprop_gpu":116,"./webgl/mulmat_gpu":117,"./webgl/mulmat_packed_gpu":118,"./webgl/multinomial_gpu":119,"./webgl/onehot_gpu":120,"./webgl/pack_gpu":121,"./webgl/pad_gpu":122,"./webgl/pool_gpu":123,"./webgl/reduce_gpu":124,"./webgl/resize_bilinear_backprop_gpu":125,"./webgl/resize_bilinear_gpu":126,"./webgl/resize_nearest_neighbor_backprop_gpu":127,"./webgl/resize_nearest_neighbor_gpu":128,"./webgl/reverse_gpu":129,"./webgl/scatter_gpu":130,"./webgl/segment_gpu":131,"./webgl/select_gpu":132,"./webgl/slice_gpu":134,"./webgl/strided_slice_gpu":135,"./webgl/tex_util":136,"./webgl/texture_manager":137,"./webgl/tile_gpu":138,"./webgl/transpose_gpu":139,"./webgl/unaryop_gpu":140,"./webgl/unpack_gpu":141,"./webgl/webgl_util":142,"./where_impl":143}],84:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function mergeRealAndImagArrays(real, imag) {
@@ -15399,8 +16034,59 @@ function splitRealAndImagArrays(complex) {
     return { real: real, imag: imag };
 }
 exports.splitRealAndImagArrays = splitRealAndImagArrays;
+function complexWithEvenIndex(complex) {
+    var len = Math.ceil(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 0; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithEvenIndex = complexWithEvenIndex;
+function complexWithOddIndex(complex) {
+    var len = Math.floor(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 2; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithOddIndex = complexWithOddIndex;
+function getComplexWithIndex(complex, index) {
+    var real = complex[index * 2];
+    var imag = complex[index * 2 + 1];
+    return { real: real, imag: imag };
+}
+exports.getComplexWithIndex = getComplexWithIndex;
+function assignToTypedArray(data, real, imag, index) {
+    data[index * 2] = real;
+    data[index * 2 + 1] = imag;
+}
+exports.assignToTypedArray = assignToTypedArray;
+function exponents(n) {
+    var real = new Float32Array(n / 2);
+    var imag = new Float32Array(n / 2);
+    for (var i = 0; i < Math.ceil(n / 2); i++) {
+        var x = -2 * Math.PI * (i / n);
+        real[i] = Math.cos(x);
+        imag[i] = Math.sin(x);
+    }
+    return { real: real, imag: imag };
+}
+exports.exponents = exponents;
+function exponent(k, n) {
+    var x = -2 * Math.PI * (k / n);
+    var real = Math.cos(x);
+    var imag = Math.sin(x);
+    return { real: real, imag: imag };
+}
+exports.exponent = exponent;
 
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15458,7 +16144,33 @@ function intersectionOverUnion(boxes, i, j) {
     return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 
-},{"../ops/tensor_ops":171}],85:[function(require,module,exports){
+},{"../ops/tensor_ops":191}],86:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function getChannels(name) {
+    return ['x', 'y', 'z', 'w'].map(function (d) { return name + "." + d; });
+}
+exports.getChannels = getChannels;
+function getInnerDims(rank, dims) {
+    return dims.slice(0, rank).slice(-2);
+}
+exports.getInnerDims = getInnerDims;
+function getSourceCoords(rank, dims) {
+    if (rank === 1) {
+        return 'rc';
+    }
+    var coords = '';
+    for (var i = 0; i < rank; i++) {
+        coords += dims[i];
+        if (i < rank - 1) {
+            coords += ',';
+        }
+    }
+    return coords;
+}
+exports.getSourceCoords = getSourceCoords;
+
+},{}],87:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function split(x, sizeSplits, axis) {
@@ -15473,7 +16185,7 @@ function split(x, sizeSplits, axis) {
 }
 exports.split = split;
 
-},{}],86:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15508,7 +16220,7 @@ function topkImpl(x, xShape, xDtype, k, sorted) {
 }
 exports.topkImpl = topkImpl;
 
-},{"../ops/tensor_ops":171,"../util":194}],87:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214}],89:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ArgMinMaxProgram = (function () {
@@ -15526,13 +16238,13 @@ var ArgMinMaxProgram = (function () {
         var indexSnippet = firstPass ?
             'inOffset + i;' :
             'round(getBestIndicesA(batch, inOffset + i));';
-        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = 0;\n        float bestValue = getA(batch, inOffset);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
+        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = inOffset;\n        float bestValue = getA(batch, bestIndex);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
     }
     return ArgMinMaxProgram;
 }());
 exports.ArgMinMaxProgram = ArgMinMaxProgram;
 
-},{}],88:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var AvgPool2DBackpropProgram = (function () {
@@ -15543,16 +16255,20 @@ var AvgPool2DBackpropProgram = (function () {
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
         var avgMultiplier = 1 / (filterHeight * filterWidth);
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + ";\n            wC+= " + dilationWidth + ") {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return AvgPool2DBackpropProgram;
 }());
 exports.AvgPool2DBackpropProgram = AvgPool2DBackpropProgram;
 
-},{}],89:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15576,13 +16292,52 @@ var BatchNormProgram = (function () {
             scaleSnippet = 'getScaleAtOutCoords()';
         }
         this.outputShape = xShape;
-        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput(dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));\n      }\n    ";
     }
     return BatchNormProgram;
 }());
 exports.BatchNormProgram = BatchNormProgram;
 
-},{"../../ops/broadcast_util":139}],90:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],92:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var broadcast_util = require("../../ops/broadcast_util");
+var BatchNormPackedProgram = (function () {
+    function BatchNormPackedProgram(xShape, meanShape, varianceShape, offsetShape, scaleShape, varianceEpsilon) {
+        this.supportsBroadcasting = true;
+        this.usesPackedTextures = true;
+        this.variableNames = ['x', 'mean', 'variance'];
+        broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+        broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+        var meanSnippet = broadcastSample('mean', meanShape.length);
+        var varianceSnippet = broadcastSample('variance', varianceShape.length);
+        var offsetSnippet = 'vec4 offset = vec4(0.0)';
+        if (offsetShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+            this.variableNames.push('offset');
+            offsetSnippet = broadcastSample('offset', offsetShape.length);
+        }
+        var scaleSnippet = 'vec4 scale = vec4(1.0)';
+        if (scaleShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+            this.variableNames.push('scale');
+            scaleSnippet = broadcastSample('scale', scaleShape.length);
+        }
+        this.outputShape = xShape;
+        this.userCode = "\n      void main() {\n        ivec4 rc = getOutputCoords();\n\n        " + offsetSnippet + ";\n        " + scaleSnippet + ";\n\n        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);\n        " + meanSnippet + ";\n        " + varianceSnippet + ";\n\n        vec4 inv = scale * inversesqrt(variance + vec4(" + varianceEpsilon + "));\n\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+    }
+    return BatchNormPackedProgram;
+}());
+exports.BatchNormPackedProgram = BatchNormPackedProgram;
+function broadcastSample(texName, rank) {
+    var texSampler = "get" + texName.charAt(0).toUpperCase() + texName.slice(1);
+    if (rank === 1) {
+        return "\n      vec4 " + texName + "Sample = " + texSampler + "(rc.w);\n      vec4 " + texName + " = vec4(" + texName + "Sample.xy, " + texName + "Sample.xy);\n    ";
+    }
+    return "vec4 " + texName + " = " + texSampler + "(rc.x, rc.y, rc.z, rc.w)";
+}
+
+},{"../../ops/broadcast_util":151}],93:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15602,7 +16357,7 @@ var BinaryOpComplexProgram = (function () {
 }());
 exports.BinaryOpComplexProgram = BinaryOpComplexProgram;
 
-},{"../../ops/broadcast_util":139}],91:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],94:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15651,7 +16406,7 @@ var BinaryOpProgram = (function () {
 }());
 exports.BinaryOpProgram = BinaryOpProgram;
 
-},{"../../ops/broadcast_util":139}],92:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],95:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ClipProgram = (function () {
@@ -15664,7 +16419,20 @@ var ClipProgram = (function () {
 }());
 exports.ClipProgram = ClipProgram;
 
-},{}],93:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var ComplexAbsProgram = (function () {
+    function ComplexAbsProgram(shape) {
+        this.variableNames = ['real', 'imag'];
+        this.outputShape = shape;
+        this.userCode = "\n      void main() {\n        float real = getRealAtOutCoords();\n        float imag = getImagAtOutCoords();\n        vec2 v = vec2(real, imag);\n\n        setOutput(sqrt(dot(v, v)));\n      }\n    ";
+    }
+    return ComplexAbsProgram;
+}());
+exports.ComplexAbsProgram = ComplexAbsProgram;
+
+},{}],97:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var concat_util = require("../../ops/concat_util");
@@ -15680,7 +16448,7 @@ var ConcatProgram = (function () {
 }());
 exports.ConcatProgram = ConcatProgram;
 
-},{"../../ops/concat_util":143}],94:[function(require,module,exports){
+},{"../../ops/concat_util":155}],98:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DDerFilterProgram = (function () {
@@ -15712,7 +16480,7 @@ var Conv2DDerInputProgram = (function () {
 }());
 exports.Conv2DDerInputProgram = Conv2DDerInputProgram;
 
-},{}],95:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DDerFilterProgram = (function () {
@@ -15746,7 +16514,7 @@ var DepthwiseConv2DDerInputProgram = (function () {
 }());
 exports.DepthwiseConv2DDerInputProgram = DepthwiseConv2DDerInputProgram;
 
-},{}],96:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DProgram = (function () {
@@ -15769,7 +16537,7 @@ var Conv2DProgram = (function () {
 }());
 exports.Conv2DProgram = Conv2DProgram;
 
-},{}],97:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DProgram = (function () {
@@ -15793,7 +16561,7 @@ var DepthwiseConv2DProgram = (function () {
 }());
 exports.DepthwiseConv2DProgram = DepthwiseConv2DProgram;
 
-},{}],98:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var CropAndResizeProgram = (function () {
@@ -15834,7 +16602,7 @@ var CropAndResizeProgram = (function () {
 }());
 exports.CropAndResizeProgram = CropAndResizeProgram;
 
-},{}],99:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -15885,7 +16653,7 @@ function getFinalCoord(rank, name) {
     }
 }
 
-},{"./shader_compiler":123}],100:[function(require,module,exports){
+},{"./shader_compiler":133}],104:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthToSpaceProgram = (function () {
@@ -15941,7 +16709,7 @@ var DepthToSpaceProgram = (function () {
 }());
 exports.DepthToSpaceProgram = DepthToSpaceProgram;
 
-},{}],101:[function(require,module,exports){
+},{}],105:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var EncodeFloatProgram = (function () {
@@ -15954,7 +16722,25 @@ var EncodeFloatProgram = (function () {
 }());
 exports.EncodeFloatProgram = EncodeFloatProgram;
 
-},{}],102:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COMPLEX_FFT = {
+    REAL: 'return real * expR - imag * expI;',
+    IMAG: 'return real * expI + imag * expR;'
+};
+var FFTProgram = (function () {
+    function FFTProgram(op, inputShape) {
+        this.variableNames = ['real', 'imag'];
+        var innerDim = inputShape[1];
+        this.outputShape = inputShape;
+        this.userCode = "\n      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;\n\n      float unaryOpComplex(float real, float expR, float imag, float expI) {\n        " + op + "\n      }\n\n      float mulMatDFT(int batch, int index) {\n        float indexRatio = float(index) / float(" + innerDim + ");\n        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;\n\n        float result = 0.0;\n\n        for (int i = 0; i < " + innerDim + "; i++) {\n          // x = (-2 * PI / N) * index * i;\n          float x = negativeTwoPiTimesIndexRatio * float(i);\n          float expR = cos(x);\n          float expI = sin(x);\n          float real = getReal(batch, i);\n          float imag = getImag(batch, i);\n\n          result += unaryOpComplex(real, expR, imag, expI);\n        }\n\n        return result;\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        setOutput(mulMatDFT(coords[0], coords[1]));\n      }\n    ";
+    }
+    return FFTProgram;
+}());
+exports.FFTProgram = FFTProgram;
+
+},{}],107:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var FromPixelsProgram = (function () {
@@ -15968,7 +16754,7 @@ var FromPixelsProgram = (function () {
 }());
 exports.FromPixelsProgram = FromPixelsProgram;
 
-},{}],103:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16007,7 +16793,26 @@ function getSourceCoords(aShape, axis) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],104:[function(require,module,exports){
+},{"./shader_compiler":133}],109:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var GatherNDProgram = (function () {
+    function GatherNDProgram(sliceDim, strides, shape) {
+        this.sliceDim = sliceDim;
+        this.strides = strides;
+        this.variableNames = ['x', 'indices'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + this.strides + ");\n         void main() {\n          " + dtype + " coords = getOutputCoords();\n          int flattenIndex = 0;\n          for (int j = 0; j < " + this.sliceDim + "; j++) {\n            int index = round(getIndices(coords[0], j));\n            flattenIndex += index * " + strideString + ";\n          }\n          setOutput(getX(flattenIndex, coords[1]));\n        }\n      ";
+    }
+    return GatherNDProgram;
+}());
+exports.GatherNDProgram = GatherNDProgram;
+
+},{"./shader_compiler":133}],110:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16135,6 +16940,10 @@ var GPGPUContext = (function () {
         this.throwIfDisposed();
         gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
     };
+    GPGPUContext.prototype.createFloat16PackedMatrixTexture = function (rows, columns) {
+        this.throwIfDisposed();
+        return gpgpu_util.createFloat16PackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
+    };
     GPGPUContext.prototype.createPackedMatrixTexture = function (rows, columns) {
         this.throwIfDisposed();
         return gpgpu_util.createPackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
@@ -16153,9 +16962,9 @@ var GPGPUContext = (function () {
         var numChannels = webgl_util.getNumChannels();
         return gpgpu_util.uploadMatrixToTexture(this.gl, texture, rows, columns, matrix, numChannels, this.textureConfig);
     };
-    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, rows, columns, matrix) {
+    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, batch, rows, columns, matrix) {
         this.throwIfDisposed();
-        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, rows, columns, matrix, this.textureConfig);
+        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, batch, rows, columns, matrix, this.textureConfig);
     };
     GPGPUContext.prototype.downloadFloat32MatrixFromOutputTexture = function (texture, rows, columns) {
         var _this = this;
@@ -16203,9 +17012,9 @@ var GPGPUContext = (function () {
         }
         return { query: query, isFencePassed: isFencePassed };
     };
-    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, rows, columns) {
+    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, batch, rows, columns, physicalRows, physicalCols) {
         var _this = this;
-        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, rows, columns, _this.textureConfig); });
+        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, batch, rows, columns, physicalRows, physicalCols, _this.textureConfig); });
     };
     GPGPUContext.prototype.createProgram = function (fragmentShaderSource) {
         this.throwIfDisposed();
@@ -16487,7 +17296,7 @@ function binSearchLastTrue(arr) {
 }
 exports.binSearchLastTrue = binSearchLastTrue;
 
-},{"../../environment":64,"../../util":194,"./gpgpu_util":106,"./tex_util":126,"./webgl_util":131}],105:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./gpgpu_util":112,"./tex_util":136,"./webgl_util":142}],111:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../../util");
@@ -16498,7 +17307,8 @@ function compileProgram(gpgpu, program, inputs, output) {
         var shapeInfo = {
             logicalShape: input.shape,
             texShape: input.isUniform ? null : input.texData.texShape,
-            isUniform: input.isUniform
+            isUniform: input.isUniform,
+            isPacked: input.isUniform ? false : input.texData.isPacked
         };
         return { name: program.variableNames[i], shapeInfo: shapeInfo };
     });
@@ -16506,7 +17316,8 @@ function compileProgram(gpgpu, program, inputs, output) {
     var outShapeInfo = {
         logicalShape: output.shape,
         texShape: output.texData.texShape,
-        isUniform: false
+        isUniform: false,
+        isPacked: output.texData.isPacked
     };
     var source = shader_compiler.makeShader(inputInfos, outShapeInfo, userCode, program.supportsBroadcasting === true);
     var webGLProgram = gpgpu.createProgram(source);
@@ -16558,7 +17369,12 @@ function runProgram(binary, inputs, output, customSetup) {
     var outTex = output.texData.texture;
     var outTexShape = output.texData.texShape;
     var gpgpu = binary.gpgpu;
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    if (output.texData.isPacked) {
+        gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
+    else {
+        gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
     gpgpu.setProgram(binary.webGLProgram);
     inputs.forEach(function (input, i) {
         var variableName = binary.program.variableNames[i];
@@ -16600,10 +17416,11 @@ function makeShaderKey(program, inputs, output) {
 }
 exports.makeShaderKey = makeShaderKey;
 
-},{"../../util":194,"./shader_compiler":123}],106:[function(require,module,exports){
+},{"../../util":214,"./shader_compiler":133}],112:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 var tex_util = require("./tex_util");
 var webgl_util = require("./webgl_util");
 function getWebGLContextAttributes() {
@@ -16698,7 +17515,7 @@ function getTextureConfig(gl, textureHalfFloatExtension) {
 }
 exports.getTextureConfig = getTextureConfig;
 function createAndConfigureTexture(gl, width, height, internalFormat, textureFormat, textureType) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     var texture = webgl_util.createTexture(gl);
     var tex2d = gl.TEXTURE_2D;
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(tex2d, texture); });
@@ -16730,6 +17547,11 @@ function createPackedMatrixTexture(gl, rows, columns, textureConfig) {
     return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatPackedFloat, gl.RGBA, gl.FLOAT);
 }
 exports.createPackedMatrixTexture = createPackedMatrixTexture;
+function createFloat16PackedMatrixTexture(gl, rows, columns, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), width = _a[0], height = _a[1];
+    return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA, textureConfig.textureTypeHalfFloat);
+}
+exports.createFloat16PackedMatrixTexture = createFloat16PackedMatrixTexture;
 function bindVertexProgramAttributeStreams(gl, program, vertexBuffer) {
     var posOffset = 0;
     var uvOffset = 3 * 4;
@@ -16747,7 +17569,7 @@ function uploadPixelDataToTexture(gl, texture, pixels) {
 }
 exports.uploadPixelDataToTexture = uploadPixelDataToTexture;
 function uploadDataToTexture(gl, texture, width, height, data, textureFormat) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, texture); });
     webgl_util.callAndCheck(gl, function () { return gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, textureFormat, gl.FLOAT, data); });
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, null); });
@@ -16766,10 +17588,10 @@ function uploadMatrixToTexture(gl, texture, rows, columns, matrix, numChannels, 
     uploadDataToTexture(gl, texture, w, h, unpackedArray, textureConfig.textureFormatFloat);
 }
 exports.uploadMatrixToTexture = uploadMatrixToTexture;
-function uploadMatrixToPackedTexture(gl, texture, rows, columns, matrix, textureConfig) {
+function uploadMatrixToPackedTexture(gl, texture, batch, rows, columns, matrix, textureConfig) {
     var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
     var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
-    tex_util.encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA);
+    tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
     uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }
 exports.uploadMatrixToPackedTexture = uploadMatrixToPackedTexture;
@@ -16818,16 +17640,32 @@ function downloadByteEncodedFloatMatrixFromOutputTexture(gl, rows, columns, text
     return new Float32Array(downloadTarget.buffer);
 }
 exports.downloadByteEncodedFloatMatrixFromOutputTexture = downloadByteEncodedFloatMatrixFromOutputTexture;
-function downloadMatrixFromPackedOutputTexture(gl, rows, columns, textureConfig) {
-    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
-    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+function downloadMatrixFromPackedOutputTexture(gl, batch, rows, cols, physicalRows, physicalCols, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(physicalRows, physicalCols), w = _a[0], h = _a[1];
+    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
     webgl_util.callAndCheck(gl, function () { return gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, packedRGBA); });
-    var matrix = new Float32Array(rows * columns);
-    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix);
+    var matrix = new Float32Array(util.sizeFromShape([batch, rows, cols]));
+    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, batch, rows, cols, matrix);
 }
 exports.downloadMatrixFromPackedOutputTexture = downloadMatrixFromPackedOutputTexture;
 
-},{"../../environment":64,"./tex_util":126,"./webgl_util":131}],107:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./tex_util":136,"./webgl_util":142}],113:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Im2ColProgram = (function () {
+    function Im2ColProgram(outputShape, inputShape, convInfo) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var filterWidth = convInfo.filterWidth, inChannels = convInfo.inChannels, strideWidth = convInfo.strideWidth, strideHeight = convInfo.strideHeight, padInfo = convInfo.padInfo, outWidth = convInfo.outWidth, dilationWidth = convInfo.dilationWidth, dilationHeight = convInfo.dilationHeight;
+        var left = padInfo.left, top = padInfo.top;
+        var itemsPerBlockRow = inChannels * filterWidth;
+        this.userCode = "\n      void main() {\n        ivec2 rc = getOutputCoords();\n\n        vec4 result = vec4(0);\n\n        for(int row=0; row<=1; row++) {\n          for(int col=0; col<=1; col++) {\n            int blockIndex = rc.y + col;\n            int pos = rc.x + row;\n\n            if(blockIndex >= " + outputShape[1] + " || pos >= " + outputShape[0] + ") continue;\n\n            int offsetY = int(blockIndex / (" + outWidth + ")) * " + strideHeight + " - " + top + ";\n            int d0 = offsetY + " + dilationHeight + " * (pos / " + itemsPerBlockRow + ");\n\n            if(d0 >= " + inputShape[0] + " || d0 < 0) continue;\n\n            int offsetX = int(mod(float(blockIndex), " + outWidth + ".) * " + strideWidth + ". - " + left + ".);\n            int d1 = offsetX + " + dilationWidth + " * (int(mod(float(pos), " + itemsPerBlockRow + ".) / " + inChannels + ".));\n\n            if(d1 >= " + inputShape[1] + " || d1 < 0) continue;\n\n            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), " + inChannels + ".)));\n          }\n        }\n\n        gl_FragColor = result;\n      }\n    ";
+    }
+    return Im2ColProgram;
+}());
+exports.Im2ColProgram = Im2ColProgram;
+
+},{}],114:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNProgram = (function () {
@@ -16854,7 +17692,7 @@ var LRNProgram = (function () {
 }());
 exports.LRNProgram = LRNProgram;
 
-},{}],108:[function(require,module,exports){
+},{}],115:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNGradProgram = (function () {
@@ -16873,27 +17711,28 @@ var LRNGradProgram = (function () {
 }());
 exports.LRNGradProgram = LRNGradProgram;
 
-},{}],109:[function(require,module,exports){
+},{}],116:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MaxPool2DBackpropProgram = (function () {
     function MaxPool2DBackpropProgram(convInfo) {
         this.variableNames = ['dy', 'maxPos'];
         this.outputShape = convInfo.inShape;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var lastIndex = filterHeight * filterWidth - 1;
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + filterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        var dilationHeight = convInfo.dilationHeight;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var lastIndex = effectiveFilterHeight * effectiveFilterWidth - 1;
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n          wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + effectiveFilterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return MaxPool2DBackpropProgram;
 }());
 exports.MaxPool2DBackpropProgram = MaxPool2DBackpropProgram;
 
-},{}],110:[function(require,module,exports){
+},{}],117:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MatMulProgram = (function () {
@@ -16922,7 +17761,29 @@ var MatMulProgram = (function () {
 }());
 exports.MatMulProgram = MatMulProgram;
 
-},{}],111:[function(require,module,exports){
+},{}],118:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var MatMulPackedProgram = (function () {
+    function MatMulPackedProgram(aShape, bShape, outputShape, transposeA, transposeB) {
+        if (transposeA === void 0) { transposeA = false; }
+        if (transposeB === void 0) { transposeB = false; }
+        this.variableNames = ['matrixA', 'matrixB'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var sharedDim = transposeA ? aShape[0] : aShape[1];
+        var sharedDimensionPacked = Math.ceil(sharedDim / 2);
+        var aSample = transposeA ? 'i * 2, rc.x' : 'rc.x, i * 2';
+        var bSample = transposeB ? 'rc.y, i * 2' : 'i * 2, rc.y';
+        var aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
+        var bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
+        this.userCode = "\n      const float sharedDimension = " + sharedDimensionPacked + ".0;\n\n      vec4 dot2x2ARowBCol(ivec2 rc) {\n        vec4 result = vec4(0);\n        for (int i = 0; i < " + sharedDimensionPacked + "; i++) {\n          vec4 a = getMatrixA(" + aSample + ");\n          vec4 b = getMatrixB(" + bSample + ");\n\n          result += (" + aSwizzle[0] + " * " + bSwizzle[0] + ") + (" + aSwizzle[1] + " * " + bSwizzle[1] + ");\n        }\n        return result;\n      }\n\n      void main() {\n        ivec2 rc = getOutputCoords();\n        setOutput(dot2x2ARowBCol(rc));\n      }\n    ";
+    }
+    return MatMulPackedProgram;
+}());
+exports.MatMulPackedProgram = MatMulPackedProgram;
+
+},{}],119:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MultinomialProgram = (function () {
@@ -16944,7 +17805,7 @@ var MultinomialProgram = (function () {
 }());
 exports.MultinomialProgram = MultinomialProgram;
 
-},{}],112:[function(require,module,exports){
+},{}],120:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var OneHotProgram = (function () {
@@ -16957,7 +17818,69 @@ var OneHotProgram = (function () {
 }());
 exports.OneHotProgram = OneHotProgram;
 
-},{}],113:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var PackProgram = (function () {
+    function PackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var outOfBoundsCondition = getOutOfBoundsCondition(rank, outputShape, channels);
+        var setup = getSetup(rank, outputShape[outputShape.length - 1], outputShape[outputShape.length - 2], channels);
+        var output = getOutput(outputShape, channels);
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n\n        if(" + outOfBoundsCondition + ") {\n          gl_FragColor = vec4(0);\n        } else {\n          " + setup + "\n\n          setOutput(vec4(" + output + "));\n        }\n      }\n    ";
+    }
+    return PackProgram;
+}());
+exports.PackProgram = PackProgram;
+function getSourceCoordsArr(rank, dims) {
+    var coords = [];
+    for (var row = 0; row <= 1; row++) {
+        for (var col = 0; col <= 1; col++) {
+            var coord = (row === 0 ? 'r' : 'rp1') + ", " + (col === 0 ? 'c' : 'cp1');
+            for (var d = 2; d < rank; d++) {
+                coord = dims[dims.length - 1 - d] + "," + coord;
+            }
+            coords.push(coord);
+        }
+    }
+    return coords;
+}
+function getOutOfBoundsCondition(rank, shape, dims) {
+    if (rank === 1) {
+        return "rc > " + shape[0];
+    }
+    var cond = '';
+    for (var i = 0; i < rank; i++) {
+        cond += dims[i] + " >= " + shape[i];
+        if (i < rank - 1) {
+            cond += '||';
+        }
+    }
+    return cond;
+}
+function getSetup(rank, cols, rows, dims) {
+    if (rank === 1) {
+        return '';
+    }
+    var innerDims = packing_util_1.getInnerDims(rank, dims);
+    return "\n    int r = " + innerDims[0] + ";\n    int c = " + innerDims[1] + ";\n    int rp1 = r + 1;\n    int cp1 = c + 1;\n\n    bool cEdge = cp1 >= " + cols + ";\n    bool rEdge = rp1 >= " + rows + ";\n  ";
+}
+function getOutput(shape, dims) {
+    var rank = shape.length;
+    var sourceCoords = getSourceCoordsArr(rank, dims);
+    if (rank === 1) {
+        return "getA(rc),\n            rc + 1 >= " + shape[0] + " ? 0. : getA(rc + 1),\n            0, 0";
+    }
+    return "getA(" + sourceCoords[0] + "),\n          cEdge ? 0. : getA(" + sourceCoords[1] + "),\n          rEdge ? 0. : getA(" + sourceCoords[2] + "),\n          rEdge || cEdge ? 0. : getA(" + sourceCoords[3] + ")";
+}
+
+},{"../packing_util":86,"./shader_compiler":133}],122:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16980,7 +17903,7 @@ var PadProgram = (function () {
 }());
 exports.PadProgram = PadProgram;
 
-},{"./shader_compiler":123}],114:[function(require,module,exports){
+},{"./shader_compiler":133}],123:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Pool2DProgram = (function () {
@@ -16989,10 +17912,13 @@ var Pool2DProgram = (function () {
         if (poolType === 'avg' && computePositions) {
             throw new Error('Cannot compute positions for average pool.');
         }
-        var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         this.outputShape = convInfo.outShape;
@@ -17003,7 +17929,7 @@ var Pool2DProgram = (function () {
         }
         if (computePositions) {
             var compareOp_1 = '>=';
-            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + filterHeight + "; wR++) {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + filterWidth + "; wC++) {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + filterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
+            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + effectiveFilterHeight + ";\n              wR += " + dilationHeight + ") {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + effectiveFilterWidth + ";\n                wC += " + dilationWidth + ") {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + effectiveFilterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
             return;
         }
         var compareOp = 'max';
@@ -17015,13 +17941,13 @@ var Pool2DProgram = (function () {
         var filterWidthNearestVec4 = Math.floor(filterWidth / 4) * 4;
         var filterWidthVec4Remainder = filterWidth % 4;
         var updateSnippet = "\n      if (" + isAvgPool + ") {\n        avgValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
-        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC;\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              getValue(batch, xR, xC + 3, d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC * " + dilationWidth + ";\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 3 * " + dilationWidth + ", d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return Pool2DProgram;
 }());
 exports.Pool2DProgram = Pool2DProgram;
 
-},{}],115:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ReduceProgram = (function () {
@@ -17034,7 +17960,10 @@ var ReduceProgram = (function () {
         this.outputShape = [batchSize, outSize];
         var initializationValue = '0.0';
         var compareOp = "";
-        if (reduceType === 'min') {
+        if (reduceType === 'prod') {
+            initializationValue = '1.0';
+        }
+        else if (reduceType === 'min') {
             initializationValue = '1.0 / 0.0';
             compareOp = "min";
         }
@@ -17047,6 +17976,9 @@ var ReduceProgram = (function () {
         if (reduceType === 'sum') {
             returnValue = "sumValue";
         }
+        else if (reduceType === 'prod') {
+            returnValue = "prodValue";
+        }
         else if (reduceType === 'all') {
             returnValue = "allValue";
         }
@@ -17055,7 +17987,7 @@ var ReduceProgram = (function () {
         }
         var windowSizeNearestVec4 = Math.floor(windowSize / 4) * 4;
         var windowSizeVec4Remainder = windowSize % 4;
-        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
+        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else if (" + (reduceType === 'prod') + ") {\n        vec2 tmp = vec2(values[0], values[1]) * vec2(values[2], values[3]);\n        prodValue *= tmp[0] * tmp[1];\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
         var vecType = "vec4";
         if (reduceType === 'all') {
             initializationValue = '1.0';
@@ -17071,13 +18003,13 @@ var ReduceProgram = (function () {
         if (inSize % windowSize > 0) {
             checkOutOfBounds = "\n        if (inIdx < 0 || inIdx >= " + inSize + ") {\n          return initializationValue;\n        }\n      ";
         }
-        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float prodValue = 1.0;\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return ReduceProgram;
 }());
 exports.ReduceProgram = ReduceProgram;
 
-},{}],116:[function(require,module,exports){
+},{}],125:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearBackpropProgram = (function () {
@@ -17107,7 +18039,7 @@ var ResizeBilinearBackpropProgram = (function () {
 }());
 exports.ResizeBilinearBackpropProgram = ResizeBilinearBackpropProgram;
 
-},{}],117:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearProgram = (function () {
@@ -17130,7 +18062,7 @@ var ResizeBilinearProgram = (function () {
 }());
 exports.ResizeBilinearProgram = ResizeBilinearProgram;
 
-},{}],118:[function(require,module,exports){
+},{}],127:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeigborBackpropProgram = (function () {
@@ -17160,7 +18092,7 @@ var ResizeNearestNeigborBackpropProgram = (function () {
 }());
 exports.ResizeNearestNeigborBackpropProgram = ResizeNearestNeigborBackpropProgram;
 
-},{}],119:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeighborProgram = (function () {
@@ -17184,7 +18116,7 @@ var ResizeNearestNeighborProgram = (function () {
 }());
 exports.ResizeNearestNeighborProgram = ResizeNearestNeighborProgram;
 
-},{}],120:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17214,7 +18146,41 @@ var ReverseProgram = (function () {
 }());
 exports.ReverseProgram = ReverseProgram;
 
-},{"./shader_compiler":123}],121:[function(require,module,exports){
+},{"./shader_compiler":133}],130:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var ScatterProgram = (function () {
+    function ScatterProgram(updateSize, sliceDim, indicesRank, updatesRank, strides, shape, summingDupeIndex) {
+        if (summingDupeIndex === void 0) { summingDupeIndex = true; }
+        this.variableNames = ['updates', 'indices', 'defaultValue'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var indicesString = '';
+        if (indicesRank === 1) {
+            indicesString = 'i';
+        }
+        else if (indicesRank === 2) {
+            indicesString = 'i, j';
+        }
+        var indicesSnippet = "getIndices(" + indicesString + ")";
+        var updatesString = '';
+        if (updatesRank === 1) {
+            updatesString = 'i';
+        }
+        else if (updatesRank === 2) {
+            updatesString = 'i, coords[1]';
+        }
+        var updatesSnippet = "getUpdates(" + updatesString + ")";
+        var strideString = sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + strides + ");\n\n        void main() {\n          " + dtype + " coords = getOutputCoords();\n          float sum = 0.0;\n          bool found = false;\n          for (int i = 0; i < " + updateSize + "; i++) {\n            int flattenedIndex = 0;\n            for (int j = 0; j < " + sliceDim + "; j++) {\n              int index = round(" + indicesSnippet + ");\n              flattenedIndex += index * " + strideString + ";\n            }\n            if (flattenedIndex == coords[0]) {\n              sum += " + updatesSnippet + ";\n              found = true;\n            }\n          }\n          setOutput(mix(getDefaultValue(), sum, float(found)));\n        }\n      ";
+    }
+    return ScatterProgram;
+}());
+exports.ScatterProgram = ScatterProgram;
+
+},{"./shader_compiler":133}],131:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var SegmentOpProgram = (function () {
@@ -17245,7 +18211,7 @@ var SegmentOpProgram = (function () {
 }());
 exports.SegmentOpProgram = SegmentOpProgram;
 
-},{}],122:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17282,7 +18248,7 @@ var SelectProgram = (function () {
 }());
 exports.SelectProgram = SelectProgram;
 
-},{"./shader_compiler":123}],123:[function(require,module,exports){
+},{"./shader_compiler":133}],133:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -17299,11 +18265,21 @@ function makeShader(inputsInfo, outputShape, userCode, broadcast) {
     var inputSamplingSnippet = inputsInfo.map(function (x) { return getInputSamplingSnippet(x, outputShape, broadcast); })
         .join('\n');
     var outTexShape = outputShape.texShape;
-    var outputSamplingSnippet = getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    var outputSamplingSnippet;
+    var floatTextureSetOutputSnippet;
+    if (outputShape.isPacked) {
+        outputSamplingSnippet =
+            getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    }
+    else {
+        outputSamplingSnippet =
+            getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    }
     var source = [
-        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-        FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-        inputSamplingSnippet, userCode
+        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+        inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
     ].join('\n');
     return source;
 }
@@ -17330,14 +18306,47 @@ function getSamplerFromInInfo(inInfo) {
                 " is not yet supported");
     }
 }
+function getPackedSamplerFromInInfo(inInfo) {
+    var shape = inInfo.shapeInfo.logicalShape;
+    switch (shape.length) {
+        case 1:
+            return getPackedSampler1D(inInfo);
+        case 2:
+            return getPackedSampler2D(inInfo);
+        case 4:
+            return getPackedSampler4D(inInfo);
+        default:
+            throw new Error("Packed " + shape.length + "-D input sampling" +
+                " is not yet supported");
+    }
+}
 function getInputSamplingSnippet(inInfo, outShapeInfo, broadcast) {
     var res = getSamplerFlat(inInfo);
-    res += getSamplerFromInInfo(inInfo);
+    if (inInfo.shapeInfo.isPacked) {
+        res += getPackedSamplerFromInInfo(inInfo);
+    }
+    else {
+        res += getSamplerFromInInfo(inInfo);
+    }
     if (broadcast ||
         util.arraysEqual(inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
         res += getSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     }
     return res;
+}
+function getPackedOutputSamplingSnippet(outShape, outTexShape) {
+    switch (outShape.length) {
+        case 0:
+            return getOutputScalarCoords();
+        case 1:
+            return getOutputPacked1DCoords(outShape, outTexShape);
+        case 2:
+            return getOutputPacked2DCoords(outShape, outTexShape);
+        case 4:
+            return getOutputPacked4DCoords(outShape, outTexShape);
+        default:
+            throw new Error(outShape.length + "-D output packed sampling is not yet supported");
+    }
 }
 function getOutputSamplingSnippet(outShape, outTexShape) {
     switch (outShape.length) {
@@ -17359,17 +18368,28 @@ function getOutputSamplingSnippet(outShape, outTexShape) {
             throw new Error(outShape.length + "-D output sampling is not yet supported");
     }
 }
-var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom1D(int texNumR, int texNumC, int index) {\n  int texelIndex = index / 2;\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom2D(int texelsInLogicalRow, int texNumR,\n  int texNumC, int row, int col) {\n  int texelIndex = (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_3D_SNIPPET = "\nvec2 UVfrom3D(int texNumR, int texNumC, int stride0,\n    int stride1, int row, int col, int depth) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,\n    int texelsInBatch, int texelsInLogicalRow, int b2, int b,\n    int row, int col) {\n  int index = b2 * texelsInBatch2 + b * texelsInBatch +\n    (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_5D_SNIPPET = "\nvec2 UVfrom5D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int row, int col, int depth,\n    int depth2, int depth3) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 +\n              depth * stride2 + depth2 * stride3 + depth3;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_6D_SNIPPET = "\nvec2 UVfrom6D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int stride4,\n    int row, int col, int depth, int depth2, int depth3, int depth4) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2 *\n    stride3 + depth3 * stride4 + depth4;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var FLOAT_TEXTURE_SAMPLE_SNIPPET = "\n  float sampleTexture(sampler2D textureSampler, vec2 uv) {\n    return texture2D(textureSampler, uv).r;\n  }\n";
-var FLOAT_TEXTURE_SETOUTPUT_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
-var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
+var FLOAT_TEXTURE_SET_R_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
+var FLOAT_TEXTURE_SET_RGBA_SNIPPET = "\n  void setOutput(vec4 val) {\n    gl_FragColor = val;\n  }\n";
+var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
 function getOutputScalarCoords() {
     return "\n    int getOutputCoords() {\n      return 0;\n    }\n  ";
+}
+function getOutputPacked1DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (texShape[0] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.x * " + packedTexShape[1] + ".0);\n      }\n    ";
+    }
+    if (texShape[1] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.y * " + packedTexShape[0] + ".0);\n      }\n    ";
+    }
+    return "\n    int getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      return resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n    }\n  ";
 }
 function getOutput1DCoords(shape, texShape) {
     if (texShape[0] === 1) {
@@ -17384,6 +18404,13 @@ function getOutput3DCoords(shape, texShape) {
     var stride0 = shape[1] * shape[2];
     var stride1 = shape[2];
     return "\n    ivec3 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n      int c = index / " + stride1 + ";\n      int d = index - c * " + stride1 + ";\n      return ivec3(r, c, d);\n    }\n  ";
+}
+function getOutputPacked4DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texelsInLogicalRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    ivec4 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n\n      int b2 = index / " + texelsInBatch2 + ";\n      index -= b2 * " + texelsInBatch2 + ";\n\n      int b = index / " + texelsInBatch + ";\n      index -= b * " + texelsInBatch + ";\n\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = int(mod(float(index), " + texelsInLogicalRow + ".)) * 2;\n\n      return ivec4(b2, b, r, c);\n    }\n  ";
 }
 function getOutput4DCoords(shape, texShape) {
     var stride2 = shape[3];
@@ -17406,6 +18433,14 @@ function getOutput6DCoords(shape, texShape) {
     var stride0 = shape[1] * stride1;
     return "\n    ivec6 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n        vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n\n      int c = index / " + stride1 + ";\n      index -= c * " + stride1 + ";\n\n      int d = index / " + stride2 + ";\n      index -= d * " + stride2 + ";\n\n      int d2 = index / " + stride3 + ";\n      index -= d2 * " + stride3 + ";\n\n      int d3 = index / " + stride4 + ";\n      int d4 = index - d3 * " + stride4 + ";\n\n      ivec6 result = ivec6(r, c, d, d2, d3, d4);\n      return result;\n    }\n  ";
 }
+function getOutputPacked2DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (util.arraysEqual(shape, texShape)) {
+        return "\n      ivec2 getOutputCoords() {\n        return 2 * ivec2(resultUV.yx * vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      }\n    ";
+    }
+    var texelsInLogicalRow = Math.ceil(shape[1] / 2);
+    return "\n    ivec2 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = imod(index, " + texelsInLogicalRow + ") * 2;\n\n      return ivec2(r, c);\n    }\n  ";
+}
 function getOutput2DCoords(shape, texShape) {
     if (util.arraysEqual(shape, texShape)) {
         return "\n      ivec2 getOutputCoords() {\n        return ivec2(resultUV.yx * vec2(" + texShape[0] + ", " + texShape[1] + "));\n      }\n    ";
@@ -17426,10 +18461,31 @@ function getSamplerScalar(inputInfo) {
     }
     return "\n    float " + funcName + "() {\n      return sampleTexture(" + texName + ", halfCR);\n    }\n  ";
 }
+function getPackedSampler1D(inputInfo) {
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    return "\n    vec4 " + funcName + "(int index) {\n      vec2 uv = packedUVfrom1D(\n        " + packedTexShape[0] + ", " + packedTexShape[1] + ", index);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
+}
 function getSampler1D(inputInfo) {
     var texName = inputInfo.name;
     var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
     return "\n    float " + funcName + "(int index) {\n      return " + funcName + "Flat(index);\n    }\n  ";
+}
+function getPackedSampler2D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var texNumR = texShape[0];
+    var texNumC = texShape[1];
+    if (texShape != null && util.arraysEqual(shape, texShape)) {
+        return "\n      vec4 " + funcName + "(int row, int col) {\n        vec2 uv = (vec2(col, row) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n\n        return texture2D(" + texName + ", uv);\n      }\n    ";
+    }
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var valuesPerRow = Math.ceil(shape[1] / 2);
+    return "\n    vec4 " + funcName + "(int row, int col) {\n      vec2 uv = packedUVfrom2D(" + valuesPerRow + ", " + packedTexShape[0] + ", " + packedTexShape[1] + ", row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler2D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17449,15 +18505,15 @@ function getSampler2D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col) {\n        int index = row * " + shape[1] + " + col;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col) {\n        float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2(0.5, (float(index) + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2(0.5, (index + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     if (texNumR === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2((float(index) + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2((index + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n  float " + funcName + "(int row, int col) {\n    vec2 uv = UVfrom2D(" + texNumR + ", " + texNumC + ", " + shape[1] + ", row, col);\n    return sampleTexture(" + texName + ", uv);\n  }\n";
 }
@@ -17475,18 +18531,31 @@ function getSampler3D(inputInfo) {
         return "\n        " + getSamplerFromInInfo(newInputInfo) + "\n        float " + funcName + "(int row, int col, int depth) {\n          return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n        }\n      ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth) {\n        int index = row * " + stride0 + " + col * " + stride1 + " + depth;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth) {\n        float index = dot(vec3(row, col, depth),\n                          vec3(" + stride0 + ", " + stride1 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n        float " + funcName + "(int row, int col, int depth) {\n          int texR = row;\n          int texC = col * " + stride1 + " + depth;\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
+        return "\n        float " + funcName + "(int row, int col, int depth) {\n          float texR = float(row);\n          float texC = dot(vec2(col, depth), vec2(" + stride1 + ", 1));\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
     }
     if (texNumC === stride1) {
-        return "\n    float " + funcName + "(int row, int col, int depth) {\n      int texR = row * " + shape[1] + " + col;\n      int texC = depth;\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col, int depth) {\n      float texR = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      float texC = float(depth);\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n      float " + funcName + "(int row, int col, int depth) {\n        vec2 uv = UVfrom3D(\n            " + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ", row, col, depth);\n        return sampleTexture(" + texName + ", uv);\n      }\n  ";
+}
+function getPackedSampler4D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texNumR = packedTexShape[0];
+    var texNumC = packedTexShape[1];
+    var valuesPerRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    vec4 " + funcName + "(int b2, int b, int row, int col) {\n      vec2 uv = packedUVfrom4D(\n        " + texNumR + ", " + texNumC + ", " + texelsInBatch2 + ",\n        " + texelsInBatch + ", " + valuesPerRow + ", b2, b, row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler4D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17502,16 +18571,16 @@ function getSampler4D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float index = dot(vec4(row, col, depth, depth2),\n                          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = float(row);\n        float texC =\n            dot(vec3(col, depth, depth2), vec3(" + stride1 + ", " + stride2 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride2) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = dot(vec3(row, col, depth),\n                         vec3(" + shape[1] * shape[2] + ", " + shape[2] + ", 1));\n        float texC = float(depth2);\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2) {\n      vec2 uv = UVfrom4D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", row, col, depth, depth2);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17530,16 +18599,16 @@ function getSampler5D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " +\n                   depth2 * " + stride3 + " + depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride3) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " +\n                   depth * " + shape[3] + " + depth2;\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] + ", " + shape[2] * shape[3] + ",\n            " + shape[3] + ", 1));\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n      vec2 uv = UVfrom5D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", row, col, depth, depth2, depth3);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17559,16 +18628,16 @@ function getSampler6D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3 * " + stride3 + "\n            + depth4\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          dot(\n            vec2(depth3, depth4),\n            vec2(" + stride4 + ", 1));\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", " + stride4 + ")) + depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride4) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] * shape[4] + ",\n               " + shape[2] * shape[3] * shape[4] + ",\n               " + shape[3] * shape[4] + ",\n               " + shape[4] + ")) + depth3;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n      vec2 uv = UVfrom6D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", " + stride4 + "\n          ,row, col, depth, depth2, depth3, depth4);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17697,7 +18766,7 @@ function getSqueezedParams(params, keptDims) {
     return keptDims.map(function (d) { return params[d]; }).join(', ');
 }
 
-},{"../../ops/broadcast_util":139,"../../util":194}],124:[function(require,module,exports){
+},{"../../ops/broadcast_util":151,"../../util":214}],134:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17761,7 +18830,7 @@ function getCoords(rank) {
     }
 }
 
-},{"./shader_compiler":123}],125:[function(require,module,exports){
+},{"./shader_compiler":133}],135:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17799,9 +18868,10 @@ var StridedSliceProgram = (function () {
 }());
 exports.StridedSliceProgram = StridedSliceProgram;
 
-},{"./shader_compiler":123}],126:[function(require,module,exports){
+},{"./shader_compiler":133}],136:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var util = require("../../util");
 var TextureUsage;
 (function (TextureUsage) {
     TextureUsage[TextureUsage["RENDER"] = 0] = "RENDER";
@@ -17811,9 +18881,11 @@ var TextureUsage;
 })(TextureUsage = exports.TextureUsage || (exports.TextureUsage = {}));
 var PhysicalTextureType;
 (function (PhysicalTextureType) {
-    PhysicalTextureType[PhysicalTextureType["FLOAT16"] = 0] = "FLOAT16";
-    PhysicalTextureType[PhysicalTextureType["FLOAT32"] = 1] = "FLOAT32";
-    PhysicalTextureType[PhysicalTextureType["UNSIGNED_BYTE"] = 2] = "UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT16"] = 0] = "UNPACKED_FLOAT16";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT32"] = 1] = "UNPACKED_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_4X1_UNSIGNED_BYTE"] = 2] = "PACKED_4X1_UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT32"] = 3] = "PACKED_2X2_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT16"] = 4] = "PACKED_2X2_FLOAT16";
 })(PhysicalTextureType = exports.PhysicalTextureType || (exports.PhysicalTextureType = {}));
 function getUnpackedMatrixTextureShapeWidthHeight(rows, columns) {
     return [columns, rows];
@@ -17881,118 +18953,130 @@ function getPackedRGBAArraySizeFromMatrixShape(rows, columns) {
     return w * h * 4;
 }
 exports.getPackedRGBAArraySizeFromMatrixShape = getPackedRGBAArraySizeFromMatrixShape;
-function encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA) {
+function encodeMatrixToPackedRGBA(matrix, batches, rows, columns, packedRGBA) {
     var requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
     if (packedRGBA.length < requiredSize) {
-        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >= " + requiredSize);
+        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >=\n        " + requiredSize);
     }
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    {
-        var dstStride = (oddWidth ? 4 : 0);
-        var oneRow = columns;
-        var dst = 0;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            var matrixSrcRow = (blockY * 2 * columns);
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                var matrixSrcCol = blockX * 2;
-                var src = matrixSrcRow + matrixSrcCol;
-                packedRGBA[dst] = matrix[src];
-                packedRGBA[dst + 1] = matrix[src + 1];
-                packedRGBA[dst + 2] = matrix[src + oneRow];
-                packedRGBA[dst + 3] = matrix[src + oneRow + 1];
-                dst += 4;
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var sourceOffset = batch * rows * columns;
+        var batchOffset = batch * flattenedMatrixSize;
+        {
+            var dstStride = (oddWidth ? 4 : 0);
+            var oneRow = columns;
+            var dst = batchOffset;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                var matrixSrcRow = (blockY * 2 * columns);
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    var matrixSrcCol = blockX * 2;
+                    var src = sourceOffset + matrixSrcRow + matrixSrcCol;
+                    packedRGBA[dst] = matrix[src];
+                    packedRGBA[dst + 1] = matrix[src + 1];
+                    packedRGBA[dst + 2] = matrix[src + oneRow];
+                    packedRGBA[dst + 3] = matrix[src + oneRow + 1];
+                    dst += 4;
+                }
+                dst += dstStride;
             }
-            dst += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = columns - 1;
-        var dst = (textureWidth - 1) * 4;
-        var srcStride = 2 * columns;
-        var dstStride = textureWidth * 4;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            packedRGBA[dst] = matrix[src];
-            packedRGBA[dst + 2] = matrix[src + columns];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + columns - 1;
+            var dst = batchOffset + (texelsPerRow - 1) * 4;
+            var srcStride = 2 * columns;
+            var dstStride = texelsPerRow * 4;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                packedRGBA[dst] = matrix[src];
+                packedRGBA[dst + 2] = matrix[src + columns];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (rows - 1) * columns;
-        var dst = (textureHeight - 1) * textureWidth * 4;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            packedRGBA[dst++] = matrix[src++];
-            packedRGBA[dst++] = matrix[src++];
-            dst += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (rows - 1) * columns;
+            var dst = batchOffset + (texelsPerBatch - texelsPerRow) * 4;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                packedRGBA[dst++] = matrix[src++];
+                packedRGBA[dst++] = matrix[src++];
+                dst += 2;
+            }
+            if (oddWidth && oddHeight) {
+                packedRGBA[batchOffset + flattenedMatrixSize - 4] = matrix[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        packedRGBA[packedRGBA.length - 4] = matrix[matrix.length - 1];
     }
     return packedRGBA;
 }
 exports.encodeMatrixToPackedRGBA = encodeMatrixToPackedRGBA;
-function decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix) {
+function decodeMatrixFromPackedRGBA(packedRGBA, batches, rows, columns, matrix) {
     var requiredSize = rows * columns;
-    if (requiredSize < matrix.length) {
+    if (matrix.length < requiredSize) {
         throw new Error("matrix length (" + matrix.length + ") must be >= " + requiredSize);
     }
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
-    {
-        var srcStride = oddWidth ? 4 : 0;
-        var dstStride = columns + (oddWidth ? 1 : 0);
-        var src = 0;
-        var dstRow1 = 0;
-        var dstRow2 = columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var batchOffset = batch * rows * columns;
+        var sourceOffset = batch * flattenedMatrixSize;
+        {
+            var srcStride = oddWidth ? 4 : 0;
+            var dstStride = columns + (oddWidth ? 1 : 0);
+            var src = sourceOffset;
+            var dstRow1 = batchOffset;
+            var dstRow2 = batchOffset + columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                }
+                src += srcStride;
+                dstRow1 += dstStride;
+                dstRow2 += dstStride;
             }
-            src += srcStride;
-            dstRow1 += dstStride;
-            dstRow2 += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = (textureWidth - 1) * 4;
-        var dst = columns - 1;
-        var srcStride = textureWidth * 4;
-        var dstStride = 2 * columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            matrix[dst] = packedRGBA[src];
-            matrix[dst + columns] = packedRGBA[src + 2];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + (texelsPerRow - 1) * 4;
+            var dst = batchOffset + columns - 1;
+            var srcStride = texelsPerRow * 4;
+            var dstStride = 2 * columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                matrix[dst] = packedRGBA[src];
+                matrix[dst + columns] = packedRGBA[src + 2];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (textureHeight - 1) * textureWidth * 4;
-        var dst = (rows - 1) * columns;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            matrix[dst++] = packedRGBA[src++];
-            matrix[dst++] = packedRGBA[src++];
-            src += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (texelsPerBatch - texelsPerRow) * 4;
+            var dst = batchOffset + (rows - 1) * columns;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                matrix[dst++] = packedRGBA[src++];
+                matrix[dst++] = packedRGBA[src++];
+                src += 2;
+            }
+            if (oddWidth) {
+                matrix[batchOffset + (rows * columns) - 1] = packedRGBA[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        matrix[matrix.length - 1] = packedRGBA[packedRGBA.length - 4];
     }
     return matrix;
 }
 exports.decodeMatrixFromPackedRGBA = decodeMatrixFromPackedRGBA;
 
-},{}],127:[function(require,module,exports){
+},{"../../util":214}],137:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
@@ -18006,9 +19090,9 @@ var TextureManager = (function () {
         this.logEnabled = false;
         this.usedTextures = {};
     }
-    TextureManager.prototype.acquireTexture = function (shapeRC, usage) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(usage);
-        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType);
+    TextureManager.prototype.acquireTexture = function (shapeRC, usage, isPacked) {
+        var physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
+        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18026,24 +19110,34 @@ var TextureManager = (function () {
         this.numUsedTextures++;
         this.log();
         var newTexture;
-        if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT32) {
+        if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32) {
+            newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16) {
+            newTexture =
+                this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32) {
             newTexture =
                 this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT16) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16) {
             newTexture =
                 this.gpgpu.createFloat16MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNSIGNED_BYTE) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE) {
             newTexture =
                 this.gpgpu.createUnsignedBytesMatrixTexture(shapeRC[0], shapeRC[1]);
         }
         this.usedTextures[shapeKey].push(newTexture);
         return newTexture;
     };
-    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType);
-        var shapeKey = getKeyFromTextureShape(shape, physicalTexType);
+    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType, isPacked) {
+        if (this.freeTextures == null) {
+            return;
+        }
+        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+        var shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18095,26 +19189,31 @@ var TextureManager = (function () {
     return TextureManager;
 }());
 exports.TextureManager = TextureManager;
-function getPhysicalFromLogicalTextureType(logicalTexType) {
-    if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
+function getPhysicalFromLogicalTextureType(logicalTexType, isPacked) {
+    if (isPacked) {
+        return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32 :
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    else if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
         logicalTexType === tex_util_1.TextureUsage.PIXELS) {
-        return tex_util_1.PhysicalTextureType.UNSIGNED_BYTE;
+        return tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.UPLOAD) {
-        return tex_util_1.PhysicalTextureType.FLOAT32;
+        return tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.RENDER) {
         return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-            tex_util_1.PhysicalTextureType.FLOAT32 :
-            tex_util_1.PhysicalTextureType.FLOAT16;
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32 :
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16;
     }
     throw new Error("Unknown logical texture type " + logicalTexType);
 }
-function getKeyFromTextureShape(shapeRowsCol, physicalTexType) {
-    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType;
+function getKeyFromTextureShape(shapeRowsCol, physicalTexType, isPacked) {
+    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType + "_" + isPacked;
 }
 
-},{"../../environment":64,"./tex_util":126}],128:[function(require,module,exports){
+},{"../../environment":64,"./tex_util":136}],138:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18150,7 +19249,7 @@ function getSourceCoords(aShape) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],129:[function(require,module,exports){
+},{"./shader_compiler":133}],139:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18183,7 +19282,7 @@ function getSwitchedCoords(newDim) {
     return switchedCoords.join();
 }
 
-},{"./shader_compiler":123}],130:[function(require,module,exports){
+},{"./shader_compiler":133}],140:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var erf_util = require("../../ops/erf_util");
@@ -18250,12 +19349,33 @@ exports.RECIPROCAL = "return 1.0 / x;";
 exports.LOGICAL_NOT = "return float(!(x >= 1.0));";
 exports.TO_INT = "return float(int(x));";
 
-},{"../../ops/erf_util":146,"../../ops/selu_util":166}],131:[function(require,module,exports){
+},{"../../ops/erf_util":159,"../../ops/selu_util":183}],141:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var MAX_TEXTURE_SIZE = null;
-var util = require("../../util");
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var UnpackProgram = (function () {
+    function UnpackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var sourceCoords = packing_util_1.getSourceCoords(rank, channels);
+        var innerDims = packing_util_1.getInnerDims(rank, channels);
+        var coords = rank === 1 ? 'rc' : innerDims.join(',');
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n        vec2 modCoord = mod(vec2(" + coords + "), 2.);\n        vec4 packedInput = getA(" + sourceCoords + ");\n\n        setOutput(\n          modCoord.x == 0. ?\n            (modCoord.y == 0. ? packedInput.r : packedInput.g) :\n            (modCoord.y == 0. ? packedInput.b : packedInput.a)\n        );\n      }\n    ";
+    }
+    return UnpackProgram;
+}());
+exports.UnpackProgram = UnpackProgram;
+
+},{"../packing_util":86,"./shader_compiler":133}],142:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 function createWebGLRenderingContext(attributes) {
     var canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -18406,15 +19526,6 @@ function createStaticIndexBuffer(gl, data) {
     return buffer;
 }
 exports.createStaticIndexBuffer = createStaticIndexBuffer;
-function queryMaxTextureSize(gl) {
-    if (MAX_TEXTURE_SIZE != null) {
-        return MAX_TEXTURE_SIZE;
-    }
-    MAX_TEXTURE_SIZE =
-        callAndCheck(gl, function () { return gl.getParameter(gl.MAX_TEXTURE_SIZE); });
-    return MAX_TEXTURE_SIZE;
-}
-exports.queryMaxTextureSize = queryMaxTextureSize;
 function getNumChannels() {
     if (environment_1.ENV.get('WEBGL_VERSION') === 2) {
         return 1;
@@ -18426,8 +19537,8 @@ function createTexture(gl) {
     return throwIfNull(gl, function () { return gl.createTexture(); }, 'Unable to create WebGLTexture.');
 }
 exports.createTexture = createTexture;
-function validateTextureSize(gl, width, height) {
-    var maxTextureSize = queryMaxTextureSize(gl);
+function validateTextureSize(width, height) {
+    var maxTextureSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
     if ((width <= 0) || (height <= 0)) {
         var requested = "[" + width + "x" + height + "]";
         throw new Error('Requested texture size ' + requested + ' is invalid.');
@@ -18533,12 +19644,19 @@ function validateTextureUnit(gl, textureUnit) {
         throw new Error("textureUnit must be in " + textureUnitRange + ".");
     }
 }
-function getTextureShapeFromLogicalShape(gl, logShape) {
+function getTextureShapeFromLogicalShape(logShape, isPacked) {
+    if (isPacked === void 0) { isPacked = false; }
+    var maxTexSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    if (isPacked) {
+        maxTexSize = maxTexSize * 2;
+        logShape = logShape.map(function (d, i) { return i >= logShape.length - 2 ?
+            util.nearestLargerEven(logShape[i]) :
+            logShape[i]; });
+    }
     if (logShape.length !== 2) {
         var squeezeResult = util.squeezeShape(logShape);
         logShape = squeezeResult.newShape;
     }
-    var maxTexSize = queryMaxTextureSize(gl);
     var size = util.sizeFromShape(logShape);
     if (logShape.length <= 1 && size <= maxTexSize) {
         return [size, 1];
@@ -18547,9 +19665,18 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
         logShape[1] <= maxTexSize) {
         return logShape;
     }
+    else if (logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+        logShape[2] <= maxTexSize) {
+        return [logShape[0] * logShape[1], logShape[2]];
+    }
     else if (logShape.length === 3 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] <= maxTexSize) {
         return [logShape[0], logShape[1] * logShape[2]];
+    }
+    else if (logShape.length === 4 &&
+        logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+        logShape[3] <= maxTexSize) {
+        return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
     }
     else if (logShape.length === 4 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
@@ -18561,7 +19688,7 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
 }
 exports.getTextureShapeFromLogicalShape = getTextureShapeFromLogicalShape;
 
-},{"../../environment":64,"../../util":194}],132:[function(require,module,exports){
+},{"../../environment":64,"../../util":214}],143:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var array_ops_1 = require("../ops/array_ops");
@@ -18583,7 +19710,7 @@ function whereImpl(condShape, condVals) {
 }
 exports.whereImpl = whereImpl;
 
-},{"../ops/array_ops":134}],133:[function(require,module,exports){
+},{"../ops/array_ops":146}],144:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -18608,7 +19735,13 @@ function log() {
 }
 exports.log = log;
 
-},{"./environment":64}],134:[function(require,module,exports){
+},{"./environment":64}],145:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var confusion_matrix_1 = require("./ops/confusion_matrix");
+exports.confusionMatrix = confusion_matrix_1.confusionMatrix;
+
+},{"./ops/confusion_matrix":156}],146:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -19007,9 +20140,10 @@ function stack_(tensors, axis) {
 function batchToSpaceND_(x, blockShape, crops) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'batchToSpaceND');
     var prod = blockShape.reduce(function (a, b) { return a * b; });
-    util.assert($x.rank >= 1 + blockShape.length, "input rank should be > than [blockShape] but got " + $x.rank);
-    util.assert(crops.length === blockShape.length, "crops.shape[0] must be equal to [blockShape] but got " + crops.length);
-    util.assert($x.shape[0] % prod === 0, "input tensor batch must be divisible by prod( blockShape )");
+    util.assert($x.rank >= 1 + blockShape.length, "input rank is " + $x.rank + " but should be > than blockShape.length " + blockShape.length);
+    util.assert(crops.length === blockShape.length, "crops.length is " + crops.length + " but should be equal to blockShape.length  " + blockShape.length);
+    util.assert($x.shape[0] % prod === 0, "input tensor batch is " + $x.shape[0] + " but is not divisible by the product of " +
+        ("the elements of blockShape " + blockShape.join(' * ') + " === " + prod));
     var grad = function (dy) {
         return { $x: function () { return dy.spaceToBatchND(blockShape, crops); } };
     };
@@ -19136,7 +20270,7 @@ exports.tile = operation_1.op({ tile_: tile_ });
 exports.truncatedNormal = operation_1.op({ truncatedNormal_: truncatedNormal_ });
 exports.unstack = operation_1.op({ unstack_: unstack_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_split":142,"./operation":156,"./rand":159,"./tensor_ops":171}],135:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_split":154,"./operation":171,"./rand":174,"./tensor_ops":191}],147:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getReshaped(inputShape, blockShape, prod, batchToSpace) {
@@ -19234,7 +20368,7 @@ function getSliceSize(uncroppedShape, crops, blockShape) {
 }
 exports.getSliceSize = getSliceSize;
 
-},{}],136:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -19324,7 +20458,7 @@ function getInnerMostAxes(numAxes, rank) {
 }
 exports.getInnerMostAxes = getInnerMostAxes;
 
-},{"../util":194}],137:[function(require,module,exports){
+},{"../util":214}],149:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19544,7 +20678,7 @@ exports.batchNormalization3d = operation_1.op({ batchNormalization3d_: batchNorm
 exports.batchNormalization4d = operation_1.op({ batchNormalization4d_: batchNormalization4d_ });
 exports.batchNormalization = operation_1.op({ batchNormalization_: batchNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],138:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],150:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19910,7 +21044,7 @@ exports.squaredDifferenceStrict = operation_1.op({ squaredDifferenceStrict_: squ
 exports.sub = operation_1.op({ sub_: sub_ });
 exports.subStrict = operation_1.op({ subStrict_: subStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../types":193,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],139:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../types":213,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],151:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getBroadcastDims(inShape, outShape) {
@@ -19980,7 +21114,7 @@ function assertAndGetBroadcastShape(shapeA, shapeB) {
 }
 exports.assertAndGetBroadcastShape = assertAndGetBroadcastShape;
 
-},{}],140:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20084,7 +21218,7 @@ exports.lessStrict = operation_1.op({ lessStrict_: lessStrict_ });
 exports.notEqual = operation_1.op({ notEqual_: notEqual_ });
 exports.notEqualStrict = operation_1.op({ notEqualStrict_: notEqualStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],141:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],153:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20110,7 +21244,7 @@ exports.complex = operation_1.op({ complex_: complex_ });
 exports.real = operation_1.op({ real_: real_ });
 exports.imag = operation_1.op({ imag_: imag_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],142:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],154:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20136,6 +21270,7 @@ function concat_(tensors, axis) {
     if (axis === void 0) { axis = 0; }
     util_1.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     var $tensors = tensor_util_env_1.convertToTensorArray(tensors, 'tensors', 'concat');
+    axis = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var outShape = concat_util_1.computeOutShape($tensors.map(function (t) { return t.shape; }), axis);
     if (util_1.sizeFromShape(outShape) === 0) {
         return tensor_ops_1.tensor([], outShape);
@@ -20144,16 +21279,15 @@ function concat_(tensors, axis) {
     if ($tensors.length === 1) {
         return $tensors[0];
     }
-    var axes = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var shapes = $tensors.map(function (t) { return t.shape; });
-    concat_util_1.assertParamsConsistent(shapes, axes);
+    concat_util_1.assertParamsConsistent(shapes, axis);
     var der = function (dy) {
         var sizeSplits = shapes.map(function (s) { return s[axis]; });
         var derTensors = exports.split(dy, sizeSplits, axis);
         return derTensors.map(function (t) { return function () { return t; }; });
     };
     var inputs = $tensors;
-    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axes); }, inputs, der);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axis); }, inputs, der);
 }
 function split_(x, numOrSizeSplits, axis) {
     if (axis === void 0) { axis = 0; }
@@ -20178,7 +21312,7 @@ exports.concat3d = operation_1.op({ concat3d_: concat3d_ });
 exports.concat4d = operation_1.op({ concat4d_: concat4d_ });
 exports.split = operation_1.op({ split_: split_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_util":143,"./operation":156,"./tensor_ops":171}],143:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_util":155,"./operation":171,"./tensor_ops":191}],155:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -20208,13 +21342,40 @@ function computeOutShape(shapes, axis) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194}],144:[function(require,module,exports){
+},{"../util":214}],156:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tensor_util_env_1 = require("../tensor_util_env");
+var util = require("../util");
+var array_ops_1 = require("./array_ops");
+var operation_1 = require("./operation");
+function confusionMatrix_(labels, predictions, numClasses) {
+    var $labels = tensor_util_env_1.convertToTensor(labels, 'label', 'confusionMatrix', 'int32');
+    var $predictions = tensor_util_env_1.convertToTensor(predictions, 'label', 'confusionMatrix', 'int32');
+    util.assert(numClasses == null || numClasses > 0 && Number.isInteger(numClasses), "If provided, numClasses must be a positive integer, " +
+        ("but got " + numClasses));
+    util.assert($labels.rank === 1, "Expected the rank of labels to be 1, but got " + $labels.rank);
+    util.assert($predictions.rank === 1, "Expected the rank of predictions to be 1, " +
+        ("but got " + $predictions.rank));
+    util.assert($labels.shape[0] === $predictions.shape[0], "Mismatch in the number of examples: " +
+        ($labels.shape[0] + " vs. " + $predictions.shape[0] + ". ") +
+        "Labels and predictions should have the same number of elements.");
+    util.assert(numClasses > 0 && Number.isInteger(numClasses), "numClasses is required to be a positive integer, but got " + numClasses);
+    var oneHotLabels = array_ops_1.oneHot($labels, numClasses);
+    var oneHotPredictions = array_ops_1.oneHot($predictions, numClasses);
+    return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+exports.confusionMatrix_ = confusionMatrix_;
+exports.confusionMatrix = operation_1.op({ confusionMatrix_: confusionMatrix_ });
+
+},{"../tensor_util_env":210,"../util":214,"./array_ops":146,"./operation":171}],157:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
+var matmul_1 = require("./matmul");
 var operation_1 = require("./operation");
 function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) {
     if (dataFormat === void 0) { dataFormat = 'NWC'; }
@@ -20236,7 +21397,7 @@ function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) 
     }
     util.assert(x3D.shape[2] === $filter.shape[1], "Error in conv1d: depth of input (" + x3D.shape[2] + ") must match " +
         ("input depth for filter " + $filter.shape[1] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
         ("Got stride " + stride + " and dilation '" + dilation + "'"));
     util.assert(dataFormat === 'NWC', "Error in conv1d: got dataFormat of " + dataFormat + " but only NWC is currently supported.");
     var filter4D = $filter.as4D(1, $filter.shape[0], $filter.shape[1], $filter.shape[2]);
@@ -20270,19 +21431,30 @@ function conv2d_(x, filter, strides, pad, dataFormat, dilations, dimRoundingMode
     }
     util.assert(x4D.shape[3] === $filter.shape[2], "Error in conv2d: depth of input (" + x4D.shape[3] + ") must match " +
         ("input depth for filter " + $filter.shape[2] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert(dataFormat === 'NHWC', "Error in conv2d: got dataFormat of " + dataFormat + " but only NHWC is currently supported.");
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
-    var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
-            ("yet supported in gradients. Got dilations '" + dilations + "'"));
-        return {
-            x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
-            $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+    var res;
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' || convInfo.padInfo.type === 'VALID')) {
+        var x2d = x4D.reshape([-1, convInfo.inChannels]);
+        var w2d = $filter.reshape([convInfo.inChannels, convInfo.outChannels]);
+        res = matmul_1.matMul(x2d, w2d).reshape(convInfo.outShape);
+    }
+    else {
+        var grad = function (dy) {
+            util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+                ("yet supported in gradients. Got dilations '" + dilations + "'"));
+            return {
+                x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
+                $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+            };
         };
-    };
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+        res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+    }
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20316,8 +21488,15 @@ function conv2dDerInput_(xShape, dy, filter, strides, pad, dimRoundingMode) {
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
     var dilations = 1;
+    var grad = function (ddx) {
+        var dataFormat = 'NHWC';
+        return {
+            dy4D: function () { return exports.conv2d(ddx, filter, strides, pad, dataFormat, dilations, dimRoundingMode); },
+            filter: function () { return exports.conv2dDerFilter(ddx, dy4D, filter.shape, strides, pad, dimRoundingMode); }
+        };
+    };
     var convInfo = conv_util.computeConv2DInfo(xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D });
+    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D, filter: filter }, grad);
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20376,7 +21555,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     if (dilations == null) {
         dilations = [1, 1];
     }
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in depthwiseConv2d: pad must be an integer when using, " +
@@ -20384,7 +21563,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     }
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode, true);
     var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+        util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
             ("1 are not yet supported. Got dilations '" + dilations + "'"));
         return {
             x: function () { return depthwiseConv2dDerInput(x4D.shape, dy, $filter, convInfo); },
@@ -20436,16 +21615,6 @@ function separableConv2d_(x, depthwiseFilter, pointwiseFilter, strides, pad, dil
     }
     return res;
 }
-function parseTupleParam(param) {
-    return typeof param === 'number' ? [param, param] : param;
-}
-function tupleValuesAreOne(param) {
-    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
-    return dimA === 1 && dimB === 1;
-}
-function eitherStridesOrDilationsAreOne(strides, dilations) {
-    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
-}
 function depthwiseConv2dDerInput(xShape, dy, filter, convInfo) {
     var dy4D = dy;
     var reshapedTo4D = false;
@@ -20472,15 +21641,16 @@ function depthwiseConv2dDerFilter(x, dy, filterShape, convInfo) {
 }
 exports.conv1d = operation_1.op({ conv1d_: conv1d_ });
 exports.conv2d = operation_1.op({ conv2d_: conv2d_ });
+exports.conv2dDerFilter = operation_1.op({ conv2dDerFilter_: conv2dDerFilter_ });
 exports.depthwiseConv2d = operation_1.op({ depthwiseConv2d_: depthwiseConv2d_ });
 exports.separableConv2d = operation_1.op({ separableConv2d_: separableConv2d_ });
 exports.conv2dTranspose = operation_1.op({ conv2dTranspose_: conv2dTranspose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],145:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./matmul":168,"./operation":171}],158:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
-function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, dataFormat) {
+function computePool2DInfo(inShape, filterSize, strides, dilations, pad, roundingMode, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var _a = parseTupleParam(filterSize), filterHeight = _a[0], filterWidth = _a[1];
     var filterShape;
@@ -20493,7 +21663,6 @@ function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, data
     else {
         throw new Error("Unknown dataFormat " + dataFormat);
     }
-    var dilations = 1;
     return computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundingMode, false, dataFormat);
 }
 exports.computePool2DInfo = computePool2DInfo;
@@ -20538,6 +21707,8 @@ function computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundi
         strideWidth: strideWidth,
         filterHeight: filterHeight,
         filterWidth: filterWidth,
+        effectiveFilterHeight: effectiveFilterHeight,
+        effectiveFilterWidth: effectiveFilterWidth,
         dilationHeight: dilationHeight,
         dilationWidth: dilationWidth,
         inShape: inShape,
@@ -20622,8 +21793,17 @@ function conditionalRound(value, roundingMode) {
             throw new Error("Unknown roundingMode " + roundingMode);
     }
 }
+function tupleValuesAreOne(param) {
+    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
+    return dimA === 1 && dimB === 1;
+}
+exports.tupleValuesAreOne = tupleValuesAreOne;
+function eitherStridesOrDilationsAreOne(strides, dilations) {
+    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+exports.eitherStridesOrDilationsAreOne = eitherStridesOrDilationsAreOne;
 
-},{"../util":194}],146:[function(require,module,exports){
+},{"../util":214}],159:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ERF_P = 0.3275911;
@@ -20633,7 +21813,64 @@ exports.ERF_A3 = 1.421413741;
 exports.ERF_A4 = -1.453152027;
 exports.ERF_A5 = 1.061405429;
 
-},{}],147:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function gatherND_(x, indices) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'gatherND', 'int32');
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'gatherND');
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.gatherND($x, $indices); }, { $x: $x, $indices: $indices });
+}
+exports.gatherND = operation_1.op({ gatherND_: gatherND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],161:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function prepareAndValidate(tensor, indices) {
+    if (tensor.rank < 1) {
+        throw new Error('tf.gatherND() expects the input to be rank 1 or higher,' +
+            (" but the rank was " + tensor.rank + "."));
+    }
+    if (indices.rank < 1) {
+        throw new Error('tf.gatherND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error('tf.gatherND() expects the indices to be int32 type,' +
+            (" but the dtype was " + indices.dtype + "."));
+    }
+    if (indices.shape[indices.rank - 1] > tensor.rank) {
+        throw new Error('index innermost dimension length must be <= tensor rank; saw: ' +
+            (indices.shape[indices.rank - 1] + " vs. " + tensor.rank));
+    }
+    if (tensor.size === 0) {
+        throw new Error('Requested more than 0 entries, but input is empty.' +
+            (" Input shape: " + tensor.shape + "."));
+    }
+    var indicesShape = indices.shape;
+    var sliceRank = indicesShape[indicesShape.length - 1];
+    var nResult = 1;
+    for (var i = 0; i < indicesShape.length - 1; ++i) {
+        nResult *= indicesShape[i];
+    }
+    var inputShape = tensor.shape;
+    var resultShape = indicesShape.slice();
+    resultShape.pop();
+    var sliceSize = 1;
+    for (var i = sliceRank; i < tensor.rank; ++i) {
+        sliceSize *= inputShape[i];
+        resultShape.push(inputShape[i]);
+    }
+    var strides = util_1.computeStrides(tensor.shape).map(function (stride) { return stride / sliceSize; }).concat([1]).slice(0, sliceRank);
+    return [resultShape, nResult, sliceSize, strides];
+}
+exports.prepareAndValidate = prepareAndValidate;
+
+},{"../util":214}],162:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -20828,7 +22065,7 @@ exports.nonMaxSuppression = operation_1.op({ nonMaxSuppression_: nonMaxSuppressi
 exports.nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
 exports.cropAndResize = cropAndResize_;
 
-},{"../environment":64,"../kernels/non_max_suppression_impl":84,"../tensor_util_env":190,"../util":194,"./operation":156}],148:[function(require,module,exports){
+},{"../environment":64,"../kernels/non_max_suppression_impl":85,"../tensor_util_env":210,"../util":214,"./operation":171}],163:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20974,7 +22211,7 @@ function qr2d(x, fullMatrices) {
 exports.gramSchmidt = operation_1.op({ gramSchmidt_: gramSchmidt_ });
 exports.qr = operation_1.op({ qr_: qr_ });
 
-},{"../environment":64,"../globals":66,"../util":194,"./array_ops":134,"./concat_split":142,"./norm":155,"./operation":156,"./reduction_ops":161,"./tensor_ops":171}],149:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../util":214,"./array_ops":146,"./concat_split":154,"./norm":170,"./operation":171,"./reduction_ops":176,"./tensor_ops":191}],164:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21091,7 +22328,7 @@ exports.logicalXor = operation_1.op({ logicalXor_: logicalXor_ });
 exports.where = operation_1.op({ where_: where_ });
 exports.whereAsync = whereAsync_;
 
-},{"../environment":64,"../kernels/where_impl":132,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],150:[function(require,module,exports){
+},{"../environment":64,"../kernels/where_impl":143,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],165:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var globals_1 = require("../globals");
@@ -21316,7 +22553,7 @@ exports.meanSquaredError = operation_1.op({ meanSquaredError_: meanSquaredError_
 exports.sigmoidCrossEntropy = operation_1.op({ sigmoidCrossEntropy_: sigmoidCrossEntropy_ });
 exports.softmaxCrossEntropy = operation_1.op({ softmaxCrossEntropy_: softmaxCrossEntropy_ });
 
-},{"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],151:[function(require,module,exports){
+},{"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],166:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21353,7 +22590,7 @@ function localResponseNormalization_(x, depthRadius, bias, alpha, beta) {
 }
 exports.localResponseNormalization = operation_1.op({ localResponseNormalization_: localResponseNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],152:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],167:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21402,7 +22639,7 @@ function basicLSTMCell_(forgetBias, lstmKernel, lstmBias, data, c, h) {
 exports.basicLSTMCell = operation_1.op({ basicLSTMCell_: basicLSTMCell_ });
 exports.multiRNNCell = operation_1.op({ multiRNNCell_: multiRNNCell_ });
 
-},{"../tensor_util_env":190,"./operation":156}],153:[function(require,module,exports){
+},{"../tensor_util_env":210,"./operation":171}],168:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21498,7 +22735,7 @@ exports.matMul = operation_1.op({ matMul_: matMul_ });
 exports.dot = operation_1.op({ dot_: dot_ });
 exports.outerProduct = operation_1.op({ outerProduct_: outerProduct_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],154:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],169:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_1 = require("../tensor_util");
@@ -21526,7 +22763,7 @@ function movingAverage_(v, x, decay, step, zeroDebias) {
 }
 exports.movingAverage = operation_1.op({ movingAverage_: movingAverage_ });
 
-},{"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],155:[function(require,module,exports){
+},{"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],170:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21589,7 +22826,7 @@ function normImpl(x, p, axis) {
 }
 exports.norm = operation_1.op({ norm_: norm_ });
 
-},{"../tensor_util_env":190,"./axis_util":136,"./operation":156,"./tensor_ops":171}],156:[function(require,module,exports){
+},{"../tensor_util_env":210,"./axis_util":148,"./operation":171,"./tensor_ops":191}],171:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21629,7 +22866,7 @@ function op(f) {
 }
 exports.op = op;
 
-},{"../environment":64}],157:[function(require,module,exports){
+},{"../environment":64}],172:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -21660,6 +22897,10 @@ __export(require("./lstm"));
 __export(require("./moving_average"));
 __export(require("./strided_slice"));
 __export(require("./topk"));
+__export(require("./scatter_nd"));
+__export(require("./spectral_ops"));
+__export(require("./sparse_to_dense"));
+__export(require("./gather_nd"));
 var operation_1 = require("./operation");
 exports.op = operation_1.op;
 var losses = require("./loss_ops");
@@ -21668,8 +22909,10 @@ var linalg = require("./linalg_ops");
 exports.linalg = linalg;
 var image = require("./image_ops");
 exports.image = image;
+var spectral = require("./spectral_ops");
+exports.spectral = spectral;
 
-},{"./array_ops":134,"./batchnorm":137,"./binary_ops":138,"./compare":140,"./complex_ops":141,"./concat_split":142,"./conv":144,"./image_ops":147,"./linalg_ops":148,"./logical_ops":149,"./loss_ops":150,"./lrn":151,"./lstm":152,"./matmul":153,"./moving_average":154,"./norm":155,"./operation":156,"./pool":158,"./reduction_ops":161,"./relu_ops":162,"./reverse":163,"./segment_ops":164,"./slice":167,"./softmax":169,"./strided_slice":170,"./tensor_ops":171,"./topk":172,"./transpose":173,"./unary_ops":174}],158:[function(require,module,exports){
+},{"./array_ops":146,"./batchnorm":149,"./binary_ops":150,"./compare":152,"./complex_ops":153,"./concat_split":154,"./conv":157,"./gather_nd":160,"./image_ops":162,"./linalg_ops":163,"./logical_ops":164,"./loss_ops":165,"./lrn":166,"./lstm":167,"./matmul":168,"./moving_average":169,"./norm":170,"./operation":171,"./pool":173,"./reduction_ops":176,"./relu_ops":177,"./reverse":178,"./scatter_nd":179,"./segment_ops":181,"./slice":184,"./softmax":186,"./sparse_to_dense":187,"./spectral_ops":189,"./strided_slice":190,"./tensor_ops":191,"./topk":192,"./transpose":193,"./unary_ops":194}],173:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21677,7 +22920,7 @@ var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
 var operation_1 = require("./operation");
-function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'maxPool');
     var x4D = $x;
     var reshapedTo4D = false;
@@ -21685,18 +22928,21 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
         reshapedTo4D = true;
         x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
     }
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
     util.assert(x4D.rank === 4, "Error in maxPool: input must be rank 4 but got rank " + x4D.rank + ".");
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in maxPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var grad = function (dy, saved) {
         var y4D = saved[0];
         return {
-            x: function () {
-                return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, pad);
-            }
+            x: function () { return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, dilations, pad); }
         };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.maxPool(x4D, convInfo)); }, { x: x4D }, grad);
@@ -21705,9 +22951,17 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return maxPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function avgPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'avgPool');
     util.assert($x.dtype === 'float32', 'The input dtype to avgPool must be float32');
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var x4D = $x;
     var reshapedTo4D = false;
     if ($x.rank === 3) {
@@ -21719,9 +22973,11 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
         util.assert(util.isInt(pad), "Error in avgPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad);
     var grad = function (dy) {
-        return { x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, pad); } };
+        return {
+            x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, dilations, pad); }
+        };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPool(x4D, convInfo); }, { x: x4D }, grad);
     res = res.cast($x.dtype);
@@ -21730,11 +22986,33 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundingMode) {
+function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return avgPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function pool_(input, windowShape, poolingType, padding, dilationRate, strides) {
+    if (dilationRate == null) {
+        dilationRate = 1;
+    }
+    if (strides == null) {
+        strides = 1;
+    }
+    if (poolingType === 'avg') {
+        return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+    else {
+        return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+}
+function maxPoolBackprop(dy, input, output, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'maxPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'maxPoolBackprop');
     var $output = tensor_util_env_1.convertToTensor(output, 'output', 'maxPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPoolBackProp: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert($dy.rank === 4, "Error in maxPoolBackprop: dy must be rank 4 but got rank " +
         ($dy.rank + "."));
     util.assert($input.rank === 4, "Error in maxPoolBackprop: input must be rank 4 but got rank " +
@@ -21743,14 +23021,19 @@ function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundin
         util.assert(util.isInt(pad), "Error in maxPoolBackprop: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.maxPoolBackprop($dy, $input, $output, convInfo); }, { $dy: $dy, $input: $input });
     return res;
 }
-function avgPoolBackprop(dy, input, filterSize, strides, pad) {
+function avgPoolBackprop(dy, input, filterSize, strides, dilations, pad) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'avgPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'avgPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPoolBackprop: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var input4D = $input;
     var dy4D = $dy;
     var reshapedTo4D = false;
@@ -21763,7 +23046,7 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
         (dy4D.rank + "."));
     util.assert(input4D.rank === 4, "Error in avgPoolBackprop: input must be rank 4 but got rank " +
         (input4D.rank + "."));
-    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, dilations, pad);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPoolBackprop(dy4D, input4D, convInfo); }, { dy4D: dy4D, input4D: input4D });
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
@@ -21772,8 +23055,9 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
 }
 exports.maxPool = operation_1.op({ maxPool_: maxPool_ });
 exports.avgPool = operation_1.op({ avgPool_: avgPool_ });
+exports.pool = operation_1.op({ pool_: pool_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],159:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./operation":171}],174:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var seedrandom = require("seedrandom");
@@ -21831,7 +23115,7 @@ var MPRandGauss = (function () {
 }());
 exports.MPRandGauss = MPRandGauss;
 
-},{"seedrandom":281}],160:[function(require,module,exports){
+},{"seedrandom":305}],175:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -21844,7 +23128,7 @@ function computeOptimalWindowSize(inSize) {
 }
 exports.computeOptimalWindowSize = computeOptimalWindowSize;
 
-},{"../util":194}],161:[function(require,module,exports){
+},{"../util":214}],176:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21905,6 +23189,28 @@ function sum_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function prod_(x, axis, keepDims) {
+    if (axis === void 0) { axis = null; }
+    if (keepDims === void 0) { keepDims = false; }
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'prod');
+    if ($x.dtype === 'bool') {
+        $x = $x.toInt();
+    }
+    var axes = axis_util.parseAxisParam(axis, $x.shape);
+    var permutation = axis_util.getAxesPermutation(axes, $x.rank);
+    var reductionAxes = axes;
+    var permutedX = $x;
+    if (permutation != null) {
+        permutedX = $x.transpose(permutation);
+        reductionAxes = axis_util.getInnerMostAxes(reductionAxes.length, $x.rank);
+    }
+    var value = environment_1.ENV.engine.runKernel(function (backend) { return backend.prod(permutedX, reductionAxes); }, { permutedX: permutedX });
+    if (keepDims) {
+        var newShape = axis_util.expandShapeToKeepDim(value.shape, axes);
+        value = value.reshape(newShape);
+    }
+    return value;
+}
 function mean_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
@@ -21931,10 +23237,26 @@ function mean_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes) {
+    var y = saved[0];
+    if (y.rank < xOrig.rank) {
+        y = y.reshape(axis_util.expandShapeToKeepDim(y.shape, origAxes));
+    }
+    if (dy.rank < xOrig.rank) {
+        dy = dy.reshape(axis_util.expandShapeToKeepDim(dy.shape, origAxes));
+    }
+    return {
+        $x: function () {
+            var dx = dy.mul(xOrig.equal(y).cast(dy.dtype));
+            return permutedAxes == null ? dx : dx.transpose(permutedAxes);
+        }
+    };
+}
 function min_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'min');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -21942,10 +23264,13 @@ function min_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.min($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.min($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -21953,6 +23278,7 @@ function max_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'max');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -21960,10 +23286,13 @@ function max_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.max($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.max($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22063,8 +23392,9 @@ exports.mean = operation_1.op({ mean_: mean_ });
 exports.min = operation_1.op({ min_: min_ });
 exports.moments = operation_1.op({ moments_: moments_ });
 exports.sum = operation_1.op({ sum_: sum_ });
+exports.prod = operation_1.op({ prod_: prod_ });
 
-},{"../environment":64,"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156,"./tensor_ops":171}],162:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171,"./tensor_ops":191}],177:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22130,7 +23460,7 @@ exports.prelu = operation_1.op({ prelu_: prelu_ });
 exports.relu = operation_1.op({ relu_: relu_ });
 exports.selu = operation_1.op({ selu_: selu_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./binary_ops":138,"./logical_ops":149,"./operation":156,"./selu_util":166,"./tensor_ops":171}],163:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./binary_ops":150,"./logical_ops":164,"./operation":171,"./selu_util":183,"./tensor_ops":191}],178:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22176,7 +23506,99 @@ exports.reverse2d = operation_1.op({ reverse2d_: reverse2d_ });
 exports.reverse3d = operation_1.op({ reverse3d_: reverse3d_ });
 exports.reverse4d = operation_1.op({ reverse4d_: reverse4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],164:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],179:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+var scatter_nd_util = require("./scatter_nd_util");
+function scatterND_(indices, updates, shape) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'scatterND', 'int32');
+    var $updates = tensor_util_env_1.convertToTensor(updates, 'updates', 'scatterND');
+    scatter_nd_util.validateInput($updates, $indices, shape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.scatterND($indices, $updates, shape); }, { $indices: $indices, $updates: $updates });
+}
+exports.scatterND = operation_1.op({ scatterND_: scatterND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171,"./scatter_nd_util":180}],180:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function validateUpdateShape(shape, indices, updates) {
+    var sliceDim = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var batchDim = (indices.rank > 1) ? indices.rank - 1 : 1;
+    var shapeError = 'Must have updates.shape = indices.shape[:batchDim] + ' +
+        ("shape[sliceDim:], got updates.shape: " + updates.shape) +
+        (", indices.shape: " + indices.shape + ", shape: " + shape) +
+        (", sliceDim: " + sliceDim + ", and batchDim: " + batchDim + ".");
+    if (updates.rank < batchDim) {
+        throw new Error(shapeError + (" update.rank < " + batchDim + ". "));
+    }
+    if (shape.length < sliceDim + (updates.rank - batchDim)) {
+        throw new Error(shapeError +
+            (" Output shape length < " + (sliceDim + (updates.rank - batchDim))));
+    }
+    if (updates.rank !== batchDim + shape.length - sliceDim) {
+        throw new Error(shapeError + (" update.rank != " + (batchDim + shape.length - sliceDim)));
+    }
+    for (var d = 0; d < batchDim; ++d) {
+        if (updates.shape[d] !== indices.shape[d]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + d + "] (" + updates.shape[d] + ") != indices.shape[" + d + "] (" + indices.shape[d] + ")."));
+        }
+    }
+    for (var d = 0; d < updates.rank - batchDim; ++d) {
+        if (updates.shape[d + batchDim] !== shape[d + sliceDim]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + (d + batchDim) + "] (" + updates.shape[d + batchDim] + ") != shape[" + (d + batchDim) + "] (" + shape[d + batchDim] + ")"));
+        }
+    }
+}
+exports.validateUpdateShape = validateUpdateShape;
+function validateInput(updates, indices, shape) {
+    if (indices.rank < 1) {
+        throw new Error('tf.scatterND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (updates.rank < 1) {
+        throw new Error('tf.scatterND() expects the updates to be rank 1 or higher,' +
+            (" but the rank was " + updates.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error("The dtype of 'indices' should be int32, but got dtype: " + indices.dtype);
+    }
+    if (shape.length < 1) {
+        throw new Error("Output rank must be greater or equal to 1, but got shape: " + shape);
+    }
+    if (shape.length === 0) {
+        if (indices.size === 0) {
+            throw new Error("Indices specified for empty output. indices shape: " + indices.shape);
+        }
+        if (updates.size === 0) {
+            throw new Error("Updates specified for empty output. updates shape: " + updates.shape);
+        }
+    }
+    validateUpdateShape(shape, indices, updates);
+}
+exports.validateInput = validateInput;
+function calculateShapes(updates, indices, shape) {
+    var sliceRank = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var totalNd = shape.length;
+    var sliceSize = 1;
+    for (var i = sliceRank; i < totalNd; ++i) {
+        sliceSize *= shape[i];
+    }
+    var safeSliceDim = (sliceRank < 1) ? 1 : sliceRank;
+    var numUpdates = indices.size / safeSliceDim;
+    var outputStrides = util_1.computeStrides(shape).concat([1]);
+    var strides = outputStrides.slice(outputStrides.length - sliceRank, outputStrides.length);
+    var outputSize = util_1.sizeFromShape(shape);
+    return { sliceRank: sliceRank, numUpdates: numUpdates, sliceSize: sliceSize, strides: strides, outputSize: outputSize };
+}
+exports.calculateShapes = calculateShapes;
+
+},{"../util":214}],181:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22268,7 +23690,7 @@ function gatherDropNegatives(x, indices) {
 exports.gather = operation_1.op({ gather_: gather_ });
 exports.unsortedSegmentSum = operation_1.op({ unsortedSegmentSum_: unsortedSegmentSum_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./axis_util":136,"./binary_ops":138,"./compare":140,"./logical_ops":149,"./operation":156,"./tensor_ops":171}],165:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./axis_util":148,"./binary_ops":150,"./compare":152,"./logical_ops":164,"./operation":171,"./tensor_ops":191}],182:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22310,13 +23732,13 @@ function computeOutShape(aShape, axis, numSegments) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194,"./reduce_util":160}],166:[function(require,module,exports){
+},{"../util":214,"./reduce_util":175}],183:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SELU_SCALEALPHA = 1.7580993408473768599402175208123;
 exports.SELU_SCALE = 1.0507009873554804934193349852946;
 
-},{}],167:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22331,17 +23753,17 @@ function slice1d_(x, begin, size) {
 }
 function slice2d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice2d');
-    util.assert($x.rank === 2, "slice1d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 2, "slice2d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice3d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice3d');
-    util.assert($x.rank === 3, "slice1d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 3, "slice3d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice4d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice4d');
-    util.assert($x.rank === 4, "slice1d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 4, "slice4d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice_(x, begin, size) {
@@ -22398,7 +23820,7 @@ exports.slice2d = operation_1.op({ slice2d_: slice2d_ });
 exports.slice3d = operation_1.op({ slice3d_: slice3d_ });
 exports.slice4d = operation_1.op({ slice4d_: slice4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./slice_util":168}],168:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./slice_util":185}],185:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -22489,7 +23911,7 @@ function stopForAxis(endMask, stopIndices, strides, inputShape, axis) {
 }
 exports.stopForAxis = stopForAxis;
 
-},{"../util":194}],169:[function(require,module,exports){
+},{"../util":214}],186:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gradients_1 = require("../gradients");
@@ -22521,7 +23943,67 @@ function softmax_(logits, dim) {
 }
 exports.softmax = operation_1.op({ softmax_: softmax_ });
 
-},{"../gradients":67,"../tensor_util_env":190,"./operation":156}],170:[function(require,module,exports){
+},{"../gradients":67,"../tensor_util_env":210,"./operation":171}],187:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var sparse_to_dense = require("../ops/sparse_to_dense_util");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function sparseToDense_(sparseIndices, sparseValues, outputShape, defaultValue) {
+    var $sparseIndices = tensor_util_env_1.convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
+    var $sparseValues = tensor_util_env_1.convertToTensor(sparseValues, 'sparseValues', 'sparseToDense');
+    var $defaultValue = tensor_util_env_1.convertToTensor(defaultValue, 'defaultValue', 'sparseToDense');
+    sparse_to_dense.validateInput($sparseIndices, $sparseValues, outputShape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.sparseToDense($sparseIndices, $sparseValues, outputShape, $defaultValue); }, { $sparseIndices: $sparseIndices, $sparseValues: $sparseValues, $defaultValue: $defaultValue });
+}
+exports.sparseToDense = operation_1.op({ sparseToDense_: sparseToDense_ });
+
+},{"../environment":64,"../ops/sparse_to_dense_util":188,"../tensor_util_env":210,"./operation":171}],188:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateInput(sparseIndices, sparseValues, outputShape) {
+    if (sparseIndices.dtype !== 'int32') {
+        throw new Error('tf.sparseToDense() expects the indices to be int32 type,' +
+            (" but the dtype was " + sparseIndices.dtype + "."));
+    }
+    if (sparseIndices.rank > 2) {
+        throw new Error('sparseIndices should be a scalar, vector, or matrix,' +
+            (" but got shape " + sparseIndices.shape + "."));
+    }
+    var numElems = sparseIndices.rank > 0 ? sparseIndices.shape[0] : 1;
+    var numDims = sparseIndices.rank > 1 ? sparseIndices.shape[1] : 1;
+    if (outputShape.length !== numDims) {
+        throw new Error('outputShape has incorrect number of elements:,' +
+            (" " + outputShape.length + ", should be: " + numDims + "."));
+    }
+    var numValues = sparseValues.size;
+    if (!(sparseValues.rank === 0 ||
+        sparseValues.rank === 1 && numValues === numElems)) {
+        throw new Error('sparseValues has incorrect shape ' +
+            (sparseValues.shape + ", should be [] or [" + numElems + "]"));
+    }
+}
+exports.validateInput = validateInput;
+
+},{}],189:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var operation_1 = require("../ops/operation");
+var util_1 = require("../util");
+function fft_(input) {
+    util_1.assert(input.dtype === 'complex64', "The dtype for tf.spectral.fft() must be complex64 " +
+        ("but got " + input.dtype + "."));
+    var innerDimensionSize = input.shape[input.shape.length - 1];
+    var batch = input.size / innerDimensionSize;
+    var input2D = input.as2D(batch, innerDimensionSize);
+    var ret = environment_1.ENV.engine.runKernel(function (backend) { return backend.fft(input2D); }, { input: input });
+    return ret.reshape(input.shape);
+}
+exports.fft = operation_1.op({ fft_: fft_ });
+
+},{"../environment":64,"../ops/operation":171,"../util":214}],190:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22544,12 +24026,13 @@ function stridedSlice_(x, begin, end, strides, beginMask, endMask, ellipsisMask,
 }
 exports.stridedSlice = operation_1.op({ stridedSlice_: stridedSlice_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],171:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],191:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_1 = require("../tensor");
 var tensor_util_env_1 = require("../tensor_util_env");
+var tensor_util_env_2 = require("../tensor_util_env");
 var util_1 = require("../util");
 var complex_ops_1 = require("./complex_ops");
 var operation_1 = require("./operation");
@@ -22564,7 +24047,7 @@ function tensor(values, shape, dtype) {
         throw new Error('values passed to tensor(values) must be an ' +
             'array of numbers or booleans, or a TypedArray');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (shape != null && inferredShape.length !== 1) {
         util_1.assertShapesMatch(shape, inferredShape, "Error creating a new Tensor. " +
             ("Inferred shape (" + inferredShape + ") does not match the ") +
@@ -22591,7 +24074,7 @@ exports.scalar = scalar;
 function tensor1d(values, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     util_1.assertNonNull(values);
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 1) {
         throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
@@ -22604,7 +24087,7 @@ function tensor2d(values, shape, dtype) {
     if (shape != null && shape.length !== 2) {
         throw new Error('tensor2d() requires shape to have two numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
         throw new Error('tensor2d() requires values to be number[][] or flat/TypedArray');
     }
@@ -22622,7 +24105,7 @@ function tensor3d(values, shape, dtype) {
     if (shape != null && shape.length !== 3) {
         throw new Error('tensor3d() requires shape to have three numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
         throw new Error('tensor3d() requires values to be number[][][] or flat/TypedArray');
     }
@@ -22640,7 +24123,7 @@ function tensor4d(values, shape, dtype) {
     if (shape != null && shape.length !== 4) {
         throw new Error('tensor4d() requires shape to have four numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
         throw new Error('tensor4d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22658,7 +24141,7 @@ function tensor5d(values, shape, dtype) {
     if (shape != null && shape.length !== 5) {
         throw new Error('tensor5d() requires shape to have five numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 5 && inferredShape.length !== 1) {
         throw new Error('tensor5d() requires values to be ' +
             'number[][][][][] or flat/TypedArray');
@@ -22677,7 +24160,7 @@ function tensor6d(values, shape, dtype) {
     if (shape != null && shape.length !== 6) {
         throw new Error('tensor6d() requires shape to have six numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 6 && inferredShape.length !== 1) {
         throw new Error('tensor6d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22768,7 +24251,7 @@ exports.range = range;
 exports.onesLike = operation_1.op({ onesLike_: onesLike_ });
 exports.zerosLike = operation_1.op({ zerosLike_: zerosLike_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./complex_ops":141,"./operation":156}],172:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./complex_ops":153,"./operation":171}],192:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22791,7 +24274,7 @@ function topk_(x, k, sorted) {
 }
 exports.topk = operation_1.op({ topk_: topk_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],173:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],193:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22821,7 +24304,7 @@ function transpose_(x, perm) {
 }
 exports.transpose = operation_1.op({ transpose_: transpose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],174:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],194:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23111,7 +24594,7 @@ exports.step = operation_1.op({ step_: step_ });
 exports.tan = operation_1.op({ tan_: tan_ });
 exports.tanh = operation_1.op({ tanh_: tanh_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./tensor_ops":171}],175:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./tensor_ops":191}],195:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23218,7 +24701,7 @@ var AdadeltaOptimizer = (function (_super) {
 exports.AdadeltaOptimizer = AdadeltaOptimizer;
 serialization_1.registerClass(AdadeltaOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],176:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],196:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23300,7 +24783,7 @@ var AdagradOptimizer = (function (_super) {
 exports.AdagradOptimizer = AdagradOptimizer;
 serialization_1.registerClass(AdagradOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],177:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],197:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23419,7 +24902,7 @@ var AdamOptimizer = (function (_super) {
 exports.AdamOptimizer = AdamOptimizer;
 serialization_1.registerClass(AdamOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],178:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],198:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23540,7 +25023,7 @@ var AdamaxOptimizer = (function (_super) {
 exports.AdamaxOptimizer = AdamaxOptimizer;
 serialization_1.registerClass(AdamaxOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],179:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],199:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23630,7 +25113,7 @@ var MomentumOptimizer = (function (_super) {
 exports.MomentumOptimizer = MomentumOptimizer;
 serialization_1.registerClass(MomentumOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./sgd_optimizer":183}],180:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./sgd_optimizer":203}],200:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23671,7 +25154,7 @@ var Optimizer = (function (_super) {
 }(serialization_1.Serializable));
 exports.Optimizer = Optimizer;
 
-},{"../globals":66,"../serialization":185}],181:[function(require,module,exports){
+},{"../globals":66,"../serialization":205}],201:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./adadelta_optimizer");
@@ -23727,7 +25210,7 @@ var OptimizerConstructors = (function () {
 }());
 exports.OptimizerConstructors = OptimizerConstructors;
 
-},{"./adadelta_optimizer":175,"./adagrad_optimizer":176,"./adam_optimizer":177,"./adamax_optimizer":178,"./momentum_optimizer":179,"./rmsprop_optimizer":182,"./sgd_optimizer":183}],182:[function(require,module,exports){
+},{"./adadelta_optimizer":195,"./adagrad_optimizer":196,"./adam_optimizer":197,"./adamax_optimizer":198,"./momentum_optimizer":199,"./rmsprop_optimizer":202,"./sgd_optimizer":203}],202:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23871,7 +25354,7 @@ var RMSPropOptimizer = (function (_super) {
 exports.RMSPropOptimizer = RMSPropOptimizer;
 serialization_1.registerClass(RMSPropOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],183:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],203:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23931,7 +25414,7 @@ var SGDOptimizer = (function (_super) {
 exports.SGDOptimizer = SGDOptimizer;
 serialization_1.registerClass(SGDOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],184:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],204:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("./util");
@@ -23955,7 +25438,11 @@ var Profiler = (function () {
             var vals = r.dataSync();
             util.checkComputationForNaN(vals, r.dtype, name);
             timer.then(function (timing) {
-                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+                var extraInfo = '';
+                if (timing.getExtraProfileInfo != null) {
+                    extraInfo = timing.getExtraProfileInfo();
+                }
+                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
             });
         });
         return result;
@@ -23966,19 +25453,19 @@ exports.Profiler = Profiler;
 var Logger = (function () {
     function Logger() {
     }
-    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs) {
+    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs, extraInfo) {
         var time = util.rightPad(timeMs + "ms", 9);
         var paddedName = util.rightPad(name, 25);
         var rank = result.rank;
         var size = result.size;
         var shape = util.rightPad(result.shape.toString(), 14);
-        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size + "\t%c" + extraInfo, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange', 'color: green');
     };
     return Logger;
 }());
 exports.Logger = Logger;
 
-},{"./util":194}],185:[function(require,module,exports){
+},{"./util":214}],205:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -24023,7 +25510,7 @@ function registerClass(cls) {
 }
 exports.registerClass = registerClass;
 
-},{"./util":194}],186:[function(require,module,exports){
+},{"./util":214}],206:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -24136,7 +25623,7 @@ function backpropagateGradients(tensorAccumulatedGradientMap, filteredTape) {
 }
 exports.backpropagateGradients = backpropagateGradients;
 
-},{"./tensor":187,"./util":194}],187:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],207:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24522,6 +26009,12 @@ var Tensor = (function () {
         if (keepDims === void 0) { keepDims = false; }
         this.throwIfDisposed();
         return opHandler.sum(this, axis, keepDims);
+    };
+    Tensor.prototype.prod = function (axis, keepDims) {
+        if (axis === void 0) { axis = null; }
+        if (keepDims === void 0) { keepDims = false; }
+        this.throwIfDisposed();
+        return opHandler.prod(this, axis, keepDims);
     };
     Tensor.prototype.mean = function (axis, keepDims) {
         if (axis === void 0) { axis = null; }
@@ -24923,6 +26416,10 @@ var Tensor = (function () {
         if (beta === void 0) { beta = 0.5; }
         return opHandler.localResponseNormalization(this, radius, bias, alpha, beta);
     };
+    Tensor.prototype.pool = function (windowShape, poolingType, padding, dilationRate, strides) {
+        this.throwIfDisposed();
+        return opHandler.pool(this, windowShape, poolingType, padding, dilationRate, strides);
+    };
     Tensor.prototype.variable = function (trainable, name, dtype) {
         if (trainable === void 0) { trainable = true; }
         this.throwIfDisposed();
@@ -24955,6 +26452,10 @@ var Tensor = (function () {
     Tensor.prototype.depthToSpace = function (blockSize, dataFormat) {
         this.throwIfDisposed();
         return opHandler.depthToSpace(this, blockSize, dataFormat);
+    };
+    Tensor.prototype.fft = function () {
+        this.throwIfDisposed();
+        return opHandler.spectral.fft(this);
     };
     Tensor.nextId = 0;
     return Tensor;
@@ -25018,7 +26519,7 @@ Object.defineProperty(Variable, Symbol.hasInstance, {
 var variable = Variable.variable;
 exports.variable = variable;
 
-},{"./tensor_format":188,"./util":194}],188:[function(require,module,exports){
+},{"./tensor_format":208,"./util":214}],208:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -25149,7 +26650,7 @@ function createComplexTuples(vals) {
     return complexTuples;
 }
 
-},{"./util":194}],189:[function(require,module,exports){
+},{"./util":214}],209:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -25224,12 +26725,47 @@ function isIterable(obj) {
     return Array.isArray(obj) || typeof obj === 'object';
 }
 
-},{"./tensor":187,"./util":194}],190:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],210:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
 var tensor_1 = require("./tensor");
 var util_1 = require("./util");
+function inferShape(val) {
+    var firstElem = val;
+    if (util_1.isTypedArray(val)) {
+        return [val.length];
+    }
+    if (!Array.isArray(val)) {
+        return [];
+    }
+    var shape = [];
+    while (firstElem instanceof Array) {
+        shape.push(firstElem.length);
+        firstElem = firstElem[0];
+    }
+    if (val instanceof Array && environment_1.ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+        deepAssertShapeConsistency(val, shape, []);
+    }
+    return shape;
+}
+exports.inferShape = inferShape;
+function deepAssertShapeConsistency(val, shape, indices) {
+    indices = indices || [];
+    if (!(val instanceof Array)) {
+        util_1.assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
+            ("but should be an array of " + shape[0] + " elements"); });
+        return;
+    }
+    util_1.assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
+        ("but is an array of " + val.length + " elements"); });
+    util_1.assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
+        ("elements, but has " + val.length + " elements"); });
+    var subShape = shape.slice(1);
+    for (var i = 0; i < val.length; ++i) {
+        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
+    }
+}
 function convertToTensor(x, argName, functionName, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     dtype = dtype || 'float32';
@@ -25241,7 +26777,7 @@ function convertToTensor(x, argName, functionName, dtype) {
         throw new Error("Argument '" + argName + "' passed to '" + functionName + "' must be a " +
             ("Tensor or TensorLike, but got " + x.constructor.name));
     }
-    var inferredShape = util_1.inferShape(x);
+    var inferredShape = inferShape(x);
     if (!util_1.isTypedArray(x) && !Array.isArray(x)) {
         x = [x];
     }
@@ -25258,7 +26794,7 @@ function convertToTensorArray(arg, argName, functionName) {
 }
 exports.convertToTensorArray = convertToTensorArray;
 
-},{"./environment":64,"./tensor":187,"./util":194}],191:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],211:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -25278,6 +26814,9 @@ exports.BROWSER_ENVS = {
 };
 exports.CPU_ENVS = {
     'HAS_WEBGL': false
+};
+exports.BROWSER_CPU_ENVS = {
+    'BACKEND': 'test-cpu'
 };
 exports.ALL_ENVS = {};
 function expectArraysClose(actual, expected, epsilon) {
@@ -25379,7 +26918,7 @@ function expectArrayBuffersEqual(actual, expected) {
 }
 exports.expectArrayBuffersEqual = expectArrayBuffersEqual;
 
-},{"./environment":64,"./tensor":187,"./util":194}],192:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],212:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./optimizers/adadelta_optimizer");
@@ -25402,7 +26941,7 @@ exports.train = {
     adam: optimizer_constructors_1.OptimizerConstructors.adam
 };
 
-},{"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer_constructors":181,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183}],193:[function(require,module,exports){
+},{"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer_constructors":201,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203}],213:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DType;
@@ -25464,7 +27003,7 @@ function sumOutType(type) {
 }
 exports.sumOutType = sumOutType;
 
-},{}],194:[function(require,module,exports){
+},{}],214:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -25485,6 +27024,18 @@ function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 exports.clamp = clamp;
+function nearestLargerEven(val) {
+    return val % 2 === 0 ? val : val + 1;
+}
+exports.nearestLargerEven = nearestLargerEven;
+function sum(arr) {
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) {
+        sum += arr[i];
+    }
+    return sum;
+}
+exports.sum = sum;
 function randUniform(a, b) {
     var r = Math.random();
     return (b * r) + (1 - r) * a;
@@ -25527,41 +27078,6 @@ function flatten(arr, ret) {
     return ret;
 }
 exports.flatten = flatten;
-function inferShape(val) {
-    var firstElem = val;
-    if (isTypedArray(val)) {
-        return [val.length];
-    }
-    if (!Array.isArray(val)) {
-        return [];
-    }
-    var shape = [];
-    while (firstElem instanceof Array) {
-        shape.push(firstElem.length);
-        firstElem = firstElem[0];
-    }
-    if (val instanceof Array) {
-        deepAssertShapeConsistency(val, shape, []);
-    }
-    return shape;
-}
-exports.inferShape = inferShape;
-function deepAssertShapeConsistency(val, shape, indices) {
-    indices = indices || [];
-    if (!(val instanceof Array)) {
-        assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
-            ("but should be an array of " + shape[0] + " elements"); });
-        return;
-    }
-    assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
-        ("but is an array of " + val.length + " elements"); });
-    assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
-        ("elements, but has " + val.length + " elements"); });
-    var subShape = shape.slice(1);
-    for (var i = 0; i < val.length; ++i) {
-        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
-    }
-}
 function sizeFromShape(shape) {
     if (shape.length === 0) {
         return 1;
@@ -25578,6 +27094,12 @@ function isScalarShape(shape) {
 }
 exports.isScalarShape = isScalarShape;
 function arraysEqual(n1, n2) {
+    if (n1 === n2) {
+        return true;
+    }
+    if (n1 == null || n2 == null) {
+        return false;
+    }
     if (n1.length !== n2.length) {
         return false;
     }
@@ -25895,13 +27417,13 @@ function now() {
 exports.now = now;
 
 }).call(this,require('_process'))
-},{"_process":269}],195:[function(require,module,exports){
+},{"_process":293}],215:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.17';
+var version = '0.13.8';
 exports.version = version;
 
-},{}],196:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gpgpu_util = require("./kernels/webgl/gpgpu_util");
@@ -25913,7 +27435,7 @@ exports.MathBackendWebGL = backend_webgl_1.MathBackendWebGL;
 var gpgpu_context_1 = require("./kernels/webgl/gpgpu_context");
 exports.GPGPUContext = gpgpu_context_1.GPGPUContext;
 
-},{"./kernels/backend_webgl":82,"./kernels/webgl/gpgpu_context":104,"./kernels/webgl/gpgpu_util":106,"./kernels/webgl/webgl_util":131}],197:[function(require,module,exports){
+},{"./kernels/backend_webgl":83,"./kernels/webgl/gpgpu_context":110,"./kernels/webgl/gpgpu_util":112,"./kernels/webgl/webgl_util":142}],217:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -25955,7 +27477,7 @@ var Elu = (function (_super) {
     return Elu;
 }(Activation));
 exports.Elu = Elu;
-tfjs_core_1.serialization.SerializationMap.register(Elu);
+tfjs_core_1.serialization.registerClass(Elu);
 var Selu = (function (_super) {
     __extends(Selu, _super);
     function Selu() {
@@ -25968,7 +27490,7 @@ var Selu = (function (_super) {
     return Selu;
 }(Activation));
 exports.Selu = Selu;
-tfjs_core_1.serialization.SerializationMap.register(Selu);
+tfjs_core_1.serialization.registerClass(Selu);
 var Relu = (function (_super) {
     __extends(Relu, _super);
     function Relu() {
@@ -25981,7 +27503,7 @@ var Relu = (function (_super) {
     return Relu;
 }(Activation));
 exports.Relu = Relu;
-tfjs_core_1.serialization.SerializationMap.register(Relu);
+tfjs_core_1.serialization.registerClass(Relu);
 var Relu6 = (function (_super) {
     __extends(Relu6, _super);
     function Relu6() {
@@ -25994,7 +27516,7 @@ var Relu6 = (function (_super) {
     return Relu6;
 }(Activation));
 exports.Relu6 = Relu6;
-tfjs_core_1.serialization.SerializationMap.register(Relu6);
+tfjs_core_1.serialization.registerClass(Relu6);
 var Linear = (function (_super) {
     __extends(Linear, _super);
     function Linear() {
@@ -26007,7 +27529,7 @@ var Linear = (function (_super) {
     return Linear;
 }(Activation));
 exports.Linear = Linear;
-tfjs_core_1.serialization.SerializationMap.register(Linear);
+tfjs_core_1.serialization.registerClass(Linear);
 var Sigmoid = (function (_super) {
     __extends(Sigmoid, _super);
     function Sigmoid() {
@@ -26020,7 +27542,7 @@ var Sigmoid = (function (_super) {
     return Sigmoid;
 }(Activation));
 exports.Sigmoid = Sigmoid;
-tfjs_core_1.serialization.SerializationMap.register(Sigmoid);
+tfjs_core_1.serialization.registerClass(Sigmoid);
 var HardSigmoid = (function (_super) {
     __extends(HardSigmoid, _super);
     function HardSigmoid() {
@@ -26033,7 +27555,7 @@ var HardSigmoid = (function (_super) {
     return HardSigmoid;
 }(Activation));
 exports.HardSigmoid = HardSigmoid;
-tfjs_core_1.serialization.SerializationMap.register(HardSigmoid);
+tfjs_core_1.serialization.registerClass(HardSigmoid);
 var Softplus = (function (_super) {
     __extends(Softplus, _super);
     function Softplus() {
@@ -26046,7 +27568,7 @@ var Softplus = (function (_super) {
     return Softplus;
 }(Activation));
 exports.Softplus = Softplus;
-tfjs_core_1.serialization.SerializationMap.register(Softplus);
+tfjs_core_1.serialization.registerClass(Softplus);
 var Softsign = (function (_super) {
     __extends(Softsign, _super);
     function Softsign() {
@@ -26059,7 +27581,7 @@ var Softsign = (function (_super) {
     return Softsign;
 }(Activation));
 exports.Softsign = Softsign;
-tfjs_core_1.serialization.SerializationMap.register(Softsign);
+tfjs_core_1.serialization.registerClass(Softsign);
 var Tanh = (function (_super) {
     __extends(Tanh, _super);
     function Tanh() {
@@ -26072,7 +27594,7 @@ var Tanh = (function (_super) {
     return Tanh;
 }(Activation));
 exports.Tanh = Tanh;
-tfjs_core_1.serialization.SerializationMap.register(Tanh);
+tfjs_core_1.serialization.registerClass(Tanh);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax() {
@@ -26086,7 +27608,7 @@ var Softmax = (function (_super) {
     return Softmax;
 }(Activation));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 function serializeActivation(activation) {
     return activation.getClassName();
 }
@@ -26114,7 +27636,7 @@ function getActivation(identifier) {
 }
 exports.getActivation = getActivation;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],198:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],218:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26132,7 +27654,7 @@ function imageDataFormat() {
 }
 exports.imageDataFormat = imageDataFormat;
 
-},{"@tensorflow/tfjs-core":68}],199:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26177,7 +27699,7 @@ function disposeScalarCache() {
 }
 exports.disposeScalarCache = disposeScalarCache;
 
-},{"@tensorflow/tfjs-core":68}],200:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -26386,27 +27908,42 @@ function randomNormal(shape, mean, stddev, dtype, seed) {
 }
 exports.randomNormal = randomNormal;
 function dot(x, y) {
-    if (y.rank !== 2) {
-        throw new errors_1.NotImplementedError("dot support for y other than rank 2 is not yet implemented: " +
-            ("y shape = " + y.shape));
+    if ((x.rank < 2) || (y.rank < 2)) {
+        throw new errors_1.NotImplementedError("dot requires both inputs to be rank >= 2" +
+            (" but got x shape = " + x.shape + " and y shape = " + y.shape));
+    }
+    if (y.rank >= 3) {
+        var xLastDim = x.shape.slice(-1)[0];
+        var ySecondLastDim = y.shape.slice(-2)[0];
+        if (xLastDim !== ySecondLastDim) {
+            throw new errors_1.NotImplementedError("If rank y >= 3, then the second last dim" +
+                (" of y must equal the last dim of x but got x shape = " + x.shape + " and ") +
+                (" y shape = " + y.shape));
+        }
+    }
+    if ((x.rank === 2) && (y.rank === 2)) {
+        return tfc.matMul(x, y);
     }
     else {
-        if (x.rank === 2) {
-            return tfc.matMul(x, y);
-        }
-        else if (x.rank === 3) {
-            var xShape0 = x.shape[0];
-            var xShape1 = x.shape[1];
-            var xShape2 = x.shape[2];
-            x = x.reshape([xShape0 * xShape1, xShape2]);
-            return tfc.matMul(x, y).reshape([
-                xShape0, xShape1, y.shape[1]
-            ]);
-        }
-        else {
-            throw new errors_1.NotImplementedError("dot support for x of rank " + x.rank + " is not yet implemented: " +
-                ("x shape = " + x.shape));
-        }
+        var xFirstDims = x.shape.slice();
+        var xLastDim = xFirstDims.pop();
+        x = x.reshape([-1, xLastDim]);
+        var yShape = y.shape.slice();
+        var yLastDim = yShape.pop();
+        var ySecondLastDim = yShape.pop();
+        var yOtherDims = yShape.concat([yLastDim]);
+        var perm = Array.from({ length: y.rank }, function (_, i) {
+            if (i === 0) {
+                return y.rank - 2;
+            }
+            else if (i <= y.rank - 2) {
+                return i - 1;
+            }
+            return i;
+        });
+        y = y.transpose(perm).reshape([ySecondLastDim, -1]);
+        var outputShape = xFirstDims.concat(yOtherDims);
+        return tfc.matMul(x, y).reshape(outputShape);
     }
 }
 exports.dot = dot;
@@ -26574,7 +28111,7 @@ function inTrainPhase(x, alt, training) {
 }
 exports.inTrainPhase = inTrainPhase;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/math_utils":240,"./common":198,"@tensorflow/tfjs-core":68}],201:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/math_utils":264,"./common":218,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26624,8 +28161,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("./backend/state");
+var errors_1 = require("./errors");
 var logs_1 = require("./logs");
 var generic_utils = require("./utils/generic_utils");
+var ModelLoggingVerbosity;
+(function (ModelLoggingVerbosity) {
+    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
+    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
+})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
 var BaseCallback = (function () {
     function BaseCallback() {
         this.validationData = null;
@@ -26779,19 +28322,22 @@ var CallbackList = (function () {
                         if (logs == null) {
                             logs = {};
                         }
-                        _i = 0, _a = this.callbacks;
-                        _b.label = 1;
+                        return [4, logs_1.resolveScalarsInLogs(logs)];
                     case 1:
-                        if (!(_i < _a.length)) return [3, 4];
+                        _b.sent();
+                        _i = 0, _a = this.callbacks;
+                        _b.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3, 5];
                         callback = _a[_i];
                         return [4, callback.onBatchEnd(batch, logs)];
-                    case 2:
-                        _b.sent();
-                        _b.label = 3;
                     case 3:
+                        _b.sent();
+                        _b.label = 4;
+                    case 4:
                         _i++;
-                        return [3, 1];
-                    case 4: return [2];
+                        return [3, 2];
+                    case 5: return [2];
                 }
             });
         });
@@ -27275,8 +28821,70 @@ function standardizeCallbacks(callbacks) {
     return callbackConfigs.map(function (callbackConfig) { return new CustomCallback(callbackConfig); });
 }
 exports.standardizeCallbacks = standardizeCallbacks;
+var CallbackConstructorRegistry = (function () {
+    function CallbackConstructorRegistry() {
+    }
+    CallbackConstructorRegistry.registerCallbackConstructor = function (verbosityLevel, callbackConstructor) {
+        tfjs_core_1.util.assert(verbosityLevel >= 0 && Number.isInteger(verbosityLevel), "Verbosity level is expected to be an integer >= 0, " +
+            ("but got " + verbosityLevel));
+        CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
+        if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {
+            CallbackConstructorRegistry.constructors[verbosityLevel] = [];
+        }
+        CallbackConstructorRegistry.constructors[verbosityLevel].push(callbackConstructor);
+    };
+    CallbackConstructorRegistry.checkForDuplicate = function (callbackConstructor) {
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var constructors = CallbackConstructorRegistry.constructors[+levelName];
+            constructors.forEach(function (ctor) {
+                if (ctor === callbackConstructor) {
+                    throw new errors_1.ValueError('Duplicate callback constructor.');
+                }
+            });
+        }
+    };
+    CallbackConstructorRegistry.clear = function () {
+        CallbackConstructorRegistry.constructors = {};
+    };
+    CallbackConstructorRegistry.createCallbacks = function (verbosityLevel) {
+        var constructors = [];
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var level = +levelName;
+            if (verbosityLevel >= level) {
+                constructors.push.apply(constructors, CallbackConstructorRegistry.constructors[level]);
+            }
+        }
+        return constructors.map(function (ctor) { return new ctor(); });
+    };
+    CallbackConstructorRegistry.constructors = {};
+    return CallbackConstructorRegistry;
+}());
+exports.CallbackConstructorRegistry = CallbackConstructorRegistry;
+function configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics) {
+    var history = new History();
+    var actualCallbacks = [
+        new BaseLogger(yieldEvery)
+    ].concat(CallbackConstructorRegistry.createCallbacks(verbose));
+    if (callbacks != null) {
+        actualCallbacks.push.apply(actualCallbacks, callbacks);
+    }
+    actualCallbacks.push(history);
+    var callbackList = new CallbackList(actualCallbacks);
+    callbackList.setParams({
+        epochs: epochs,
+        initialEpoch: initialEpoch,
+        samples: numTrainSamples,
+        steps: stepsPerEpoch,
+        batchSize: batchSize,
+        verbose: verbose,
+        doValidation: doValidation,
+        metrics: callbackMetrics,
+    });
+    return { callbackList: callbackList, history: history };
+}
+exports.configureCallbacks = configureCallbacks;
 
-},{"./backend/state":199,"./logs":231,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],202:[function(require,module,exports){
+},{"./backend/state":219,"./errors":233,"./logs":255,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27308,7 +28916,7 @@ var Callback = (function (_super) {
 }(base_callbacks_1.BaseCallback));
 exports.Callback = Callback;
 
-},{"./base_callbacks":201,"./engine/training":209}],203:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/training":230}],223:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils_1 = require("./utils/generic_utils");
@@ -27377,13 +28985,13 @@ function getUniqueTensorName(scopedName) {
     }
 }
 exports.getUniqueTensorName = getUniqueTensorName;
-var tensorNameRegex = new RegExp(/^[A-Za-z][A-Za-z0-9\._\/]*$/);
+var tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
 function isValidTensorName(name) {
     return name.match(tensorNameRegex) ? true : false;
 }
 exports.isValidTensorName = isValidTensorName;
 
-},{"./utils/generic_utils":238}],204:[function(require,module,exports){
+},{"./utils/generic_utils":262}],224:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27441,7 +29049,7 @@ var MaxNorm = (function (_super) {
     return MaxNorm;
 }(Constraint));
 exports.MaxNorm = MaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MaxNorm);
+tfjs_core_1.serialization.registerClass(MaxNorm);
 var UnitNorm = (function (_super) {
     __extends(UnitNorm, _super);
     function UnitNorm(config) {
@@ -27461,7 +29069,7 @@ var UnitNorm = (function (_super) {
     return UnitNorm;
 }(Constraint));
 exports.UnitNorm = UnitNorm;
-tfjs_core_1.serialization.SerializationMap.register(UnitNorm);
+tfjs_core_1.serialization.registerClass(UnitNorm);
 var NonNeg = (function (_super) {
     __extends(NonNeg, _super);
     function NonNeg() {
@@ -27474,7 +29082,7 @@ var NonNeg = (function (_super) {
     return NonNeg;
 }(Constraint));
 exports.NonNeg = NonNeg;
-tfjs_core_1.serialization.SerializationMap.register(NonNeg);
+tfjs_core_1.serialization.registerClass(NonNeg);
 var MinMaxNorm = (function (_super) {
     __extends(MinMaxNorm, _super);
     function MinMaxNorm(config) {
@@ -27511,7 +29119,7 @@ var MinMaxNorm = (function (_super) {
     return MinMaxNorm;
 }(Constraint));
 exports.MinMaxNorm = MinMaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MinMaxNorm);
+tfjs_core_1.serialization.registerClass(MinMaxNorm);
 exports.CONSTRAINT_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'maxNorm': 'MaxNorm',
     'minMaxNorm': 'MinMaxNorm',
@@ -27547,7 +29155,7 @@ function getConstraint(identifier) {
 }
 exports.getConstraint = getConstraint;
 
-},{"./backend/common":198,"./backend/state":199,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],205:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28210,7 +29818,7 @@ var Container = (function (_super) {
             keptNodes = layer instanceof Container ? 1 : 0;
             for (var originalNodeIndex = 0; originalNodeIndex < layer.inboundNodes.length; originalNodeIndex++) {
                 var nodeKey = Container.nodeKey(layer, originalNodeIndex);
-                if (nodeKey in this.containerNodes) {
+                if (this.containerNodes.has(nodeKey)) {
                     nodeConversionMap[nodeKey] = keptNodes;
                     keptNodes += 1;
                 }
@@ -28293,7 +29901,7 @@ var Container = (function (_super) {
                             var tensorIndex = node.tensorIndices[i];
                             var nodeKey_1 = Container.nodeKey(inboundLayer, nodeIndex);
                             var newNodeIndex = nodeConversionMap[nodeKey_1];
-                            if (newNodeIndex === null || newNodeIndex === undefined) {
+                            if (newNodeIndex == null) {
                                 newNodeIndex = 0;
                             }
                             nodeData.push([inboundLayer.name, newNodeIndex, tensorIndex, kwargs]);
@@ -28414,19 +30022,20 @@ var Container = (function (_super) {
                 var layerData = layersFromConfig_2[_a];
                 var layer = createdLayers[layerData.name];
                 if (layer.name in unprocessedNodes) {
-                    for (var _b = 0, _c = unprocessedNodes[layer.name]; _b < _c.length; _b++) {
-                        var nodeData = _c[_b];
+                    var currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
+                    delete unprocessedNodes[layer.name];
+                    for (var _b = 0, currentUnprocessedNodesForLayer_1 = currentUnprocessedNodesForLayer; _b < currentUnprocessedNodesForLayer_1.length; _b++) {
+                        var nodeData = currentUnprocessedNodesForLayer_1[_b];
                         processNode(layer, nodeData);
                     }
-                    delete unprocessedNodes[layer.name];
                 }
             }
         }
         var inputTensors = [];
         var outputTensors = [];
         var inputLayersFromConfig = config.inputLayers;
-        for (var _d = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _d < inputLayersFromConfig_1.length; _d++) {
-            var layerData = inputLayersFromConfig_1[_d];
+        for (var _c = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _c < inputLayersFromConfig_1.length; _c++) {
+            var layerData = inputLayersFromConfig_1[_c];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28436,8 +30045,8 @@ var Container = (function (_super) {
             inputTensors.push(layerOutputTensors[tensorIndex]);
         }
         var outputLayersFromConfig = config.outputLayers;
-        for (var _e = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _e < outputLayersFromConfig_1.length; _e++) {
-            var layerData = outputLayersFromConfig_1[_e];
+        for (var _d = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _d < outputLayersFromConfig_1.length; _d++) {
+            var layerData = outputLayersFromConfig_1[_d];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28480,7 +30089,23 @@ var Container = (function (_super) {
 }(topology_1.Layer));
 exports.Container = Container;
 
-},{"../backend/state":199,"../errors":210,"../layers/serialization":229,"../utils/generic_utils":238,"../utils/serialization_utils":241,"../utils/types_utils":242,"../variables":244,"../version":245,"./input_layer":207,"./topology":208,"@tensorflow/tfjs-core":68}],206:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"../layers/serialization":253,"../utils/generic_utils":262,"../utils/serialization_utils":265,"../utils/types_utils":266,"../variables":268,"../version":269,"./input_layer":228,"./topology":229,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyIterator = (function () {
+    function LazyIterator() {
+    }
+    return LazyIterator;
+}());
+exports.LazyIterator = LazyIterator;
+var Dataset = (function () {
+    function Dataset() {
+    }
+    return Dataset;
+}());
+exports.Dataset = Dataset;
+
+},{}],227:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -28614,7 +30239,7 @@ function getNodeOutputs(fetch) {
     return layerOutputs;
 }
 
-},{"../errors":210,"./input_layer":207,"@tensorflow/tfjs-core":68}],207:[function(require,module,exports){
+},{"../errors":233,"./input_layer":228,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28693,10 +30318,7 @@ var InputLayer = (function (_super) {
             ("InputLayer's apply() method. InputLayer name: " + this.name));
     };
     InputLayer.prototype.dispose = function () {
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: 0
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: 0 };
     };
     InputLayer.prototype.getConfig = function () {
         return {
@@ -28710,7 +30332,7 @@ var InputLayer = (function (_super) {
     return InputLayer;
 }(topology_1.Layer));
 exports.InputLayer = InputLayer;
-tfjs_core_1.serialization.SerializationMap.register(InputLayer);
+tfjs_core_1.serialization.registerClass(InputLayer);
 function Input(config) {
     if (config.batchShape == null && config.shape == null) {
         throw new Error('Please provide to Input either a `shape`' +
@@ -28741,7 +30363,7 @@ function Input(config) {
 }
 exports.Input = Input;
 
-},{"../backend/state":199,"../errors":210,"./topology":208,"@tensorflow/tfjs-core":68}],208:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"./topology":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29429,10 +31051,7 @@ var Layer = (function (_super) {
         if (--this._refCount === 0) {
             numDisposedVariables = this.disposeWeights();
         }
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: numDisposedVariables
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: numDisposedVariables };
     };
     return Layer;
 }(tfjs_core_1.serialization.Serializable));
@@ -29483,7 +31102,7 @@ function getSourceInputs(tensor, layer, nodeIndex) {
 }
 exports.getSourceInputs = getSourceInputs;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"../utils/variable_utils":243,"../variables":244,"@tensorflow/tfjs-core":68}],209:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"../utils/variable_utils":267,"../variables":268,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29535,10 +31154,8 @@ var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
-var base_callbacks_1 = require("../base_callbacks");
 var common_1 = require("../common");
 var errors_1 = require("../errors");
-var logs_1 = require("../logs");
 var losses = require("../losses");
 var Metrics = require("../metrics");
 var optimizers = require("../optimizers");
@@ -29547,6 +31164,8 @@ var layer_utils_1 = require("../utils/layer_utils");
 var math_utils_1 = require("../utils/math_utils");
 var container_1 = require("./container");
 var executor_1 = require("./executor");
+var training_dataset_1 = require("./training_dataset");
+var training_tensors_1 = require("./training_tensors");
 function isDataTensor(x) {
     return x instanceof tfjs_core_1.Tensor;
 }
@@ -29711,46 +31330,6 @@ function checkLossAndTargetCompatibility(targets, lossFns, outputShapes) {
         }
     }
 }
-function makeBatches(size, batchSize) {
-    var output = [];
-    var batchStart = 0;
-    var batchEnd = null;
-    while (batchStart < size) {
-        batchEnd = batchStart + batchSize;
-        if (batchEnd >= size) {
-            batchEnd = size;
-        }
-        output.push([batchStart, batchEnd]);
-        batchStart = batchEnd;
-    }
-    return output;
-}
-exports.makeBatches = makeBatches;
-function sliceArrays(arrays, start, stop) {
-    if (arrays == null) {
-        return [null];
-    }
-    else if (Array.isArray(arrays)) {
-        return arrays.map(function (array) { return K.sliceAlongFirstAxis(array, start, stop - start); });
-    }
-    else {
-        return K.sliceAlongFirstAxis(arrays, start, stop - start);
-    }
-}
-function sliceArraysByIndices(arrays, indices) {
-    return tfc.tidy(function () {
-        if (arrays == null) {
-            return null;
-        }
-        else if (Array.isArray(arrays)) {
-            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
-        }
-        else {
-            return K.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
-        }
-    });
-}
-exports.sliceArraysByIndices = sliceArraysByIndices;
 function checkInputData(data, names, shapes, checkBatchAxis, exceptionPrefix) {
     if (checkBatchAxis === void 0) { checkBatchAxis = true; }
     if (exceptionPrefix === void 0) { exceptionPrefix = ''; }
@@ -29823,14 +31402,6 @@ function collectMetrics(metrics, outputNames) {
         throw new TypeError('Type of metrics argument not understood. Expected an Array or ' +
             'Object, found: ' + metrics);
     }
-}
-var ModelLoggingVerbosity;
-(function (ModelLoggingVerbosity) {
-    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
-    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
-})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
-function checkBatchSize(batchSize) {
-    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
 }
 var Model = (function (_super) {
     __extends(Model, _super);
@@ -30021,13 +31592,21 @@ var Model = (function (_super) {
     Model.prototype.evaluate = function (x, y, config) {
         if (config === void 0) { config = {}; }
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         var standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
         var ins = standardizedOuts[0].concat(standardizedOuts[1]);
         this.makeTestFunction();
         var f = this.testFunction;
         var testOuts = this.testLoop(f, ins, batchSize, config.verbose, config.steps);
         return generic_utils_1.singletonOrArray(testOuts);
+    };
+    Model.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                this.makeTestFunction();
+                return [2, training_dataset_1.evaluateDataset(this, dataset, config)];
+            });
+        });
     };
     Model.prototype.checkNumSamples = function (ins, batchSize, steps, stepsName) {
         if (stepsName === void 0) { stepsName = 'steps'; }
@@ -30132,13 +31711,13 @@ var Model = (function (_super) {
             if (verbose) {
                 throw new errors_1.NotImplementedError('Verbose predictLoop() is not implemented yet.');
             }
-            var batches = makeBatches(numSamples, batchSize);
+            var batches = training_tensors_1.makeBatches(numSamples, batchSize);
             var outs = [];
             var _loop_3 = function (batchIndex) {
                 var batchOuts = tfc.tidy(function () {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
-                    var insBatch = sliceArrays(ins, batchStart, batchEnd);
+                    var insBatch = training_tensors_1.sliceArrays(ins, batchStart, batchEnd);
                     var feeds = [];
                     if (Array.isArray(insBatch)) {
                         for (var i = 0; i < insBatch.length; ++i) {
@@ -30173,7 +31752,7 @@ var Model = (function (_super) {
         if (config === void 0) { config = {}; }
         checkInputData(x, this.inputNames, this.feedInputShapes, false);
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         return this.predictLoop(x, batchSize);
     };
     Model.prototype.predictOnBatch = function (x) {
@@ -30210,204 +31789,26 @@ var Model = (function (_super) {
         }
         return [x, y, null];
     };
-    Model.prototype.fitLoop = function (f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var doValidation, numTrainSamples, indexArray, baseLogger, callbackList, _loop_4, this_1, epoch, state_2;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (batchSize == null) {
-                            batchSize = 32;
-                        }
-                        if (epochs == null) {
-                            epochs = 1;
-                        }
-                        if (shuffle == null) {
-                            shuffle = true;
-                        }
-                        if (initialEpoch == null) {
-                            initialEpoch = 0;
-                        }
-                        doValidation = false;
-                        if (valF != null && valIns != null) {
-                            doValidation = true;
-                        }
-                        if (validationSteps != null) {
-                            doValidation = true;
-                            if (stepsPerEpoch == null) {
-                                throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
-                                    'i.e., `stepsPerEpoch` must be set.');
-                            }
-                        }
-                        numTrainSamples = this.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
-                        if (numTrainSamples != null) {
-                            indexArray = math_utils_1.range(0, numTrainSamples);
-                        }
-                        this.history = new base_callbacks_1.History();
-                        baseLogger = new base_callbacks_1.BaseLogger(yieldEvery);
-                        if (callbacks == null) {
-                            callbacks = [baseLogger];
-                        }
-                        else {
-                            callbacks = [baseLogger].concat(callbacks);
-                        }
-                        callbacks = callbacks.concat([this.history]);
-                        if (verbose > 0) {
-                            throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
-                        }
-                        callbackList = new base_callbacks_1.CallbackList(callbacks);
-                        callbackList.setModel(this);
-                        callbackList.setParams({
-                            epochs: epochs,
-                            initialEpoch: initialEpoch,
-                            samples: numTrainSamples,
-                            steps: stepsPerEpoch,
-                            batchSize: batchSize,
-                            verbose: verbose,
-                            doValidation: doValidation,
-                            metrics: callbackMetrics,
-                        });
-                        return [4, callbackList.onTrainBegin()];
-                    case 1:
-                        _a.sent();
-                        this.stopTraining_ = false;
-                        _loop_4 = function (epoch) {
-                            var epochLogs, epochIndexArray1D_1, batches_1, _loop_5, batchIndex, state_3;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4, callbackList.onEpochBegin(epoch)];
-                                    case 1:
-                                        _a.sent();
-                                        epochLogs = {};
-                                        if (!(stepsPerEpoch != null)) return [3, 2];
-                                        throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
-                                    case 2:
-                                        if (shuffle === 'batch') {
-                                            throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
-                                        }
-                                        else if (shuffle) {
-                                            tfjs_core_1.util.shuffle(indexArray);
-                                        }
-                                        epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
-                                        batches_1 = makeBatches(numTrainSamples, batchSize);
-                                        _loop_5 = function (batchIndex) {
-                                            var batchLogs;
-                                            return __generator(this, function (_a) {
-                                                switch (_a.label) {
-                                                    case 0:
-                                                        batchLogs = {};
-                                                        return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
-                                                    case 1:
-                                                        _a.sent();
-                                                        tfc.tidy(function () {
-                                                            var batchStart = batches_1[batchIndex][0];
-                                                            var batchEnd = batches_1[batchIndex][1];
-                                                            var batchIds = K.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
-                                                            batchLogs['batch'] = batchIndex;
-                                                            batchLogs['size'] = batchEnd - batchStart;
-                                                            var insBatch = sliceArraysByIndices(ins, batchIds);
-                                                            var outs = f(insBatch);
-                                                            for (var i = 0; i < outLabels.length; ++i) {
-                                                                var label = outLabels[i];
-                                                                var out = outs[i];
-                                                                batchLogs[label] = out;
-                                                                tfc.keep(out);
-                                                            }
-                                                            if (batchIndex === batches_1.length - 1) {
-                                                                if (doValidation) {
-                                                                    var valOuts = _this.testLoop(valF, valIns, batchSize);
-                                                                    for (var i = 0; i < outLabels.length; ++i) {
-                                                                        var label = outLabels[i];
-                                                                        var out = valOuts[i];
-                                                                        tfc.keep(out);
-                                                                        epochLogs['val_' + label] = out;
-                                                                    }
-                                                                }
-                                                            }
-                                                        });
-                                                        return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
-                                                    case 2:
-                                                        _a.sent();
-                                                        logs_1.disposeTensorsInLogs(batchLogs);
-                                                        if (this_1.stopTraining_) {
-                                                            return [2, "break"];
-                                                        }
-                                                        return [2];
-                                                }
-                                            });
-                                        };
-                                        batchIndex = 0;
-                                        _a.label = 3;
-                                    case 3:
-                                        if (!(batchIndex < batches_1.length)) return [3, 6];
-                                        return [5, _loop_5(batchIndex)];
-                                    case 4:
-                                        state_3 = _a.sent();
-                                        if (state_3 === "break")
-                                            return [3, 6];
-                                        _a.label = 5;
-                                    case 5:
-                                        ++batchIndex;
-                                        return [3, 3];
-                                    case 6:
-                                        epochIndexArray1D_1.dispose();
-                                        _a.label = 7;
-                                    case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
-                                    case 8:
-                                        _a.sent();
-                                        if (this_1.stopTraining_) {
-                                            return [2, "break"];
-                                        }
-                                        return [2];
-                                }
-                            });
-                        };
-                        this_1 = this;
-                        epoch = initialEpoch;
-                        _a.label = 2;
-                    case 2:
-                        if (!(epoch < epochs)) return [3, 5];
-                        return [5, _loop_4(epoch)];
-                    case 3:
-                        state_2 = _a.sent();
-                        if (state_2 === "break")
-                            return [3, 5];
-                        _a.label = 4;
-                    case 4:
-                        ++epoch;
-                        return [3, 2];
-                    case 5: return [4, callbackList.onTrainEnd()];
-                    case 6:
-                        _a.sent();
-                        return [4, this.history.syncData()];
-                    case 7:
-                        _a.sent();
-                        return [2, this.history];
-                }
-            });
-        });
-    };
     Model.prototype.testLoop = function (f, ins, batchSize, verbose, steps) {
         var _this = this;
         if (verbose === void 0) { verbose = 0; }
         return tfc.tidy(function () {
             var numSamples = _this.checkNumSamples(ins, batchSize, steps, 'steps');
             var outs = [];
-            if (verbose === 1) {
+            if (verbose > 0) {
                 throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
             }
             if (steps != null) {
                 throw new errors_1.NotImplementedError('steps mode in testLoop() is not implemented yet');
             }
             else {
-                var batches = makeBatches(numSamples, batchSize);
+                var batches = training_tensors_1.makeBatches(numSamples, batchSize);
                 var indexArray = tfjs_core_1.tensor1d(math_utils_1.range(0, numSamples));
                 for (var batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
                     var batchIds = K.sliceAlongFirstAxis(indexArray, batchStart, batchEnd - batchStart);
-                    var insBatch = sliceArraysByIndices(ins, batchIds);
+                    var insBatch = training_tensors_1.sliceArraysByIndices(ins, batchIds);
                     var batchOuts = f(insBatch);
                     if (batchIndex === 0) {
                         for (var i = 0; i < batchOuts.length; ++i) {
@@ -30440,6 +31841,54 @@ var Model = (function (_super) {
             dedupedOutLabels.push(newLabel);
         }
         return dedupedOutLabels;
+    };
+    Model.prototype.makeTrainFunction = function () {
+        var _this = this;
+        return function (data) {
+            var losses = [];
+            var lossValues = [];
+            var inputs = data.slice(0, _this.inputs.length);
+            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
+            var metricsValues = [];
+            var totalLossFunction = function () {
+                var feeds = [];
+                for (var i = 0; i < _this.inputs.length; ++i) {
+                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
+                }
+                var feedDict = new executor_1.FeedDict(feeds);
+                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
+                var totalLoss;
+                for (var i = 0; i < _this.lossFunctions.length; ++i) {
+                    var lossFunction = _this.lossFunctions[i];
+                    var loss = lossFunction(targets[i], outputs[i]);
+                    losses.push(loss);
+                    var meanLoss = tfc.mean(loss);
+                    lossValues.push(meanLoss);
+                    if (i === 0) {
+                        totalLoss = loss;
+                    }
+                    else {
+                        totalLoss = tfc.add(totalLoss, loss);
+                    }
+                }
+                for (var i = 0; i < _this.metricsTensors.length; ++i) {
+                    var metric = _this.metricsTensors[i][0];
+                    var outputIndex = _this.metricsTensors[i][1];
+                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
+                    tfc.keep(meanMetric);
+                    metricsValues.push(meanMetric);
+                }
+                totalLoss = tfc.mean(totalLoss);
+                _this.calculateLosses().forEach(function (regularizerLoss) {
+                    totalLoss = tfc.add(totalLoss, regularizerLoss);
+                });
+                return totalLoss;
+            };
+            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
+            var returnCost = true;
+            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
+            return [totalLossValue].concat(metricsValues);
+        };
     };
     Model.prototype.makeTestFunction = function () {
         var _this = this;
@@ -30479,139 +31928,15 @@ var Model = (function (_super) {
     Model.prototype.fit = function (x, y, config) {
         if (config === void 0) { config = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (this.isTraining) {
-                            throw new Error('Cannot start training because another fit() call is ongoing.');
-                        }
-                        this.isTraining = true;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, , 3, 4]);
-                        batchSize = config.batchSize == null ? 32 : config.batchSize;
-                        checkBatchSize(batchSize);
-                        standardizedOuts = this.standardizeUserData(x, y, false, batchSize);
-                        inputs = standardizedOuts[0];
-                        targets = standardizedOuts[1];
-                        doValidation = false;
-                        valX = void 0;
-                        valY = void 0;
-                        valIns = void 0;
-                        needValidationDisposal = false;
-                        if (config.validationData != null && config.validationData.length > 0) {
-                            doValidation = true;
-                            if (config.validationData.length === 2) {
-                                valX = config.validationData[0];
-                                valY = config.validationData[1];
-                            }
-                            else if (config.validationData.length === 3) {
-                                throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
-                            }
-                            else {
-                                throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
-                                    "or 3 (valX, valY, valSampleWeight) items; " +
-                                    (config.validationData + " is invalid."));
-                            }
-                            valStandardized = this.standardizeUserData(valX, valY, true, batchSize);
-                            valX = valStandardized[0];
-                            valY = valStandardized[1];
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSplit != null && config.validationSplit > 0 &&
-                            config.validationSplit < 1) {
-                            doValidation = true;
-                            splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
-                            originalBatchSize = inputs[0].shape[0];
-                            valX = sliceArrays(inputs, splitAt, originalBatchSize);
-                            inputs = sliceArrays(inputs, 0, splitAt);
-                            valY = sliceArrays(targets, splitAt, originalBatchSize);
-                            targets = sliceArrays(targets, 0, splitAt);
-                            needValidationDisposal = true;
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSteps != null) {
-                            doValidation = true;
-                        }
-                        ins = inputs.concat(targets);
-                        this.checkTrainableWeightsConsistency();
-                        trainFunction = function (data) {
-                            var losses = [];
-                            var lossValues = [];
-                            var inputs = data.slice(0, _this.inputs.length);
-                            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
-                            var metricsValues = [];
-                            var totalLossFunction = function () {
-                                var feeds = [];
-                                for (var i = 0; i < _this.inputs.length; ++i) {
-                                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
-                                }
-                                var feedDict = new executor_1.FeedDict(feeds);
-                                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
-                                var totalLoss;
-                                for (var i = 0; i < _this.lossFunctions.length; ++i) {
-                                    var lossFunction = _this.lossFunctions[i];
-                                    var loss = lossFunction(targets[i], outputs[i]);
-                                    losses.push(loss);
-                                    var meanLoss = tfc.mean(loss);
-                                    lossValues.push(meanLoss);
-                                    if (i === 0) {
-                                        totalLoss = loss;
-                                    }
-                                    else {
-                                        totalLoss = tfc.add(totalLoss, loss);
-                                    }
-                                }
-                                for (var i = 0; i < _this.metricsTensors.length; ++i) {
-                                    var metric = _this.metricsTensors[i][0];
-                                    var outputIndex = _this.metricsTensors[i][1];
-                                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
-                                    tfc.keep(meanMetric);
-                                    metricsValues.push(meanMetric);
-                                }
-                                totalLoss = tfc.mean(totalLoss);
-                                _this.calculateLosses().forEach(function (regularizerLoss) {
-                                    totalLoss = tfc.add(totalLoss, regularizerLoss);
-                                });
-                                return totalLoss;
-                            };
-                            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
-                            var returnCost = true;
-                            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
-                            return [totalLossValue].concat(metricsValues);
-                        };
-                        outLabels = this.getDedupedMetricsNames();
-                        valFunction = void 0;
-                        callbackMetrics = void 0;
-                        if (doValidation) {
-                            this.makeTestFunction();
-                            valFunction = this.testFunction;
-                            callbackMetrics =
-                                outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
-                        }
-                        else {
-                            valFunction = null;
-                            valIns = [];
-                            callbackMetrics = outLabels.slice();
-                        }
-                        callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
-                        return [4, this.fitLoop(trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
-                    case 2:
-                        out = _a.sent();
-                        if (needValidationDisposal) {
-                            valIns.forEach(function (tensor) { return tensor.dispose(); });
-                            inputs.forEach(function (tensor) { return tensor.dispose(); });
-                            targets.forEach(function (tensor) { return tensor.dispose(); });
-                        }
-                        this.isTraining = false;
-                        return [2, out];
-                    case 3:
-                        this.isTraining = false;
-                        return [7];
-                    case 4: return [2];
-                }
+                return [2, training_tensors_1.fitTensors(this, x, y, config)];
+            });
+        });
+    };
+    Model.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, training_dataset_1.fitDataset(this, dataset, config)];
             });
         });
     };
@@ -30675,9 +32000,699 @@ var Model = (function (_super) {
     return Model;
 }(container_1.Container));
 exports.Model = Model;
-tfjs_core_1.serialization.SerializationMap.register(Model);
+tfjs_core_1.serialization.registerClass(Model);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../base_callbacks":201,"../common":203,"../errors":210,"../logs":231,"../losses":232,"../metrics":233,"../optimizers":235,"../utils/generic_utils":238,"../utils/layer_utils":239,"../utils/math_utils":240,"./container":205,"./executor":206,"@tensorflow/tfjs-core":68}],210:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../errors":233,"../losses":256,"../metrics":257,"../optimizers":259,"../utils/generic_utils":262,"../utils/layer_utils":263,"../utils/math_utils":264,"./container":225,"./executor":227,"./training_dataset":231,"./training_tensors":232,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var state_1 = require("../backend/state");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var generic_utils_1 = require("../utils/generic_utils");
+var dataset_stub_1 = require("./dataset_stub");
+var DEFAULT_VALIDATION_BATCH_SIZE = 32;
+function standardizeDataIteratorOutput(model, iteratorOut) {
+    if (model.outputs.length > 1) {
+        throw new errors_1.NotImplementedError("Support for training a model with multiple output tensors with " +
+            "a dataset object is not implemented yet.");
+    }
+    tfc.util.assert(Array.isArray(iteratorOut) && iteratorOut.length === 2, 'Dataset iterator for fitDataset() is expected to generate ' +
+        'an Array of length 2: `[xs, ys]`, but instead generates ' +
+        iteratorOut);
+    iteratorOut = iteratorOut;
+    var ys = iteratorOut[1];
+    var xs = iteratorOut[0];
+    if (xs instanceof tfc.Tensor) {
+        tfc.util.assert(model.inputs.length === 1, "Model has multiple " + model.inputs.length + " inputs, hence it " +
+            "expects the input dataset to generate a dictionary of tensors " +
+            (" (with keys " + JSON.stringify(model.inputNames) + ", ") +
+            "but received a single tensor.");
+        tfc.util.assert(xs.shape[0] === ys.shape[0], "Mismatch in batch size between x and y tensors (" + xs.shape[0] + " vs. " +
+            (ys.shape[0] + ")"));
+        return [xs, ys];
+    }
+    else {
+        var batchSize = void 0;
+        xs = xs;
+        var flattendXs = [];
+        for (var _i = 0, _a = model.inputNames; _i < _a.length; _i++) {
+            var inputName = _a[_i];
+            if (xs[inputName] == null) {
+                throw new errors_1.ValueError("The feature data generated by the dataset lacks the required " +
+                    ("input key '" + inputName + "'."));
+            }
+            flattendXs.push(xs[inputName]);
+            if (batchSize == null) {
+                batchSize = xs[inputName].shape[0];
+            }
+            else {
+                tfc.util.assert(xs[inputName].shape[0] === batchSize, "Mismatch in batch size between x and y tensors " +
+                    ("(" + xs[inputName].shape[0] + " vs. " + ys.shape[0] + ")"));
+            }
+        }
+        return flattendXs.concat(ys);
+    }
+}
+function standardizeTensorValidationData(data) {
+    if (data.length === 3) {
+        throw new errors_1.NotImplementedError('Validation with sample weights is not implemented yet.');
+    }
+    return { xs: data[0], ys: data[1] };
+}
+function fitDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, validationDataIterator, valXs, valYs, validationData, trainFunction, outLabels, callbackMetrics, callbacks, _a, callbackList, history_1, epoch, epochLogs, dataIterator, stepsDone, batchIndex, iteratorOut, xsAndYs, batchLogs, outs, i, label, out, valOuts, _b, i;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    tfc.util.assert(model.optimizer != null, 'You must compile a model before training/testing. Use ' +
+                        'Model.compile(modelCompileConfig).');
+                    tfc.util.assert(config != null, "For fitDataset(), the 2nd argument (config) is required, " +
+                        "but it is not provided in this call.");
+                    tfc.util.assert(config.epochs != null && config.epochs > 0 &&
+                        Number.isInteger(config.epochs), "For fitDataset(), config.epochs is expected to be a positive " +
+                        ("integer, but got " + config.epochs));
+                    tfc.util.assert(config.batchesPerEpoch != null && config.batchesPerEpoch > 0 &&
+                        Number.isInteger(config.batchesPerEpoch), "For fitDataset(), config.batchesPerEpoch is expected to be a " +
+                        ("positive integer, but got " + config.batchesPerEpoch));
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _c.label = 1;
+                case 1:
+                    _c.trys.push([1, , 21, 22]);
+                    doValidation = config.validationData != null;
+                    validationDataIterator = void 0;
+                    valXs = void 0;
+                    valYs = void 0;
+                    if (!doValidation) return [3, 4];
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 3];
+                    tfc.util.assert(config.validationBatches > 0 &&
+                        Number.isInteger(config.validationBatches), "For fitDataset() with dataset-based validation, " +
+                        "config.validationBatches is expected to be a " +
+                        ("positive integer, but got " + config.validationBatches));
+                    return [4, config.validationData.iterator()];
+                case 2:
+                    validationDataIterator = _c.sent();
+                    return [3, 4];
+                case 3:
+                    validationData = standardizeTensorValidationData(config.validationData);
+                    valXs = validationData.xs;
+                    valYs = validationData.ys;
+                    _c.label = 4;
+                case 4:
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    _a = base_callbacks_1.configureCallbacks(callbacks, config.yieldEvery, config.verbose, config.epochs, null, null, config.batchesPerEpoch, null, doValidation, callbackMetrics), callbackList = _a.callbackList, history_1 = _a.history;
+                    model.history = history_1;
+                    return [4, callbackList.onTrainBegin()];
+                case 5:
+                    _c.sent();
+                    epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
+                    epochLogs = {};
+                    return [4, dataset.iterator()];
+                case 6:
+                    dataIterator = _c.sent();
+                    _c.label = 7;
+                case 7:
+                    if (!(epoch < config.epochs)) return [3, 18];
+                    return [4, callbackList.onEpochBegin(epoch)];
+                case 8:
+                    _c.sent();
+                    stepsDone = 0;
+                    batchIndex = 0;
+                    _c.label = 9;
+                case 9:
+                    if (!(stepsDone < config.batchesPerEpoch)) return [3, 16];
+                    return [4, dataIterator.next()];
+                case 10:
+                    iteratorOut = _c.sent();
+                    if (iteratorOut.done) {
+                        console.warn('Your dataset iterator ran out of data; ' +
+                            'interrupting training. Make sure that your ' +
+                            'dataset can generate at least `batchesPerEpoch * epochs` ' +
+                            'batches (in this case, ' +
+                            (config.batchesPerEpoch * config.epochs + " batches). ") +
+                            'You may need to use the repeat() function when building ' +
+                            'your dataset.');
+                        return [3, 16];
+                    }
+                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                    batchLogs = {};
+                    batchLogs['batch'] = batchIndex;
+                    batchLogs['size'] = xsAndYs[0].shape[0];
+                    callbackList.onBatchBegin(batchIndex, batchLogs);
+                    outs = trainFunction(xsAndYs);
+                    tfc.dispose(xsAndYs);
+                    for (i = 0; i < outLabels.length; ++i) {
+                        label = outLabels[i];
+                        out = outs[i];
+                        batchLogs[label] = out;
+                        tfc.keep(out);
+                    }
+                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                case 11:
+                    _c.sent();
+                    logs_1.disposeTensorsInLogs(batchLogs);
+                    batchIndex++;
+                    stepsDone++;
+                    if (!(stepsDone >= config.batchesPerEpoch && doValidation)) return [3, 15];
+                    valOuts = void 0;
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 13];
+                    _b = generic_utils_1.toList;
+                    return [4, model.evaluateDataset(validationDataIterator, { batches: config.validationBatches })];
+                case 12:
+                    valOuts = _b.apply(void 0, [_c.sent()]);
+                    return [3, 14];
+                case 13:
+                    valOuts = generic_utils_1.toList(model.evaluate(valXs, valYs, {
+                        batchSize: config.validationBatchSize == null ?
+                            DEFAULT_VALIDATION_BATCH_SIZE :
+                            config.validationBatchSize,
+                        verbose: 0
+                    }));
+                    _c.label = 14;
+                case 14:
+                    for (i = 0; i < model.metricsNames.length; ++i) {
+                        epochLogs["val_" + model.metricsNames[i]] = valOuts[i];
+                    }
+                    _c.label = 15;
+                case 15:
+                    if (model.stopTraining_) {
+                        return [3, 16];
+                    }
+                    return [3, 9];
+                case 16: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                case 17:
+                    _c.sent();
+                    epoch++;
+                    if (model.stopTraining_) {
+                        return [3, 18];
+                    }
+                    return [3, 7];
+                case 18: return [4, callbackList.onTrainEnd()];
+                case 19:
+                    _c.sent();
+                    return [4, model.history.syncData()];
+                case 20:
+                    _c.sent();
+                    return [2, model.history];
+                case 21:
+                    model.isTraining = false;
+                    return [7];
+                case 22: return [2];
+            }
+        });
+    });
+}
+exports.fitDataset = fitDataset;
+function evaluateDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var f, outs, dataIterator, _a, numExamples, _loop_1, batch, state_2, _loop_2, i;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    f = model.testFunction;
+                    outs = [];
+                    if (config.verbose > 0) {
+                        throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
+                    }
+                    tfc.util.assert(config.batches > 0 && Number.isInteger(config.batches), 'Test loop expects `batches` to be a positive integer, but ' +
+                        ("received " + JSON.stringify(config.batches)));
+                    if (!(dataset instanceof dataset_stub_1.LazyIterator)) return [3, 1];
+                    _a = dataset;
+                    return [3, 3];
+                case 1: return [4, dataset.iterator()];
+                case 2:
+                    _a = _b.sent();
+                    _b.label = 3;
+                case 3:
+                    dataIterator = _a;
+                    numExamples = 0;
+                    _loop_1 = function (batch) {
+                        var iteratorOut, xsAndYs, batchOuts, i, batchSize, _loop_3, i;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, dataIterator.next()];
+                                case 1:
+                                    iteratorOut = _a.sent();
+                                    if (iteratorOut.done) {
+                                        console.warn('Your dataset iterator ran out of data during evaluateDataset(). ' +
+                                            'Interrupting evalution. Make sure that your ' +
+                                            'dataset can generate at least `batches` ' +
+                                            ("batches (in this case, " + config.batches + " batches). ") +
+                                            'You may need to use the repeat() function when building ' +
+                                            'your dataset.');
+                                        return [2, "break"];
+                                    }
+                                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                                    batchOuts = tfc.tidy(function () { return f(xsAndYs); });
+                                    tfc.dispose(xsAndYs);
+                                    if (batch === 0) {
+                                        for (i = 0; i < batchOuts.length; ++i) {
+                                            outs.push(state_1.getScalar(0));
+                                        }
+                                    }
+                                    batchSize = xsAndYs[0].shape[0];
+                                    _loop_3 = function (i) {
+                                        var batchOut = batchOuts[i];
+                                        var oldScalar = outs[i];
+                                        outs[i] = tfc.tidy(function () { return tfc.add(outs[i], tfc.mul(state_1.getScalar(batchSize), batchOut)); });
+                                        if (batch > 0) {
+                                            tfc.dispose(oldScalar);
+                                        }
+                                    };
+                                    for (i = 0; i < batchOuts.length; ++i) {
+                                        _loop_3(i);
+                                    }
+                                    tfc.dispose(batchOuts);
+                                    numExamples += batchSize;
+                                    return [2];
+                            }
+                        });
+                    };
+                    batch = 0;
+                    _b.label = 4;
+                case 4:
+                    if (!(batch < config.batches)) return [3, 7];
+                    return [5, _loop_1(batch)];
+                case 5:
+                    state_2 = _b.sent();
+                    if (state_2 === "break")
+                        return [3, 7];
+                    _b.label = 6;
+                case 6:
+                    ++batch;
+                    return [3, 4];
+                case 7:
+                    _loop_2 = function (i) {
+                        var oldScalar = outs[i];
+                        outs[i] =
+                            tfc.tidy(function () { return tfc.div(outs[i], state_1.getScalar(numExamples)); });
+                        tfc.dispose(oldScalar);
+                    };
+                    for (i = 0; i < outs.length; ++i) {
+                        _loop_2(i);
+                    }
+                    return [2, generic_utils_1.singletonOrArray(outs)];
+            }
+        });
+    });
+}
+exports.evaluateDataset = evaluateDataset;
+
+},{"../backend/state":219,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/generic_utils":262,"./dataset_stub":226,"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfjs_backend_1 = require("../backend/tfjs_backend");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var math_utils_1 = require("../utils/math_utils");
+function checkBatchSize(batchSize) {
+    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
+}
+exports.checkBatchSize = checkBatchSize;
+function sliceArrays(arrays, start, stop) {
+    if (arrays == null) {
+        return [null];
+    }
+    else if (Array.isArray(arrays)) {
+        return arrays.map(function (array) { return tfjs_backend_1.sliceAlongFirstAxis(array, start, stop - start); });
+    }
+    else {
+        return tfjs_backend_1.sliceAlongFirstAxis(arrays, start, stop - start);
+    }
+}
+exports.sliceArrays = sliceArrays;
+function sliceArraysByIndices(arrays, indices) {
+    return tfc.tidy(function () {
+        if (arrays == null) {
+            return null;
+        }
+        else if (Array.isArray(arrays)) {
+            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
+        }
+        else {
+            return tfjs_backend_1.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
+        }
+    });
+}
+exports.sliceArraysByIndices = sliceArraysByIndices;
+function makeBatches(size, batchSize) {
+    var output = [];
+    var batchStart = 0;
+    var batchEnd = null;
+    while (batchStart < size) {
+        batchEnd = batchStart + batchSize;
+        if (batchEnd >= size) {
+            batchEnd = size;
+        }
+        output.push([batchStart, batchEnd]);
+        batchStart = batchEnd;
+    }
+    return output;
+}
+exports.makeBatches = makeBatches;
+function fitLoop(model, f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, numTrainSamples, indexArray, _a, callbackList, history, _loop_1, epoch, state_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (batchSize == null) {
+                        batchSize = 32;
+                    }
+                    if (epochs == null) {
+                        epochs = 1;
+                    }
+                    if (shuffle == null) {
+                        shuffle = true;
+                    }
+                    if (initialEpoch == null) {
+                        initialEpoch = 0;
+                    }
+                    doValidation = false;
+                    if (valF != null && valIns != null) {
+                        doValidation = true;
+                    }
+                    if (validationSteps != null) {
+                        doValidation = true;
+                        if (stepsPerEpoch == null) {
+                            throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
+                                'i.e., `stepsPerEpoch` must be set.');
+                        }
+                    }
+                    numTrainSamples = model.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
+                    if (numTrainSamples != null) {
+                        indexArray = math_utils_1.range(0, numTrainSamples);
+                    }
+                    if (verbose == null) {
+                        verbose = 1;
+                    }
+                    _a = base_callbacks_1.configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics), callbackList = _a.callbackList, history = _a.history;
+                    callbackList.setModel(model);
+                    model.history = history;
+                    return [4, callbackList.onTrainBegin()];
+                case 1:
+                    _b.sent();
+                    model.stopTraining_ = false;
+                    _loop_1 = function (epoch) {
+                        var epochLogs, epochIndexArray1D_1, batches_1, _loop_2, batchIndex, state_2;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, callbackList.onEpochBegin(epoch)];
+                                case 1:
+                                    _a.sent();
+                                    epochLogs = {};
+                                    if (!(stepsPerEpoch != null)) return [3, 2];
+                                    throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
+                                case 2:
+                                    if (shuffle === 'batch') {
+                                        throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
+                                    }
+                                    else if (shuffle) {
+                                        tfjs_core_1.util.shuffle(indexArray);
+                                    }
+                                    epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
+                                    batches_1 = makeBatches(numTrainSamples, batchSize);
+                                    _loop_2 = function (batchIndex) {
+                                        var batchLogs;
+                                        return __generator(this, function (_a) {
+                                            switch (_a.label) {
+                                                case 0:
+                                                    batchLogs = {};
+                                                    return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
+                                                case 1:
+                                                    _a.sent();
+                                                    tfc.tidy(function () {
+                                                        var batchStart = batches_1[batchIndex][0];
+                                                        var batchEnd = batches_1[batchIndex][1];
+                                                        var batchIds = tfjs_backend_1.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
+                                                        batchLogs['batch'] = batchIndex;
+                                                        batchLogs['size'] = batchEnd - batchStart;
+                                                        var insBatch = sliceArraysByIndices(ins, batchIds);
+                                                        var outs = f(insBatch);
+                                                        for (var i = 0; i < outLabels.length; ++i) {
+                                                            var label = outLabels[i];
+                                                            var out = outs[i];
+                                                            batchLogs[label] = out;
+                                                            tfc.keep(out);
+                                                        }
+                                                        if (batchIndex === batches_1.length - 1) {
+                                                            if (doValidation) {
+                                                                var valOuts = model.testLoop(valF, valIns, batchSize);
+                                                                for (var i = 0; i < outLabels.length; ++i) {
+                                                                    var label = outLabels[i];
+                                                                    var out = valOuts[i];
+                                                                    tfc.keep(out);
+                                                                    epochLogs['val_' + label] = out;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                                                case 2:
+                                                    _a.sent();
+                                                    logs_1.disposeTensorsInLogs(batchLogs);
+                                                    if (model.stopTraining_) {
+                                                        return [2, "break"];
+                                                    }
+                                                    return [2];
+                                            }
+                                        });
+                                    };
+                                    batchIndex = 0;
+                                    _a.label = 3;
+                                case 3:
+                                    if (!(batchIndex < batches_1.length)) return [3, 6];
+                                    return [5, _loop_2(batchIndex)];
+                                case 4:
+                                    state_2 = _a.sent();
+                                    if (state_2 === "break")
+                                        return [3, 6];
+                                    _a.label = 5;
+                                case 5:
+                                    ++batchIndex;
+                                    return [3, 3];
+                                case 6:
+                                    epochIndexArray1D_1.dispose();
+                                    _a.label = 7;
+                                case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                                case 8:
+                                    _a.sent();
+                                    if (model.stopTraining_) {
+                                        return [2, "break"];
+                                    }
+                                    return [2];
+                            }
+                        });
+                    };
+                    epoch = initialEpoch;
+                    _b.label = 2;
+                case 2:
+                    if (!(epoch < epochs)) return [3, 5];
+                    return [5, _loop_1(epoch)];
+                case 3:
+                    state_1 = _b.sent();
+                    if (state_1 === "break")
+                        return [3, 5];
+                    _b.label = 4;
+                case 4:
+                    ++epoch;
+                    return [3, 2];
+                case 5: return [4, callbackList.onTrainEnd()];
+                case 6:
+                    _b.sent();
+                    return [4, model.history.syncData()];
+                case 7:
+                    _b.sent();
+                    return [2, model.history];
+            }
+        });
+    });
+}
+function fitTensors(model, x, y, config) {
+    if (config === void 0) { config = {}; }
+    return __awaiter(this, void 0, void 0, function () {
+        var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, , 3, 4]);
+                    batchSize = config.batchSize == null ? 32 : config.batchSize;
+                    checkBatchSize(batchSize);
+                    standardizedOuts = model.standardizeUserData(x, y, false, batchSize);
+                    inputs = standardizedOuts[0];
+                    targets = standardizedOuts[1];
+                    doValidation = false;
+                    valX = void 0;
+                    valY = void 0;
+                    valIns = void 0;
+                    needValidationDisposal = false;
+                    if (config.validationData != null && config.validationData.length > 0) {
+                        doValidation = true;
+                        if (config.validationData.length === 2) {
+                            valX = config.validationData[0];
+                            valY = config.validationData[1];
+                        }
+                        else if (config.validationData.length === 3) {
+                            throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
+                        }
+                        else {
+                            throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
+                                "or 3 (valX, valY, valSampleWeight) items; " +
+                                (config.validationData + " is invalid."));
+                        }
+                        valStandardized = model.standardizeUserData(valX, valY, true, batchSize);
+                        valX = valStandardized[0];
+                        valY = valStandardized[1];
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSplit != null && config.validationSplit > 0 &&
+                        config.validationSplit < 1) {
+                        doValidation = true;
+                        splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
+                        originalBatchSize = inputs[0].shape[0];
+                        valX = sliceArrays(inputs, splitAt, originalBatchSize);
+                        inputs = sliceArrays(inputs, 0, splitAt);
+                        valY = sliceArrays(targets, splitAt, originalBatchSize);
+                        targets = sliceArrays(targets, 0, splitAt);
+                        needValidationDisposal = true;
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSteps != null) {
+                        doValidation = true;
+                    }
+                    ins = inputs.concat(targets);
+                    model.checkTrainableWeightsConsistency();
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    valFunction = void 0;
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        model.makeTestFunction();
+                        valFunction = model.testFunction;
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        valFunction = null;
+                        valIns = [];
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    return [4, fitLoop(model, trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
+                case 2:
+                    out = _a.sent();
+                    if (needValidationDisposal) {
+                        valIns.forEach(function (tensor) { return tensor.dispose(); });
+                        inputs.forEach(function (tensor) { return tensor.dispose(); });
+                        targets.forEach(function (tensor) { return tensor.dispose(); });
+                    }
+                    model.isTraining = false;
+                    return [2, out];
+                case 3:
+                    model.isTraining = false;
+                    return [7];
+                case 4: return [2];
+            }
+        });
+    });
+}
+exports.fitTensors = fitTensors;
+
+},{"../backend/tfjs_backend":220,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/math_utils":264,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -30751,12 +32766,13 @@ var IndexError = (function (_super) {
 }(Error));
 exports.IndexError = IndexError;
 
-},{}],211:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
 var training_1 = require("./engine/training");
 var models_1 = require("./models");
+var base_callbacks_1 = require("./base_callbacks");
 function model(config) {
     return new training_1.Model(config);
 }
@@ -30774,8 +32790,12 @@ function input(config) {
     return input_layer_1.Input(config);
 }
 exports.input = input;
+function registerCallbackConstructor(verbosityLevel, callbackConstructor) {
+    base_callbacks_1.CallbackConstructorRegistry.registerCallbackConstructor(verbosityLevel, callbackConstructor);
+}
+exports.registerCallbackConstructor = registerCallbackConstructor;
 
-},{"./engine/input_layer":207,"./engine/training":209,"./models":234}],212:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/input_layer":228,"./engine/training":230,"./models":258}],235:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints_1 = require("./constraints");
@@ -30796,7 +32816,7 @@ function minMaxNorm(config) {
 }
 exports.minMaxNorm = minMaxNorm;
 
-},{"./constraints":204}],213:[function(require,module,exports){
+},{"./constraints":224}],236:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var initializers_1 = require("./initializers");
@@ -30853,7 +32873,7 @@ function orthogonal(config) {
 }
 exports.orthogonal = orthogonal;
 
-},{"./initializers":218}],214:[function(require,module,exports){
+},{"./initializers":242}],237:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
@@ -30982,6 +33002,10 @@ function multiply(config) {
     return new merge_1.Multiply(config);
 }
 exports.multiply = multiply;
+function dot(config) {
+    return new merge_1.Dot(config);
+}
+exports.dot = dot;
 function batchNormalization(config) {
     return new normalization_1.BatchNormalization(config);
 }
@@ -31083,7 +33107,7 @@ exports.globalMaxPool2d = globalMaxPooling2d;
 exports.maxPool1d = maxPooling1d;
 exports.maxPool2d = maxPooling2d;
 
-},{"./engine/input_layer":207,"./engine/topology":208,"./exports":211,"./layers/advanced_activations":219,"./layers/convolutional":220,"./layers/convolutional_depthwise":221,"./layers/core":222,"./layers/embeddings":223,"./layers/merge":224,"./layers/normalization":225,"./layers/padding":226,"./layers/pooling":227,"./layers/recurrent":228,"./layers/wrappers":230}],215:[function(require,module,exports){
+},{"./engine/input_layer":228,"./engine/topology":229,"./exports":234,"./layers/advanced_activations":243,"./layers/convolutional":244,"./layers/convolutional_depthwise":245,"./layers/core":246,"./layers/embeddings":247,"./layers/merge":248,"./layers/normalization":249,"./layers/padding":250,"./layers/pooling":251,"./layers/recurrent":252,"./layers/wrappers":254}],238:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var losses = require("./losses");
@@ -31104,6 +33128,14 @@ function categoricalCrossentropy(yTrue, yPred) {
     return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 exports.categoricalCrossentropy = categoricalCrossentropy;
+function precision(yTrue, yPred) {
+    return metrics.precision(yTrue, yPred);
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return metrics.recall(yTrue, yPred);
+}
+exports.recall = recall;
 function cosineProximity(yTrue, yPred) {
     return losses.cosineProximity(yTrue, yPred);
 }
@@ -31137,7 +33169,13 @@ function mse(yTrue, yPred) {
 }
 exports.mse = mse;
 
-},{"./losses":232,"./metrics":233}],216:[function(require,module,exports){
+},{"./losses":256,"./metrics":257}],239:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var models_1 = require("./models");
+exports.modelFromJSON = models_1.modelFromJSON;
+
+},{"./models":258}],240:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var regularizers = require("./regularizers");
@@ -31155,7 +33193,7 @@ function l2(config) {
 }
 exports.l2 = l2;
 
-},{"./regularizers":236}],217:[function(require,module,exports){
+},{"./regularizers":260}],241:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints = require("./exports_constraints");
@@ -31164,6 +33202,8 @@ var initializers = require("./exports_initializers");
 exports.initializers = initializers;
 var layers = require("./exports_layers");
 exports.layers = layers;
+var models = require("./exports_models");
+exports.models = models;
 var metrics = require("./exports_metrics");
 exports.metrics = metrics;
 var regularizers = require("./exports_regularizers");
@@ -31175,6 +33215,7 @@ exports.History = base_callbacks_1.History;
 var callbacks_1 = require("./callbacks");
 exports.Callback = callbacks_1.Callback;
 var topology_1 = require("./engine/topology");
+exports.InputSpec = topology_1.InputSpec;
 exports.SymbolicTensor = topology_1.SymbolicTensor;
 var training_1 = require("./engine/training");
 exports.Model = training_1.Model;
@@ -31182,6 +33223,7 @@ var exports_1 = require("./exports");
 exports.input = exports_1.input;
 exports.loadModel = exports_1.loadModel;
 exports.model = exports_1.model;
+exports.registerCallbackConstructor = exports_1.registerCallbackConstructor;
 exports.sequential = exports_1.sequential;
 var recurrent_1 = require("./layers/recurrent");
 exports.RNN = recurrent_1.RNN;
@@ -31192,7 +33234,7 @@ exports.LayerVariable = variables_1.LayerVariable;
 var version_1 = require("./version");
 exports.version_layers = version_1.version;
 
-},{"./base_callbacks":201,"./callbacks":202,"./engine/topology":208,"./engine/training":209,"./exports":211,"./exports_constraints":212,"./exports_initializers":213,"./exports_layers":214,"./exports_metrics":215,"./exports_regularizers":216,"./layers/recurrent":228,"./models":234,"./variables":244,"./version":245}],218:[function(require,module,exports){
+},{"./base_callbacks":221,"./callbacks":222,"./engine/topology":229,"./engine/training":230,"./exports":234,"./exports_constraints":235,"./exports_initializers":236,"./exports_layers":237,"./exports_metrics":238,"./exports_models":239,"./exports_regularizers":240,"./layers/recurrent":252,"./models":258,"./variables":268,"./version":269}],242:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31248,7 +33290,7 @@ var Zeros = (function (_super) {
     return Zeros;
 }(Initializer));
 exports.Zeros = Zeros;
-tfjs_core_1.serialization.SerializationMap.register(Zeros);
+tfjs_core_1.serialization.registerClass(Zeros);
 var Ones = (function (_super) {
     __extends(Ones, _super);
     function Ones() {
@@ -31261,7 +33303,7 @@ var Ones = (function (_super) {
     return Ones;
 }(Initializer));
 exports.Ones = Ones;
-tfjs_core_1.serialization.SerializationMap.register(Ones);
+tfjs_core_1.serialization.registerClass(Ones);
 var Constant = (function (_super) {
     __extends(Constant, _super);
     function Constant(config) {
@@ -31288,7 +33330,7 @@ var Constant = (function (_super) {
     return Constant;
 }(Initializer));
 exports.Constant = Constant;
-tfjs_core_1.serialization.SerializationMap.register(Constant);
+tfjs_core_1.serialization.registerClass(Constant);
 var RandomUniform = (function (_super) {
     __extends(RandomUniform, _super);
     function RandomUniform(config) {
@@ -31310,7 +33352,7 @@ var RandomUniform = (function (_super) {
     return RandomUniform;
 }(Initializer));
 exports.RandomUniform = RandomUniform;
-tfjs_core_1.serialization.SerializationMap.register(RandomUniform);
+tfjs_core_1.serialization.registerClass(RandomUniform);
 var RandomNormal = (function (_super) {
     __extends(RandomNormal, _super);
     function RandomNormal(config) {
@@ -31323,8 +33365,9 @@ var RandomNormal = (function (_super) {
         return _this;
     }
     RandomNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
         }
         return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31335,7 +33378,7 @@ var RandomNormal = (function (_super) {
     return RandomNormal;
 }(Initializer));
 exports.RandomNormal = RandomNormal;
-tfjs_core_1.serialization.SerializationMap.register(RandomNormal);
+tfjs_core_1.serialization.registerClass(RandomNormal);
 var TruncatedNormal = (function (_super) {
     __extends(TruncatedNormal, _super);
     function TruncatedNormal(config) {
@@ -31348,8 +33391,9 @@ var TruncatedNormal = (function (_super) {
         return _this;
     }
     TruncatedNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("truncatedNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("truncatedNormal does not support dType " + dtype + ".");
         }
         return tfjs_core_1.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31360,7 +33404,7 @@ var TruncatedNormal = (function (_super) {
     return TruncatedNormal;
 }(Initializer));
 exports.TruncatedNormal = TruncatedNormal;
-tfjs_core_1.serialization.SerializationMap.register(TruncatedNormal);
+tfjs_core_1.serialization.registerClass(TruncatedNormal);
 var Identity = (function (_super) {
     __extends(Identity, _super);
     function Identity(config) {
@@ -31387,7 +33431,7 @@ var Identity = (function (_super) {
     return Identity;
 }(Initializer));
 exports.Identity = Identity;
-tfjs_core_1.serialization.SerializationMap.register(Identity);
+tfjs_core_1.serialization.registerClass(Identity);
 function computeFans(shape, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var fanIn;
@@ -31447,8 +33491,9 @@ var VarianceScaling = (function (_super) {
         }
         if (this.distribution === 'normal') {
             var stddev = Math.sqrt(scale);
-            if (dtype === 'bool') {
-                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType bool.");
+            dtype = dtype || 'float32';
+            if (dtype !== 'float32' && dtype !== 'int32') {
+                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType " + dtype + ".");
             }
             return tfjs_core_1.truncatedNormal(shape, 0, stddev, dtype, this.seed);
         }
@@ -31469,7 +33514,7 @@ var VarianceScaling = (function (_super) {
     return VarianceScaling;
 }(Initializer));
 exports.VarianceScaling = VarianceScaling;
-tfjs_core_1.serialization.SerializationMap.register(VarianceScaling);
+tfjs_core_1.serialization.registerClass(VarianceScaling);
 var GlorotUniform = (function (_super) {
     __extends(GlorotUniform, _super);
     function GlorotUniform(config) {
@@ -31483,9 +33528,11 @@ var GlorotUniform = (function (_super) {
     GlorotUniform.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotUniform.className = 'GlorotUniform';
     return GlorotUniform;
 }(VarianceScaling));
 exports.GlorotUniform = GlorotUniform;
+tfjs_core_1.serialization.registerClass(GlorotUniform);
 var GlorotNormal = (function (_super) {
     __extends(GlorotNormal, _super);
     function GlorotNormal(config) {
@@ -31499,9 +33546,11 @@ var GlorotNormal = (function (_super) {
     GlorotNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotNormal.className = 'GlorotNormal';
     return GlorotNormal;
 }(VarianceScaling));
 exports.GlorotNormal = GlorotNormal;
+tfjs_core_1.serialization.registerClass(GlorotNormal);
 var HeNormal = (function (_super) {
     __extends(HeNormal, _super);
     function HeNormal(config) {
@@ -31515,9 +33564,11 @@ var HeNormal = (function (_super) {
     HeNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    HeNormal.className = 'HeNormal';
     return HeNormal;
 }(VarianceScaling));
 exports.HeNormal = HeNormal;
+tfjs_core_1.serialization.registerClass(HeNormal);
 var LeCunNormal = (function (_super) {
     __extends(LeCunNormal, _super);
     function LeCunNormal(config) {
@@ -31531,9 +33582,11 @@ var LeCunNormal = (function (_super) {
     LeCunNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    LeCunNormal.className = 'LeCunNormal';
     return LeCunNormal;
 }(VarianceScaling));
 exports.LeCunNormal = LeCunNormal;
+tfjs_core_1.serialization.registerClass(LeCunNormal);
 var Orthogonal = (function (_super) {
     __extends(Orthogonal, _super);
     function Orthogonal(config) {
@@ -31576,7 +33629,7 @@ var Orthogonal = (function (_super) {
     return Orthogonal;
 }(Initializer));
 exports.Orthogonal = Orthogonal;
-tfjs_core_1.serialization.SerializationMap.register(Orthogonal);
+tfjs_core_1.serialization.registerClass(Orthogonal);
 exports.INITIALIZER_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'constant': 'Constant',
     'glorotNormal': 'GlorotNormal',
@@ -31631,7 +33684,7 @@ function getInitializer(identifier) {
 }
 exports.getInitializer = getInitializer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./common":203,"./errors":210,"./utils/generic_utils":238,"./utils/math_utils":240,"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./common":223,"./errors":233,"./utils/generic_utils":262,"./utils/math_utils":264,"@tensorflow/tfjs-core":68}],243:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31682,7 +33735,7 @@ var ReLU = (function (_super) {
     return ReLU;
 }(topology_1.Layer));
 exports.ReLU = ReLU;
-tfjs_core_1.serialization.SerializationMap.register(ReLU);
+tfjs_core_1.serialization.registerClass(ReLU);
 var LeakyReLU = (function (_super) {
     __extends(LeakyReLU, _super);
     function LeakyReLU(config) {
@@ -31711,7 +33764,7 @@ var LeakyReLU = (function (_super) {
     return LeakyReLU;
 }(topology_1.Layer));
 exports.LeakyReLU = LeakyReLU;
-tfjs_core_1.serialization.SerializationMap.register(LeakyReLU);
+tfjs_core_1.serialization.registerClass(LeakyReLU);
 var ELU = (function (_super) {
     __extends(ELU, _super);
     function ELU(config) {
@@ -31744,7 +33797,7 @@ var ELU = (function (_super) {
     return ELU;
 }(topology_1.Layer));
 exports.ELU = ELU;
-tfjs_core_1.serialization.SerializationMap.register(ELU);
+tfjs_core_1.serialization.registerClass(ELU);
 var ThresholdedReLU = (function (_super) {
     __extends(ThresholdedReLU, _super);
     function ThresholdedReLU(config) {
@@ -31774,7 +33827,7 @@ var ThresholdedReLU = (function (_super) {
     return ThresholdedReLU;
 }(topology_1.Layer));
 exports.ThresholdedReLU = ThresholdedReLU;
-tfjs_core_1.serialization.SerializationMap.register(ThresholdedReLU);
+tfjs_core_1.serialization.registerClass(ThresholdedReLU);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax(config) {
@@ -31804,9 +33857,9 @@ var Softmax = (function (_super) {
     return Softmax;
 }(topology_1.Layer));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],244:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32121,7 +34174,7 @@ var Conv2D = (function (_super) {
     return Conv2D;
 }(Conv));
 exports.Conv2D = Conv2D;
-tfjs_core_1.serialization.SerializationMap.register(Conv2D);
+tfjs_core_1.serialization.registerClass(Conv2D);
 var Conv2DTranspose = (function (_super) {
     __extends(Conv2DTranspose, _super);
     function Conv2DTranspose(config) {
@@ -32237,7 +34290,7 @@ var Conv2DTranspose = (function (_super) {
     return Conv2DTranspose;
 }(Conv2D));
 exports.Conv2DTranspose = Conv2DTranspose;
-tfjs_core_1.serialization.SerializationMap.register(Conv2DTranspose);
+tfjs_core_1.serialization.registerClass(Conv2DTranspose);
 var SeparableConv = (function (_super) {
     __extends(SeparableConv, _super);
     function SeparableConv(rank, config) {
@@ -32364,7 +34417,7 @@ var SeparableConv2D = (function (_super) {
     return SeparableConv2D;
 }(SeparableConv));
 exports.SeparableConv2D = SeparableConv2D;
-tfjs_core_1.serialization.SerializationMap.register(SeparableConv2D);
+tfjs_core_1.serialization.registerClass(SeparableConv2D);
 var Conv1D = (function (_super) {
     __extends(Conv1D, _super);
     function Conv1D(config) {
@@ -32389,7 +34442,7 @@ var Conv1D = (function (_super) {
     return Conv1D;
 }(Conv));
 exports.Conv1D = Conv1D;
-tfjs_core_1.serialization.SerializationMap.register(Conv1D);
+tfjs_core_1.serialization.registerClass(Conv1D);
 var Cropping2D = (function (_super) {
     __extends(Cropping2D, _super);
     function Cropping2D(config) {
@@ -32413,15 +34466,17 @@ var Cropping2D = (function (_super) {
     Cropping2D.prototype.computeOutputShape = function (inputShape) {
         if (this.dataFormat === 'channelsFirst')
             return [
-                inputShape[0], inputShape[1],
+                inputShape[0],
+                inputShape[1],
                 inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+                inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
             ];
         else
             return [
                 inputShape[0],
                 inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+                inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+                inputShape[3]
             ];
     };
     Cropping2D.prototype.call = function (inputs, kwargs) {
@@ -32448,7 +34503,7 @@ var Cropping2D = (function (_super) {
     return Cropping2D;
 }(topology_1.Layer));
 exports.Cropping2D = Cropping2D;
-tfjs_core_1.serialization.SerializationMap.register(Cropping2D);
+tfjs_core_1.serialization.registerClass(Cropping2D);
 var UpSampling2D = (function (_super) {
     __extends(UpSampling2D, _super);
     function UpSampling2D(config) {
@@ -32501,9 +34556,9 @@ var UpSampling2D = (function (_super) {
     return UpSampling2D;
 }(topology_1.Layer));
 exports.UpSampling2D = UpSampling2D;
-tfjs_core_1.serialization.SerializationMap.register(UpSampling2D);
+tfjs_core_1.serialization.registerClass(UpSampling2D);
 
-},{"../activations":197,"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
+},{"../activations":217,"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32634,9 +34689,9 @@ var DepthwiseConv2D = (function (_super) {
     return DepthwiseConv2D;
 }(convolutional_1.BaseConv));
 exports.DepthwiseConv2D = DepthwiseConv2D;
-tfjs_core_1.serialization.SerializationMap.register(DepthwiseConv2D);
+tfjs_core_1.serialization.registerClass(DepthwiseConv2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],246:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32719,7 +34774,7 @@ var Dropout = (function (_super) {
     return Dropout;
 }(topology_1.Layer));
 exports.Dropout = Dropout;
-tfjs_core_1.serialization.SerializationMap.register(Dropout);
+tfjs_core_1.serialization.registerClass(Dropout);
 var Dense = (function (_super) {
     __extends(Dense, _super);
     function Dense(config) {
@@ -32809,7 +34864,7 @@ var Dense = (function (_super) {
     return Dense;
 }(topology_1.Layer));
 exports.Dense = Dense;
-tfjs_core_1.serialization.SerializationMap.register(Dense);
+tfjs_core_1.serialization.registerClass(Dense);
 var Flatten = (function (_super) {
     __extends(Flatten, _super);
     function Flatten(config) {
@@ -32841,7 +34896,7 @@ var Flatten = (function (_super) {
     return Flatten;
 }(topology_1.Layer));
 exports.Flatten = Flatten;
-tfjs_core_1.serialization.SerializationMap.register(Flatten);
+tfjs_core_1.serialization.registerClass(Flatten);
 var Activation = (function (_super) {
     __extends(Activation, _super);
     function Activation(config) {
@@ -32868,7 +34923,7 @@ var Activation = (function (_super) {
     return Activation;
 }(topology_1.Layer));
 exports.Activation = Activation;
-tfjs_core_1.serialization.SerializationMap.register(Activation);
+tfjs_core_1.serialization.registerClass(Activation);
 var RepeatVector = (function (_super) {
     __extends(RepeatVector, _super);
     function RepeatVector(config) {
@@ -32899,7 +34954,7 @@ var RepeatVector = (function (_super) {
     return RepeatVector;
 }(topology_1.Layer));
 exports.RepeatVector = RepeatVector;
-tfjs_core_1.serialization.SerializationMap.register(RepeatVector);
+tfjs_core_1.serialization.registerClass(RepeatVector);
 var Reshape = (function (_super) {
     __extends(Reshape, _super);
     function Reshape(config) {
@@ -32983,7 +35038,7 @@ var Reshape = (function (_super) {
     return Reshape;
 }(topology_1.Layer));
 exports.Reshape = Reshape;
-tfjs_core_1.serialization.SerializationMap.register(Reshape);
+tfjs_core_1.serialization.registerClass(Reshape);
 var Permute = (function (_super) {
     __extends(Permute, _super);
     function Permute(config) {
@@ -33029,9 +35084,9 @@ var Permute = (function (_super) {
     return Permute;
 }(topology_1.Layer));
 exports.Permute = Permute;
-tfjs_core_1.serialization.SerializationMap.register(Permute);
+tfjs_core_1.serialization.registerClass(Permute);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],223:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],247:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33148,9 +35203,9 @@ var Embedding = (function (_super) {
     return Embedding;
 }(topology_1.Layer));
 exports.Embedding = Embedding;
-tfjs_core_1.serialization.SerializationMap.register(Embedding);
+tfjs_core_1.serialization.registerClass(Embedding);
 
-},{"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],224:[function(require,module,exports){
+},{"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],248:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33169,6 +35224,7 @@ var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
 var topology_1 = require("../engine/topology");
 var errors_1 = require("../errors");
+var losses_1 = require("../losses");
 var generic_utils = require("../utils/generic_utils");
 var mathUtils = require("../utils/math_utils");
 var types_utils_1 = require("../utils/types_utils");
@@ -33346,6 +35402,9 @@ var Merge = (function (_super) {
         }
         return outputShape;
     };
+    Merge.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Merge yet');
+    };
     return Merge;
 }(topology_1.Layer));
 exports.Merge = Merge;
@@ -33367,7 +35426,7 @@ var Add = (function (_super) {
     return Add;
 }(Merge));
 exports.Add = Add;
-tfjs_core_1.serialization.SerializationMap.register(Add);
+tfjs_core_1.serialization.registerClass(Add);
 function add(config) {
     if (Array.isArray(config)) {
         var layer = new Add({});
@@ -33396,7 +35455,7 @@ var Multiply = (function (_super) {
     return Multiply;
 }(Merge));
 exports.Multiply = Multiply;
-tfjs_core_1.serialization.SerializationMap.register(Multiply);
+tfjs_core_1.serialization.registerClass(Multiply);
 function multiply(config) {
     if (Array.isArray(config)) {
         var layer = new Multiply({});
@@ -33425,7 +35484,7 @@ var Average = (function (_super) {
     return Average;
 }(Merge));
 exports.Average = Average;
-tfjs_core_1.serialization.SerializationMap.register(Average);
+tfjs_core_1.serialization.registerClass(Average);
 function average(config) {
     if (Array.isArray(config)) {
         var layer = new Average({});
@@ -33454,7 +35513,7 @@ var Maximum = (function (_super) {
     return Maximum;
 }(Merge));
 exports.Maximum = Maximum;
-tfjs_core_1.serialization.SerializationMap.register(Maximum);
+tfjs_core_1.serialization.registerClass(Maximum);
 function maximum(config) {
     if (Array.isArray(config)) {
         var layer = new Maximum({});
@@ -33483,7 +35542,7 @@ var Minimum = (function (_super) {
     return Minimum;
 }(Merge));
 exports.Minimum = Minimum;
-tfjs_core_1.serialization.SerializationMap.register(Minimum);
+tfjs_core_1.serialization.registerClass(Minimum);
 function minimum(config) {
     if (Array.isArray(config)) {
         var layer = new Minimum({});
@@ -33570,6 +35629,9 @@ var Concatenate = (function (_super) {
         }
         return outputShape;
     };
+    Concatenate.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Concatenate yet');
+    };
     Concatenate.prototype.getConfig = function () {
         var config = {
             'axis': this.axis,
@@ -33582,7 +35644,7 @@ var Concatenate = (function (_super) {
     return Concatenate;
 }(Merge));
 exports.Concatenate = Concatenate;
-tfjs_core_1.serialization.SerializationMap.register(Concatenate);
+tfjs_core_1.serialization.registerClass(Concatenate);
 function concatenate(config) {
     if (Array.isArray(config)) {
         var layer = new Concatenate({});
@@ -33593,8 +35655,184 @@ function concatenate(config) {
     }
 }
 exports.concatenate = concatenate;
+function interpretAxis(axis, dim) {
+    while (axis < 0) {
+        axis += dim;
+    }
+    return axis;
+}
+function batchDot(x, y, axes) {
+    if (x.shape.length > 3 || y.shape.length > 3) {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for tensors of 4D or higher rank yet');
+    }
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of x to be >= 2, " +
+        ("but got " + x.shape.length));
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of y to be >= 2, " +
+        ("but got " + y.shape.length));
+    if (typeof axes === 'number') {
+        axes = [axes, axes];
+    }
+    if (x.dtype === 'complex64' || y.dtype === 'complex64') {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for complex64-type Tensors yet.');
+    }
+    var xNDim = x.shape.length;
+    var yNDim = y.shape.length;
+    if (axes == null) {
+        axes = [xNDim - 1, yNDim - 2];
+    }
+    var axesArray = axes;
+    return tfc.tidy(function () {
+        var diff;
+        if (xNDim > yNDim) {
+            diff = xNDim - yNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            y = y.reshape(y.shape.concat(diffShape));
+        }
+        else if (yNDim > xNDim) {
+            diff = yNDim - xNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            x = x.reshape(x.shape.concat(diffShape));
+        }
+        else {
+            diff = 0;
+        }
+        var out;
+        if (x.shape.length === 2 && y.shape.length === 2) {
+            if (axesArray[0] === axesArray[1]) {
+                out = x.mulStrict(y).sum(axesArray[0]);
+            }
+            else {
+                out = x.transpose([1, 0]).mulStrict(y).sum(axesArray[1]);
+            }
+        }
+        else {
+            var adjX = axesArray[0] === x.shape.length - 1 ? null : true;
+            var adjY = axesArray[1] === y.shape.length - 1 ? true : null;
+            out = x.matMul(y, adjX, adjY);
+        }
+        if (diff > 0) {
+            var idx = void 0;
+            if (xNDim > yNDim) {
+                idx = xNDim + yNDim - 3;
+            }
+            else {
+                idx = xNDim - 1;
+            }
+            var squeezeAxes = [];
+            for (var i = idx; i < idx + diff; ++i) {
+                squeezeAxes.push(i);
+            }
+            out = out.squeeze(squeezeAxes);
+        }
+        if (out.shape.length === 1) {
+            out = out.expandDims(1);
+        }
+        return out;
+    });
+}
+var Dot = (function (_super) {
+    __extends(Dot, _super);
+    function Dot(config) {
+        var _this = _super.call(this, config) || this;
+        _this.axes = config.axes;
+        _this.normalize = config.normalize == null ? false : config.normalize;
+        _this.supportsMasking = true;
+        _this.reshapeRequired = false;
+        return _this;
+    }
+    Dot.prototype.build = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0];
+        var shape2 = inputShape[1];
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        if (shape1[axes[0]] !== shape2[axes[1]]) {
+            throw new errors_1.ValueError("Dimension incompatibility: " +
+                (shape1[axes[0]] + " !== " + shape2[axes[1]]));
+        }
+    };
+    Dot.prototype.mergeFunction = function (inputs) {
+        if (inputs.length !== 2) {
+            throw new errors_1.ValueError('A `Dot` layer must be called on exactly 2 inputs, ' +
+                ("but received " + inputs.length + " input(s)."));
+        }
+        var x1 = inputs[0];
+        var x2 = inputs[1];
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, x1.shape.length),
+                interpretAxis(this.axes, x2.shape.length)
+            ];
+        }
+        else {
+            axes = this.axes.map(function (axis, i) { return interpretAxis(axis, inputs[i].shape.length); });
+        }
+        if (this.normalize) {
+            x1 = losses_1.l2Normalize(x1, axes[0]);
+            x2 = losses_1.l2Normalize(x2, axes[1]);
+        }
+        return batchDot(x1, x2, axes);
+    };
+    Dot.prototype.interpretAxes = function (shape1, shape2) {
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, shape1.length),
+                interpretAxis(this.axes, shape2.length)
+            ];
+        }
+        else {
+            axes = this.axes;
+        }
+        return axes;
+    };
+    Dot.prototype.computeOutputShape = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0].slice();
+        var shape2 = inputShape[1].slice();
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        shape1.splice(axes[0], 1);
+        shape2.splice(axes[1], 1);
+        shape2.splice(0, 1);
+        var outputShape = shape1.concat(shape2);
+        if (outputShape.length === 1) {
+            outputShape.push(1);
+        }
+        return outputShape;
+    };
+    Dot.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Dot yet');
+    };
+    Dot.prototype.getConfig = function () {
+        var config = {
+            'axes': this.axes,
+            'normalize': this.normalize
+        };
+        var baseConfig = _super.prototype.getConfig.call(this);
+        Object.assign(config, baseConfig);
+        return config;
+    };
+    Dot.className = 'Dot';
+    return Dot;
+}(Merge));
+exports.Dot = Dot;
+tfjs_core_1.serialization.registerClass(Dot);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../losses":256,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],249:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33631,7 +35869,7 @@ function batchNormalization(x, mean, variance, beta, gamma, epsilon) {
         out = tfc.batchNormalization4d(x, mean, variance, epsilon, gamma, beta);
     }
     else {
-        throw new errors_1.NotImplementedError("batchNormalization is not implememnted for array of rank " + x.rank + " " +
+        throw new errors_1.NotImplementedError("batchNormalization is not implemented for array of rank " + x.rank + " " +
             "yet");
     }
     return out;
@@ -33684,7 +35922,11 @@ exports.normalizeBatchInTraining = normalizeBatchInTraining;
 var BatchNormalization = (function (_super) {
     __extends(BatchNormalization, _super);
     function BatchNormalization(config) {
-        var _this = _super.call(this, config) || this;
+        var _this = this;
+        if (config == null) {
+            config = {};
+        }
+        _this = _super.call(this, config) || this;
         _this.supportsMasking = true;
         _this.axis = config.axis == null ? -1 : config.axis;
         _this.momentum = config.momentum == null ? 0.99 : config.momentum;
@@ -33795,9 +36037,9 @@ var BatchNormalization = (function (_super) {
     return BatchNormalization;
 }(topology_1.Layer));
 exports.BatchNormalization = BatchNormalization;
-tfjs_core_1.serialization.SerializationMap.register(BatchNormalization);
+tfjs_core_1.serialization.registerClass(BatchNormalization);
 
-},{"../backend/state":199,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+},{"../backend/state":219,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],250:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33967,9 +36209,9 @@ var ZeroPadding2D = (function (_super) {
     return ZeroPadding2D;
 }(topology_1.Layer));
 exports.ZeroPadding2D = ZeroPadding2D;
-tfjs_core_1.serialization.SerializationMap.register(ZeroPadding2D);
+tfjs_core_1.serialization.registerClass(ZeroPadding2D);
 
-},{"../backend/common":198,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],227:[function(require,module,exports){
+},{"../backend/common":218,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],251:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34111,7 +36353,7 @@ var MaxPooling1D = (function (_super) {
     return MaxPooling1D;
 }(Pooling1D));
 exports.MaxPooling1D = MaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling1D);
+tfjs_core_1.serialization.registerClass(MaxPooling1D);
 var AveragePooling1D = (function (_super) {
     __extends(AveragePooling1D, _super);
     function AveragePooling1D(config) {
@@ -34126,7 +36368,7 @@ var AveragePooling1D = (function (_super) {
     return AveragePooling1D;
 }(Pooling1D));
 exports.AveragePooling1D = AveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling1D);
+tfjs_core_1.serialization.registerClass(AveragePooling1D);
 var Pooling2D = (function (_super) {
     __extends(Pooling2D, _super);
     function Pooling2D(config) {
@@ -34210,7 +36452,7 @@ var MaxPooling2D = (function (_super) {
     return MaxPooling2D;
 }(Pooling2D));
 exports.MaxPooling2D = MaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling2D);
+tfjs_core_1.serialization.registerClass(MaxPooling2D);
 var AveragePooling2D = (function (_super) {
     __extends(AveragePooling2D, _super);
     function AveragePooling2D(config) {
@@ -34225,7 +36467,7 @@ var AveragePooling2D = (function (_super) {
     return AveragePooling2D;
 }(Pooling2D));
 exports.AveragePooling2D = AveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling2D);
+tfjs_core_1.serialization.registerClass(AveragePooling2D);
 var GlobalPooling1D = (function (_super) {
     __extends(GlobalPooling1D, _super);
     function GlobalPooling1D(config) {
@@ -34257,7 +36499,7 @@ var GlobalAveragePooling1D = (function (_super) {
     return GlobalAveragePooling1D;
 }(GlobalPooling1D));
 exports.GlobalAveragePooling1D = GlobalAveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling1D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling1D);
 var GlobalMaxPooling1D = (function (_super) {
     __extends(GlobalMaxPooling1D, _super);
     function GlobalMaxPooling1D(config) {
@@ -34273,7 +36515,7 @@ var GlobalMaxPooling1D = (function (_super) {
     return GlobalMaxPooling1D;
 }(GlobalPooling1D));
 exports.GlobalMaxPooling1D = GlobalMaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling1D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling1D);
 var GlobalPooling2D = (function (_super) {
     __extends(GlobalPooling2D, _super);
     function GlobalPooling2D(config) {
@@ -34326,7 +36568,7 @@ var GlobalAveragePooling2D = (function (_super) {
     return GlobalAveragePooling2D;
 }(GlobalPooling2D));
 exports.GlobalAveragePooling2D = GlobalAveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling2D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling2D);
 var GlobalMaxPooling2D = (function (_super) {
     __extends(GlobalMaxPooling2D, _super);
     function GlobalMaxPooling2D() {
@@ -34348,9 +36590,9 @@ var GlobalMaxPooling2D = (function (_super) {
     return GlobalMaxPooling2D;
 }(GlobalPooling2D));
 exports.GlobalMaxPooling2D = GlobalMaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling2D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],252:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34406,9 +36648,10 @@ function standardizeArgs(inputs, initialState, constants, numConstants) {
     return { inputs: inputs, initialState: initialState, constants: constants };
 }
 exports.standardizeArgs = standardizeArgs;
-function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, inputLength) {
+function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, needPerStepOutputs) {
     if (goBackwards === void 0) { goBackwards = false; }
     if (unroll === void 0) { unroll = false; }
+    if (needPerStepOutputs === void 0) { needPerStepOutputs = false; }
     var ndim = inputs.shape.length;
     if (ndim < 3) {
         throw new errors_1.ValueError("Input should be at least 3D, but is " + ndim + "D.");
@@ -34434,24 +36677,27 @@ function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, 
     var lastOutput;
     var states = initialStates;
     var timeSteps = inputs.shape[0];
-    for (var t = 0; t < timeSteps; ++t) {
+    var _loop_1 = function (t) {
         var currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
         currentInput = currentInput.reshape(currentInput.shape.slice(1));
-        var stepOutputs = stepFunction(currentInput, states);
+        var stepOutputs = tfc.tidy(function () { return stepFunction(currentInput, states); });
         lastOutput = stepOutputs[0];
-        if (t === 0) {
-            outputs = lastOutput.reshape([1].concat(lastOutput.shape));
-        }
-        else {
-            outputs = K.concatAlongFirstAxis(outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        if (needPerStepOutputs) {
+            if (t === 0) {
+                outputs = lastOutput.expandDims(1);
+            }
+            else {
+                var newOutputs = tfc.concat([outputs, lastOutput.expandDims(1)], 1);
+                outputs.dispose();
+                outputs = newOutputs;
+            }
         }
         states = stepOutputs[1];
+    };
+    for (var t = 0; t < timeSteps; ++t) {
+        _loop_1(t);
     }
-    return [
-        lastOutput,
-        tfc.transpose(outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
-        states
-    ];
+    return [lastOutput, outputs, states];
 }
 exports.rnn = rnn;
 var RNN = (function (_super) {
@@ -34700,8 +36946,6 @@ var RNN = (function (_super) {
                 throw new errors_1.ValueError("RNN Layer has " + numStates + " state(s) but was passed " +
                     (initialState.length + " initial state(s)."));
             }
-            var inputShape = inputs.shape;
-            var timesteps = inputShape[1];
             if (_this.unroll) {
                 console.warn('Ignoring unroll = true for RNN layer, due to imperative backend.');
             }
@@ -34710,7 +36954,7 @@ var RNN = (function (_super) {
                 var outputs = _this.cell.call([inputs].concat(states), cellCallKwargs);
                 return [outputs[0], outputs.slice(1)];
             };
-            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, timesteps);
+            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, _this.returnSequences);
             var lastOutput = rnnOutputs[0];
             var outputs = rnnOutputs[1];
             var states = rnnOutputs[2];
@@ -34786,7 +37030,7 @@ var RNN = (function (_super) {
     return RNN;
 }(topology_2.Layer));
 exports.RNN = RNN;
-tfjs_core_1.serialization.SerializationMap.register(RNN);
+tfjs_core_1.serialization.registerClass(RNN);
 var RNNCell = (function (_super) {
     __extends(RNNCell, _super);
     function RNNCell() {
@@ -34905,7 +37149,7 @@ var SimpleRNNCell = (function (_super) {
     return SimpleRNNCell;
 }(RNNCell));
 exports.SimpleRNNCell = SimpleRNNCell;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNNCell);
+tfjs_core_1.serialization.registerClass(SimpleRNNCell);
 var SimpleRNN = (function (_super) {
     __extends(SimpleRNN, _super);
     function SimpleRNN(config) {
@@ -35056,7 +37300,7 @@ var SimpleRNN = (function (_super) {
     return SimpleRNN;
 }(RNN));
 exports.SimpleRNN = SimpleRNN;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNN);
+tfjs_core_1.serialization.registerClass(SimpleRNN);
 var GRUCell = (function (_super) {
     __extends(GRUCell, _super);
     function GRUCell(config) {
@@ -35231,7 +37475,7 @@ var GRUCell = (function (_super) {
     return GRUCell;
 }(RNNCell));
 exports.GRUCell = GRUCell;
-tfjs_core_1.serialization.SerializationMap.register(GRUCell);
+tfjs_core_1.serialization.registerClass(GRUCell);
 var GRU = (function (_super) {
     __extends(GRU, _super);
     function GRU(config) {
@@ -35408,7 +37652,7 @@ var GRU = (function (_super) {
     return GRU;
 }(RNN));
 exports.GRU = GRU;
-tfjs_core_1.serialization.SerializationMap.register(GRU);
+tfjs_core_1.serialization.registerClass(GRU);
 var LSTMCell = (function (_super) {
     __extends(LSTMCell, _super);
     function LSTMCell(config) {
@@ -35618,7 +37862,7 @@ var LSTMCell = (function (_super) {
     return LSTMCell;
 }(RNNCell));
 exports.LSTMCell = LSTMCell;
-tfjs_core_1.serialization.SerializationMap.register(LSTMCell);
+tfjs_core_1.serialization.registerClass(LSTMCell);
 var LSTM = (function (_super) {
     __extends(LSTM, _super);
     function LSTM(config) {
@@ -35803,7 +38047,7 @@ var LSTM = (function (_super) {
     return LSTM;
 }(RNN));
 exports.LSTM = LSTM;
-tfjs_core_1.serialization.SerializationMap.register(LSTM);
+tfjs_core_1.serialization.registerClass(LSTM);
 var StackedRNNCells = (function (_super) {
     __extends(StackedRNNCells, _super);
     function StackedRNNCells(config) {
@@ -35967,7 +38211,7 @@ var StackedRNNCells = (function (_super) {
     return StackedRNNCells;
 }(RNNCell));
 exports.StackedRNNCells = StackedRNNCells;
-tfjs_core_1.serialization.SerializationMap.register(StackedRNNCells);
+tfjs_core_1.serialization.registerClass(StackedRNNCells);
 function generateDropoutMask(ones, rate, training, count) {
     if (training === void 0) { training = null; }
     if (count === void 0) { count = 1; }
@@ -35987,7 +38231,7 @@ function generateDropoutMask(ones, rate, training, count) {
     }
 }
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"../variables":244,"./serialization":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"../variables":268,"./serialization":253,"@tensorflow/tfjs-core":68}],253:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -35998,7 +38242,7 @@ function deserialize(config, customObjects) {
 }
 exports.deserialize = deserialize;
 
-},{"../utils/generic_utils":238,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
+},{"../utils/generic_utils":262,"@tensorflow/tfjs-core":68}],254:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36139,10 +38383,10 @@ var TimeDistributed = (function (_super) {
         return tfjs_core_1.tidy(function () {
             inputs = types_utils_1.getExactlyOneTensor(inputs);
             var step = function (inputs, states) {
-                var output = _this.layer.call(inputs, kwargs);
+                var output = types_utils_1.getExactlyOneTensor(_this.layer.call(inputs, kwargs));
                 return [output, []];
             };
-            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, true);
             var y = rnnOutputs[1];
             return y;
         });
@@ -36151,7 +38395,7 @@ var TimeDistributed = (function (_super) {
     return TimeDistributed;
 }(Wrapper));
 exports.TimeDistributed = TimeDistributed;
-tfjs_core_1.serialization.SerializationMap.register(TimeDistributed);
+tfjs_core_1.serialization.registerClass(TimeDistributed);
 exports.VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
 function checkBidirectionalMergeMode(value) {
     generic_utils.checkStringTypeUnionValue(exports.VALID_BIDIRECTIONAL_MERGE_MODES, 'BidirectionalMergeMode', value);
@@ -36322,7 +38566,7 @@ var Bidirectional = (function (_super) {
                 var forwardState = initialState.slice(0, initialState.length / 2);
                 var backwardState = initialState.slice(initialState.length / 2);
                 y = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: forwardState }));
-                yRev = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
+                yRev = _this.backwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
             }
             var states;
             if (_this.returnState) {
@@ -36413,9 +38657,9 @@ var Bidirectional = (function (_super) {
     return Bidirectional;
 }(Wrapper));
 exports.Bidirectional = Bidirectional;
-tfjs_core_1.serialization.SerializationMap.register(Bidirectional);
+tfjs_core_1.serialization.registerClass(Bidirectional);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"./recurrent":228,"./serialization":229,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"./recurrent":252,"./serialization":253,"@tensorflow/tfjs-core":68}],255:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36501,14 +38745,14 @@ function disposeTensorsInLogs(logs) {
 }
 exports.disposeTensorsInLogs = disposeTensorsInLogs;
 
-},{"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],256:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var common_1 = require("./backend/common");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 function l2Normalize(x, axis) {
     return tfjs_core_1.tidy(function () {
@@ -36685,7 +38929,13 @@ function get(identifierOrFn) {
         if (identifierOrFn in lossesMap) {
             return lossesMap[identifierOrFn];
         }
-        throw new errors_1.ValueError("Unknown loss " + identifierOrFn);
+        var errMsg = "Unknown loss " + identifierOrFn;
+        if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+            errMsg = "Unknown loss " + identifierOrFn + ". " +
+                'Use "categoricalCrossentropy" as the string name for ' +
+                'tf.losses.softmaxCrossEntropy';
+        }
+        throw new errors_1.ValueError(errMsg);
     }
     else {
         return identifierOrFn;
@@ -36693,13 +38943,13 @@ function get(identifierOrFn) {
 }
 exports.get = get;
 
-},{"./backend/common":198,"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"@tensorflow/tfjs-core":68}],257:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 var losses_1 = require("./losses");
 var losses_2 = require("./losses");
@@ -36715,6 +38965,54 @@ function categoricalAccuracy(yTrue, yPred) {
     return tfjs_core_1.tidy(function () { return K.cast(tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'); });
 }
 exports.categoricalAccuracy = categoricalAccuracy;
+function truePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function falseNegatives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(zero))
+            .sum()
+            .cast('float32');
+    });
+}
+function falsePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function precision(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fp = falsePositives(yTrue, yPred);
+        var denominator = tp.add(fp);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fn = falseNegatives(yTrue, yPred);
+        var denominator = tp.add(fn);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.recall = recall;
 function binaryCrossentropy(yTrue, yPred) {
     return losses_2.binaryCrossentropy(yTrue, yPred);
 }
@@ -36744,6 +39042,7 @@ function get(identifier) {
     var metricsMap = {
         binaryAccuracy: binaryAccuracy,
         categoricalAccuracy: categoricalAccuracy,
+        precision: precision,
         categoricalCrossentropy: exports.categoricalCrossentropy,
         sparseCategoricalCrossentropy: exports.sparseCategoricalCrossentropy,
         mse: exports.mse,
@@ -36766,7 +39065,7 @@ function get(identifier) {
 }
 exports.get = get;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"./losses":232,"@tensorflow/tfjs-core":68}],234:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"./losses":256,"@tensorflow/tfjs-core":68}],258:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36830,6 +39129,10 @@ function modelFromJSON(modelAndWeightsConfig, customObjects) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
+                    if (!('modelTopology' in modelAndWeightsConfig)) {
+                        modelAndWeightsConfig = { modelTopology: modelAndWeightsConfig };
+                    }
+                    modelAndWeightsConfig = modelAndWeightsConfig;
                     modelTopology = modelAndWeightsConfig.modelTopology;
                     if (modelTopology['model_config'] != null) {
                         modelTopology = modelTopology['model_config'];
@@ -36928,6 +39231,14 @@ var Sequential = (function (_super) {
         }
         return _this;
     }
+    Sequential.prototype.checkShape = function (layer) {
+        var shape = layer.inboundNodes[0].outputTensors[0].shape;
+        if (shape.some(function (x) { return x < 0; })) {
+            throw new errors_1.ValueError('Negative dimension size caused by adding layer ' +
+                (layer.name + " with input shape [") +
+                (layer.inboundNodes[0].inputTensors[0].shape + "]"));
+        }
+    };
     Sequential.prototype.add = function (layer) {
         var isLayerModelInstance = layer instanceof Sequential || layer instanceof training_1.Model;
         var modelLayer;
@@ -36976,6 +39287,7 @@ var Sequential = (function (_super) {
                         'For multi-output layers, ' +
                         'use the functional API.');
                 }
+                this.checkShape(layer);
                 this.outputs = [layer.inboundNodes[0].outputTensors[0]];
                 this.inputs = topology_1.getSourceInputs(this.outputs[0]);
             }
@@ -37001,6 +39313,7 @@ var Sequential = (function (_super) {
                     'For multi-output layers, ' +
                     'use the functional API.');
             }
+            this.checkShape(layer);
             this.outputs = [outputTensor];
             this.inboundNodes[0].outputTensors = this.outputs;
             this.inboundNodes[0].outputShapes = [this.outputs[0].shape];
@@ -37097,6 +39410,16 @@ var Sequential = (function (_super) {
         }
         return this.model.evaluate(x, y, config);
     };
+    Sequential.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before being used.');
+                }
+                return [2, this.model.evaluateDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.prototype.predict = function (x, config) {
         if (config === void 0) { config = {}; }
         if (this.model == null) {
@@ -37131,19 +39454,40 @@ var Sequential = (function (_super) {
             });
         });
     };
+    Sequential.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before ' +
+                        'being used.');
+                }
+                return [2, this.model.fitDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.fromConfig = function (cls, config) {
-        var model = new cls({});
+        var configArray;
+        var extraModelConfig = {};
+        if (config instanceof Array) {
+            if (!(config[0].className != null) ||
+                config[0]['className'] === 'Merge') {
+                throw new errors_1.ValueError('Legacy serialization format not supported yet.');
+            }
+            configArray = config;
+        }
+        else {
+            tfjs_core_1.util.assert(config['layers'] != null, "When the config data for a Sequential model is not an Array, " +
+                "it must be an Object that contains the 'layers' field.");
+            configArray = config['layers'];
+            delete config['layers'];
+            extraModelConfig = config;
+        }
+        var model = new cls(extraModelConfig);
         if (!(model instanceof Sequential)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called on non-Sequential input: " + model);
+            throw new errors_1.NotImplementedError("Sequential.fromConfig called on non-Sequential input: " + model);
         }
-        if (!(config instanceof Array)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called without an array of configs");
-        }
-        if (!(config[0].className != null) || config[0]['className'] === 'Merge') {
-            throw new errors_1.ValueError('Legacy serialization format not supported yet.');
-        }
-        for (var _i = 0, _a = config; _i < _a.length; _i++) {
-            var conf = _a[_i];
+        for (var _i = 0, configArray_1 = configArray; _i < configArray_1.length; _i++) {
+            var conf = configArray_1[_i];
             var layer = serialization_1.deserialize(conf);
             model.add(layer);
         }
@@ -37171,9 +39515,9 @@ var Sequential = (function (_super) {
     return Sequential;
 }(training_1.Model));
 exports.Sequential = Sequential;
-tfjs_core_1.serialization.SerializationMap.register(Sequential);
+tfjs_core_1.serialization.registerClass(Sequential);
 
-},{"./backend/state":199,"./engine/input_layer":207,"./engine/topology":208,"./engine/training":209,"./errors":210,"./layers/serialization":229,"./utils/generic_utils":238,"./utils/serialization_utils":241,"./utils/types_utils":242,"@tensorflow/tfjs-core":68}],235:[function(require,module,exports){
+},{"./backend/state":219,"./engine/input_layer":228,"./engine/topology":229,"./engine/training":230,"./errors":233,"./layers/serialization":253,"./utils/generic_utils":262,"./utils/serialization_utils":265,"./utils/types_utils":266,"@tensorflow/tfjs-core":68}],259:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -37201,7 +39545,7 @@ function getOptimizer(identifier) {
 }
 exports.getOptimizer = getOptimizer;
 
-},{"./backend/common":198,"./errors":210,"@tensorflow/tfjs-core":68}],236:[function(require,module,exports){
+},{"./backend/common":218,"./errors":233,"@tensorflow/tfjs-core":68}],260:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37263,7 +39607,7 @@ var L1L2 = (function (_super) {
     return L1L2;
 }(Regularizer));
 exports.L1L2 = L1L2;
-tfjs_core_1.serialization.SerializationMap.register(L1L2);
+tfjs_core_1.serialization.registerClass(L1L2);
 function l1(config) {
     return new L1L2({ l1: config != null ? config.l1 : null, l2: 0 });
 }
@@ -37304,7 +39648,7 @@ function getRegularizer(identifier) {
 }
 exports.getRegularizer = getRegularizer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],237:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],261:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37364,7 +39708,7 @@ function deconvLength(dimSize, strideSize, kernelSize, padding) {
 }
 exports.deconvLength = deconvLength;
 
-},{"../errors":210,"./generic_utils":238,"./math_utils":240}],238:[function(require,module,exports){
+},{"../errors":233,"./generic_utils":262,"./math_utils":264}],262:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -37633,7 +39977,7 @@ function checkArrayTypeAndLength(x, expectedType, minLength, maxLength) {
 }
 exports.checkArrayTypeAndLength = checkArrayTypeAndLength;
 
-},{"../errors":210}],239:[function(require,module,exports){
+},{"../errors":233}],263:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var variable_utils_1 = require("./variable_utils");
@@ -37793,7 +40137,7 @@ function printLayerSummaryWithConnections(layer, positions, relevantNodes, print
     }
 }
 
-},{"./variable_utils":243}],240:[function(require,module,exports){
+},{"./variable_utils":267}],264:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -37865,7 +40209,7 @@ function range(begin, end) {
 }
 exports.range = range;
 
-},{"../errors":210,"@tensorflow/tfjs-core":68}],241:[function(require,module,exports){
+},{"../errors":233,"@tensorflow/tfjs-core":68}],265:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils = require("../utils/generic_utils");
@@ -37959,7 +40303,7 @@ function convertTsToPythonic(tsConfig, key) {
 }
 exports.convertTsToPythonic = convertTsToPythonic;
 
-},{"../utils/generic_utils":238}],242:[function(require,module,exports){
+},{"../utils/generic_utils":262}],266:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -38007,7 +40351,7 @@ function getExactlyOneShape(shapes) {
 }
 exports.getExactlyOneShape = getExactlyOneShape;
 
-},{"../errors":210}],243:[function(require,module,exports){
+},{"../errors":233}],267:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function countParamsInWeights(weights) {
@@ -38025,7 +40369,7 @@ function countParamsInWeights(weights) {
 }
 exports.countParamsInWeights = countParamsInWeights;
 
-},{}],244:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38118,8 +40462,9 @@ function truncatedNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'truncatedNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38128,8 +40473,9 @@ function randomNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'randomNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38164,13 +40510,13 @@ function gradients(lossFn, variables) {
 }
 exports.gradients = gradients;
 
-},{"./backend/state":199,"./common":203,"./errors":210,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
+},{"./backend/state":219,"./common":223,"./errors":233,"@tensorflow/tfjs-core":68}],269:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.7.5';
+var version = '0.8.3';
 exports.version = version;
 
-},{}],246:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -38190,13 +40536,13 @@ exports.version = {
     'tfjs': version_1.version
 };
 
-},{"./version":247,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":217}],247:[function(require,module,exports){
+},{"./version":271,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":241}],271:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.7';
+var version = '0.13.3';
 exports.version = version;
 
-},{}],248:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -38314,7 +40660,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],249:[function(require,module,exports){
+},{}],273:[function(require,module,exports){
 /**
  * Bit twiddling hacks for JavaScript.
  *
@@ -38520,9 +40866,9 @@ exports.nextCombination = function(v) {
 }
 
 
-},{}],250:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 
-},{}],251:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -40260,7 +42606,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":248,"ieee754":259}],252:[function(require,module,exports){
+},{"base64-js":272,"ieee754":283}],276:[function(require,module,exports){
 "use strict"
 
 var createThunk = require("./lib/thunk.js")
@@ -40371,7 +42717,7 @@ function compileCwise(user_args) {
 
 module.exports = compileCwise
 
-},{"./lib/thunk.js":254}],253:[function(require,module,exports){
+},{"./lib/thunk.js":278}],277:[function(require,module,exports){
 "use strict"
 
 var uniq = require("uniq")
@@ -40731,7 +43077,7 @@ function generateCWiseOp(proc, typesig) {
 }
 module.exports = generateCWiseOp
 
-},{"uniq":300}],254:[function(require,module,exports){
+},{"uniq":324}],278:[function(require,module,exports){
 "use strict"
 
 // The function below is called when constructing a cwise function object, and does the following:
@@ -40819,9 +43165,9 @@ function createThunk(proc) {
 
 module.exports = createThunk
 
-},{"./compile.js":253}],255:[function(require,module,exports){
+},{"./compile.js":277}],279:[function(require,module,exports){
 module.exports = require("cwise-compiler")
-},{"cwise-compiler":252}],256:[function(require,module,exports){
+},{"cwise-compiler":276}],280:[function(require,module,exports){
 "use strict"
 
 function dupe_array(count, value, i) {
@@ -40871,7 +43217,7 @@ function dupe(count, value) {
 }
 
 module.exports = dupe
-},{}],257:[function(require,module,exports){
+},{}],281:[function(require,module,exports){
 'use strict';
 
 function FFT(size) {
@@ -41380,7 +43726,7 @@ FFT.prototype._singleRealTransform4 = function _singleRealTransform4(outOff,
   out[outOff + 7] = FDi;
 };
 
-},{}],258:[function(require,module,exports){
+},{}],282:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 1.3.2
@@ -41570,7 +43916,7 @@ if (typeof module !== "undefined" && module.exports) {
   });
 }
 
-},{}],259:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -41656,7 +44002,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],260:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 "use strict"
 
 function iota(n) {
@@ -41668,7 +44014,7 @@ function iota(n) {
 }
 
 module.exports = iota
-},{}],261:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -41691,10 +44037,10 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],262:[function(require,module,exports){
+},{}],286:[function(require,module,exports){
 !function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.MidiConvert=e():t.MidiConvert=e()}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="",e(e.s=7)}([function(t,e,n){"use strict";n.d(e,"a",function(){return r}),n.d(e,"b",function(){return i}),n.d(e,"c",function(){return a});var r=["acoustic grand piano","bright acoustic piano","electric grand piano","honky-tonk piano","electric piano 1","electric piano 2","harpsichord","clavi","celesta","glockenspiel","music box","vibraphone","marimba","xylophone","tubular bells","dulcimer","drawbar organ","percussive organ","rock organ","church organ","reed organ","accordion","harmonica","tango accordion","acoustic guitar (nylon)","acoustic guitar (steel)","electric guitar (jazz)","electric guitar (clean)","electric guitar (muted)","overdriven guitar","distortion guitar","guitar harmonics","acoustic bass","electric bass (finger)","electric bass (pick)","fretless bass","slap bass 1","slap bass 2","synth bass 1","synth bass 2","violin","viola","cello","contrabass","tremolo strings","pizzicato strings","orchestral harp","timpani","string ensemble 1","string ensemble 2","synthstrings 1","synthstrings 2","choir aahs","voice oohs","synth voice","orchestra hit","trumpet","trombone","tuba","muted trumpet","french horn","brass section","synthbrass 1","synthbrass 2","soprano sax","alto sax","tenor sax","baritone sax","oboe","english horn","bassoon","clarinet","piccolo","flute","recorder","pan flute","blown bottle","shakuhachi","whistle","ocarina","lead 1 (square)","lead 2 (sawtooth)","lead 3 (calliope)","lead 4 (chiff)","lead 5 (charang)","lead 6 (voice)","lead 7 (fifths)","lead 8 (bass + lead)","pad 1 (new age)","pad 2 (warm)","pad 3 (polysynth)","pad 4 (choir)","pad 5 (bowed)","pad 6 (metallic)","pad 7 (halo)","pad 8 (sweep)","fx 1 (rain)","fx 2 (soundtrack)","fx 3 (crystal)","fx 4 (atmosphere)","fx 5 (brightness)","fx 6 (goblins)","fx 7 (echoes)","fx 8 (sci-fi)","sitar","banjo","shamisen","koto","kalimba","bag pipe","fiddle","shanai","tinkle bell","agogo","steel drums","woodblock","taiko drum","melodic tom","synth drum","reverse cymbal","guitar fret noise","breath noise","seashore","bird tweet","telephone ring","helicopter","applause","gunshot"],i=["piano","chromatic percussion","organ","guitar","bass","strings","ensemble","brass","reed","pipe","synth lead","synth pad","synth effects","ethnic","percussive","sound effects"],a={0:"standard kit",8:"room kit",16:"power kit",24:"electronic kit",25:"tr-808 kit",32:"jazz kit",40:"brush kit",48:"orchestra kit",56:"sound fx kit"}},function(t,e,n){"use strict";function r(t){return t.replace(/\u0000/g,"")}function i(t,e){return 60/e.bpm*(t/e.PPQ)}function a(t){return"number"==typeof t}function o(t){return"string"==typeof t}function s(t){return["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"][t%12]+(Math.floor(t/12)-1)}e.b=r,e.a=i,e.c=a,n.d(e,"d",function(){return u}),e.e=s,n.d(e,"f",function(){return c});var u=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i;return function(e){return o(e)&&t.test(e)}}(),c=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,e={cbb:-2,cb:-1,c:0,"c#":1,cx:2,dbb:0,db:1,d:2,"d#":3,dx:4,ebb:2,eb:3,e:4,"e#":5,ex:6,fbb:3,fb:4,f:5,"f#":6,fx:7,gbb:5,gb:6,g:7,"g#":8,gx:9,abb:7,ab:8,a:9,"a#":10,ax:11,bbb:9,bb:10,b:11,"b#":12,bx:13};return function(n){var r=t.exec(n),i=r[1],a=r[2];return e[i.toLowerCase()]+12*(parseInt(a)+1)}}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(11),a=(n.n(i),n(10)),o=(n.n(a),n(1)),s=n(9),u=n(5),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(){r(this,t),this.header={bpm:120,timeSignature:[4,4],PPQ:480},this.tracks=[]}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t;return n.header=e.header,e.tracks.forEach(function(t){var e=s.a.fromJSON(t);n.tracks.push(e)}),n}}]),c(t,[{key:"load",value:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:null,r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"GET";return new Promise(function(i,a){var o=new XMLHttpRequest;o.open(r,t),o.responseType="arraybuffer",o.addEventListener("load",function(){4===o.readyState&&200===o.status?i(e.decode(o.response)):a(o.status)}),o.addEventListener("error",a),o.send(n)}).catch(function(t){console.log(t)})}},{key:"decode",value:function(t){var e=this;if(t instanceof ArrayBuffer){var r=new Uint8Array(t);t=String.fromCharCode.apply(null,r)}var a=i(t);return this.header=n.i(u.a)(a),this.tracks=[],a.tracks.forEach(function(t,n){var r=new s.a;r.id=n,e.tracks.push(r);var i=0;t.forEach(function(t){i+=o.a(t.deltaTime,e.header),"meta"===t.type&&"trackName"===t.subtype?r.name=o.b(t.text):"noteOn"===t.subtype?(r.noteOn(t.noteNumber,i,t.velocity/127),-1===r.channelNumber&&(r.channelNumber=t.channel)):"noteOff"===t.subtype?r.noteOff(t.noteNumber,i):"controller"===t.subtype&&t.controllerType?r.cc(t.controllerType,i,t.value/127):"meta"===t.type&&"instrumentName"===t.subtype?r.instrument=t.text:"channel"===t.type&&"programChange"===t.subtype&&(r.patch(t.programNumber),r.channelNumber=t.channel)}),e.header.name||r.length||!r.name||(e.header.name=r.name)}),this}},{key:"encode",value:function(){var t=this,e=new a.File({ticks:this.header.PPQ}),n=this.tracks.filter(function(t){return!t.length})[0];if(this.header.name&&(!n||n.name!==this.header.name)){e.addTrack().addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:this.header.name}))}return this.tracks.forEach(function(n){var r=e.addTrack();r.setTempo(t.bpm),n.name&&r.addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:n.name})),n.encode(r,t.header)}),e.toBytes()}},{key:"toArray",value:function(){for(var t=this.encode(),e=new Array(t.length),n=0;n<t.length;n++)e[n]=t.charCodeAt(n);return e}},{key:"toJSON",value:function(){var t={header:this.header,startTime:this.startTime,duration:this.duration,tracks:(this.tracks||[]).map(function(t){return t.toJSON()})};return t.header.name||(t.header.name=""),t}},{key:"track",value:function(t){var e=new s.a(t);return this.tracks.push(e),e}},{key:"get",value:function(t){return o.c(t)?this.tracks[t]:this.tracks.find(function(e){return e.name===t})}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=new t;return r.header=this.header,r.tracks=this.tracks.map(function(t){return t.slice(e,n)}),r}},{key:"startTime",get:function(){var t=this.tracks.map(function(t){return t.startTime});return t.length?Math.min.apply(Math,t)||0:0}},{key:"bpm",get:function(){return this.header.bpm},set:function(t){var e=this.header.bpm;this.header.bpm=t;var n=e/t;this.tracks.forEach(function(t){return t.scale(n)})}},{key:"timeSignature",get:function(){return this.header.timeSignature},set:function(t){this.header.timeSignature=t}},{key:"duration",get:function(){var t=this.tracks.map(function(t){return t.duration});return t.length?Math.max.apply(Math,t)||0:0}}]),t}()},function(t,e,n){"use strict";function r(t,e){var n=0,r=t.length,i=r;if(r>0&&t[r-1].time<=e)return r-1;for(;n<i;){var a=Math.floor(n+(i-n)/2),o=t[a],s=t[a+1];if(o.time===e){for(var u=a;u<t.length;u++){t[u].time===e&&(a=u)}return a}if(o.time<e&&s.time>e)return a;o.time>e?i=a:o.time<e&&(n=a+1)}return-1}function i(t,e){if(t.length){var n=r(t,e.time);t.splice(n+1,0,e)}else t.push(e)}n.d(e,"a",function(){return i})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),a={1:"modulationWheel",2:"breath",4:"footController",5:"portamentoTime",7:"volume",8:"balance",10:"pan",64:"sustain",65:"portamentoTime",66:"sostenuto",67:"softPedal",68:"legatoFootswitch",84:"portamentoContro"},o=function(){function t(e,n,i){r(this,t),this.number=e,this.time=n,this.value=i}return i(t,[{key:"name",get:function(){if(a.hasOwnProperty(this.number))return a[this.number]}}]),t}()},function(t,e,n){"use strict";function r(t){for(var e={PPQ:t.header.ticksPerBeat},n=0;n<t.tracks.length;n++)for(var r=t.tracks[n],i=0;i<r.length;i++){var a=r[i];"meta"===a.type&&("timeSignature"===a.subtype?e.timeSignature=[a.numerator,a.denominator]:"setTempo"===a.subtype&&(e.bpm||(e.bpm=6e7/a.microsecondsPerBeat)))}return e.bpm=e.bpm||120,e}n.d(e,"a",function(){return r})},function(t,e,n){"use strict";function r(t,e){for(var n=0;n<t.length;n++){var r=t[n],i=e[n];if(r.length>i)return!0}return!1}function i(t,e,n){for(var r=0,i=1/0,a=0;a<t.length;a++){var o=t[a],s=e[a];o[s]&&o[s].time<i&&(r=a,i=o[s].time)}n[r](t[r][e[r]]),e[r]+=1}function a(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];for(var a=e.filter(function(t,e){return e%2==0}),o=new Uint32Array(a.length),s=e.filter(function(t,e){return e%2==1});r(a,o);)i(a,o,s)}n.d(e,"a",function(){return a})},function(t,e,n){"use strict";function r(t){return(new s.a).decode(t)}function i(t,e){var n=(new s.a).load(t);return e&&n.then(e),n}function a(){return new s.a}function o(t){return s.a.fromJSON(t)}Object.defineProperty(e,"__esModule",{value:!0}),e.parse=r,e.load=i,e.create=a,e.fromJSON=o;var s=n(2),u=n(0);n.d(e,"instrumentByPatchID",function(){return u.a}),n.d(e,"instrumentFamilyByID",function(){return u.b}),n.d(e,"drumKitByPatchID",function(){return u.c})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=n(1),a=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),o=function(){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1;if(r(this,t),i.c(e))this.midi=e;else{if(!i.d(e))throw new Error("the midi value must either be in Pitch Notation (e.g. C#4) or a midi value");this.name=e}this.time=n,this.duration=a,this.velocity=o}return a(t,null,[{key:"fromJSON",value:function(e){return new t(e.midi,e.time,e.duration,e.velocity)}}]),a(t,[{key:"match",value:function(t){return i.c(t)?this.midi===t:i.d(t)?this.name.toLowerCase()===t.toLowerCase():void 0}},{key:"toJSON",value:function(){return{name:this.name,midi:this.midi,time:this.time,velocity:this.velocity,duration:this.duration}}},{key:"name",get:function(){return i.e(this.midi)},set:function(t){this.midi=i.f(t)}},{key:"noteOn",get:function(){return this.time},set:function(t){this.time=t}},{key:"noteOff",get:function(){return this.time+this.duration},set:function(t){this.duration=t-this.time}}]),t}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(3),a=n(4),o=n(6),s=n(8),u=n(0),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:-1,i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:-1;r(this,t),this.name=e,this.channelNumber=i,this.notes=[],this.controlChanges={},this.instrumentNumber=n}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t(e.name,e.instrumentNumber,e.channelNumber);return n.id=e.id,e.notes&&e.notes.forEach(function(t){var e=s.a.fromJSON(t);n.notes.push(e)}),e.controlChanges&&(n.controlChanges=e.controlChanges),n}}]),c(t,[{key:"note",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,a=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1,o=new s.a(t,e,r,a);return n.i(i.a)(this.notes,o),this}},{key:"noteOn",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:1,a=new s.a(t,e,0,r);return n.i(i.a)(this.notes,a),this}},{key:"noteOff",value:function(t,e){for(var n=0;n<this.notes.length;n++){var r=this.notes[n];if(r.match(t)&&0===r.duration){r.noteOff=e;break}}return this}},{key:"cc",value:function(t,e,r){this.controlChanges.hasOwnProperty(t)||(this.controlChanges[t]=[]);var o=new a.a(t,e,r);return n.i(i.a)(this.controlChanges[t],o),this}},{key:"patch",value:function(t){return this.instrumentNumber=t,this}},{key:"channel",value:function(t){return this.channelNumber=t,this}},{key:"scale",value:function(t){return this.notes.forEach(function(e){e.time*=t,e.duration*=t}),this}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=Math.max(this.notes.findIndex(function(t){return t.time>=e}),0),i=this.notes.findIndex(function(t){return t.noteOff>=n})+1,a=new t(this.name);return a.notes=this.notes.slice(r,i),a.notes.forEach(function(t){return t.time=t.time-e}),a}},{key:"encode",value:function(t,e){function r(t){var e=Math.floor(i*t),n=Math.max(e-a,0);return a=e,n}var i=e.PPQ/(60/e.bpm),a=0,s=Math.max(0,this.channelNumber);-1!==this.instrumentNumber&&t.instrument(s,this.instrumentNumber),n.i(o.a)(this.noteOns.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOn(s,e.name,r(e.time),Math.floor(127*e.velocity))},this.noteOffs.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOff(s,e.name,r(e.time))})}},{key:"toJSON",value:function(){var t={startTime:this.startTime,duration:this.duration,length:this.length,notes:[],controlChanges:{}};return void 0!==this.id&&(t.id=this.id),t.name=this.name,-1!==this.instrumentNumber&&(t.instrumentNumber=this.instrumentNumber,t.instrument=this.instrument,t.instrumentFamily=this.instrumentFamily),-1!==this.channelNumber&&(t.channelNumber=this.channelNumber,t.isPercussion=this.isPercussion),this.notes.length&&(t.notes=this.notes.map(function(t){return t.toJSON()})),Object.keys(this.controlChanges).length&&(t.controlChanges=this.controlChanges),t}},{key:"noteOns",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOn,midi:e.midi,name:e.name,velocity:e.velocity})}),t}},{key:"noteOffs",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOff,midi:e.midi,name:e.name})}),t}},{key:"length",get:function(){return this.notes.length}},{key:"startTime",get:function(){if(this.notes.length){return this.notes[0].noteOn}return 0}},{key:"duration",get:function(){if(this.notes.length){return this.notes[this.notes.length-1].noteOff}return 0}},{key:"instrument",get:function(){return this.isPercussion?u.c[this.instrumentNumber]:u.a[this.instrumentNumber]},set:function(t){var e=u.a.indexOf(t);-1!==e&&(this.instrumentNumber=e)}},{key:"isPercussion",get:function(){return[9,10].includes(this.channelNumber)}},{key:"instrumentFamily",get:function(){return this.isPercussion?"drums":u.b[Math.floor(this.instrumentNumber/8)]}}]),t}()},function(t,e,n){(function(t){var n={};!function(t){var e=t.DEFAULT_VOLUME=90,n=(t.DEFAULT_DURATION=128,t.DEFAULT_CHANNEL=0,{midi_letter_pitches:{a:21,b:23,c:12,d:14,e:16,f:17,g:19},midiPitchFromNote:function(t){var e=/([a-g])(#+|b+)?([0-9]+)$/i.exec(t),r=e[1].toLowerCase(),i=e[2]||"";return 12*parseInt(e[3],10)+n.midi_letter_pitches[r]+("#"==i.substr(0,1)?1:-1)*i.length},ensureMidiPitch:function(t){return"number"!=typeof t&&/[^0-9]/.test(t)?n.midiPitchFromNote(t):parseInt(t,10)},midi_pitches_letter:{12:"c",13:"c#",14:"d",15:"d#",16:"e",17:"f",18:"f#",19:"g",20:"g#",21:"a",22:"a#",23:"b"},midi_flattened_notes:{"a#":"bb","c#":"db","d#":"eb","f#":"gb","g#":"ab"},noteFromMidiPitch:function(t,e){var r,i=0,a=t,e=e||!1;return t>23&&(i=Math.floor(t/12)-1,a=t-12*i),r=n.midi_pitches_letter[a],e&&r.indexOf("#")>0&&(r=n.midi_flattened_notes[r]),r+i},mpqnFromBpm:function(t){var e=Math.floor(6e7/t),n=[];do{n.unshift(255&e),e>>=8}while(e);for(;n.length<3;)n.push(0);return n},bpmFromMpqn:function(t){var e=t;if(void 0!==t[0]){e=0;for(var n=0,r=t.length-1;r>=0;++n,--r)e|=t[n]<<r}return Math.floor(6e7/t)},codes2Str:function(t){return String.fromCharCode.apply(null,t)},str2Bytes:function(t,e){if(e)for(;t.length/2<e;)t="0"+t;for(var n=[],r=t.length-1;r>=0;r-=2){var i=0===r?t[r]:t[r-1]+t[r];n.unshift(parseInt(i,16))}return n},translateTickTime:function(t){for(var e=127&t;t>>=7;)e<<=8,e|=127&t|128;for(var n=[];;){if(n.push(255&e),!(128&e))break;e>>=8}return n}}),r=function(t){if(!this)return new r(t);!t||null===t.type&&void 0===t.type||null===t.channel&&void 0===t.channel||null===t.param1&&void 0===t.param1||(this.setTime(t.time),this.setType(t.type),this.setChannel(t.channel),this.setParam1(t.param1),this.setParam2(t.param2))};r.NOTE_OFF=128,r.NOTE_ON=144,r.AFTER_TOUCH=160,r.CONTROLLER=176,r.PROGRAM_CHANGE=192,r.CHANNEL_AFTERTOUCH=208,r.PITCH_BEND=224,r.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},r.prototype.setType=function(t){if(t<r.NOTE_OFF||t>r.PITCH_BEND)throw new Error("Trying to set an unknown event: "+t);this.type=t},r.prototype.setChannel=function(t){if(t<0||t>15)throw new Error("Channel is out of bounds.");this.channel=t},r.prototype.setParam1=function(t){this.param1=t},r.prototype.setParam2=function(t){this.param2=t},r.prototype.toBytes=function(){var t=[],e=this.type|15&this.channel;return t.push.apply(t,this.time),t.push(e),t.push(this.param1),void 0!==this.param2&&null!==this.param2&&t.push(this.param2),t};var i=function(t){if(!this)return new i(t);this.setTime(t.time),this.setType(t.type),this.setData(t.data)};i.SEQUENCE=0,i.TEXT=1,i.COPYRIGHT=2,i.TRACK_NAME=3,i.INSTRUMENT=4,i.LYRIC=5,i.MARKER=6,i.CUE_POINT=7,i.CHANNEL_PREFIX=32,i.END_OF_TRACK=47,i.TEMPO=81,i.SMPTE=84,i.TIME_SIG=88,i.KEY_SIG=89,i.SEQ_EVENT=127,i.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},i.prototype.setType=function(t){this.type=t},i.prototype.setData=function(t){this.data=t},i.prototype.toBytes=function(){if(!this.type)throw new Error("Type for meta-event not specified.");var t=[];if(t.push.apply(t,this.time),t.push(255,this.type),Array.isArray(this.data))t.push(this.data.length),t.push.apply(t,this.data);else if("number"==typeof this.data)t.push(1,this.data);else if(null!==this.data&&void 0!==this.data){t.push(this.data.length);var e=this.data.split("").map(function(t){return t.charCodeAt(0)});t.push.apply(t,e)}else t.push(0);return t};var a=function(t){if(!this)return new a(t);var e=t||{};this.events=e.events||[]};a.START_BYTES=[77,84,114,107],a.END_BYTES=[0,255,47,0],a.prototype.addEvent=function(t){return this.events.push(t),this},a.prototype.addNoteOn=a.prototype.noteOn=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_ON,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNoteOff=a.prototype.noteOff=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_OFF,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNote=a.prototype.note=function(t,e,n,r,i){return this.noteOn(t,e,r,i),n&&this.noteOff(t,e,n,i),this},a.prototype.addChord=a.prototype.chord=function(t,e,n,r){if(!Array.isArray(e)&&!e.length)throw new Error("Chord must be an array of pitches");return e.forEach(function(e){this.noteOn(t,e,0,r)},this),e.forEach(function(e,r){0===r?this.noteOff(t,e,n):this.noteOff(t,e)},this),this},a.prototype.setInstrument=a.prototype.instrument=function(t,e,n){return this.events.push(new r({type:r.PROGRAM_CHANGE,channel:t,param1:e,time:n||0})),this},a.prototype.setTempo=a.prototype.tempo=function(t,e){return this.events.push(new i({type:i.TEMPO,data:n.mpqnFromBpm(t),time:e||0})),this},a.prototype.toBytes=function(){var t=0,e=[],r=a.START_BYTES,i=a.END_BYTES,o=function(n){var r=n.toBytes();t+=r.length,e.push.apply(e,r)};this.events.forEach(o),t+=i.length;var s=n.str2Bytes(t.toString(16),4);return r.concat(s,e,i)};var o=function(t){if(!this)return new o(t);var e=t||{};if(e.ticks){if("number"!=typeof e.ticks)throw new Error("Ticks per beat must be a number!");if(e.ticks<=0||e.ticks>=32768||e.ticks%1!=0)throw new Error("Ticks per beat must be an integer between 1 and 32767!")}this.ticks=e.ticks||128,this.tracks=e.tracks||[]};o.HDR_CHUNKID="MThd",o.HDR_CHUNK_SIZE="\0\0\0",o.HDR_TYPE0="\0\0",o.HDR_TYPE1="\0",o.prototype.addTrack=function(t){return t?(this.tracks.push(t),this):(t=new a,this.tracks.push(t),t)},o.prototype.toBytes=function(){var t=this.tracks.length.toString(16),e=o.HDR_CHUNKID+o.HDR_CHUNK_SIZE;return parseInt(t,16)>1?e+=o.HDR_TYPE1:e+=o.HDR_TYPE0,e+=n.codes2Str(n.str2Bytes(t,2)),e+=String.fromCharCode(this.ticks/256,this.ticks%256),this.tracks.forEach(function(t){e+=n.codes2Str(t.toBytes())}),e},t.Util=n,t.File=o,t.Track=a,t.Event=r,t.MetaEvent=i}(n),void 0!==t&&null!==t?t.exports=n:void 0!==e&&null!==e?e=n:this.Midi=n}).call(e,n(12)(t))},function(t,e){function n(t){function e(t){var e=t.read(4),n=t.readInt32();return{id:e,length:n,data:t.read(n)}}var n;stream=r(t);var i=e(stream);if("MThd"!=i.id||6!=i.length)throw"Bad .mid file - header not found";var a=r(i.data),o=a.readInt16(),s=a.readInt16(),u=a.readInt16();if(32768&u)throw"Expressing time division in SMTPE frames is not supported yet";ticksPerBeat=u;for(var c={formatType:o,trackCount:s,ticksPerBeat:ticksPerBeat},h=[],f=0;f<c.trackCount;f++){h[f]=[];var d=e(stream);if("MTrk"!=d.id)throw"Unexpected chunk - expected MTrk, got "+d.id;for(var l=r(d.data);!l.eof();){var p=function(t){var e={};e.deltaTime=t.readVarInt();var r=t.readInt8();if(240==(240&r)){if(255==r){e.type="meta";var i=t.readInt8(),a=t.readVarInt();switch(i){case 0:if(e.subtype="sequenceNumber",2!=a)throw"Expected length for sequenceNumber event is 2, got "+a;return e.number=t.readInt16(),e;case 1:return e.subtype="text",e.text=t.read(a),e;case 2:return e.subtype="copyrightNotice",e.text=t.read(a),e;case 3:return e.subtype="trackName",e.text=t.read(a),e;case 4:return e.subtype="instrumentName",e.text=t.read(a),e;case 5:return e.subtype="lyrics",e.text=t.read(a),e;case 6:return e.subtype="marker",e.text=t.read(a),e;case 7:return e.subtype="cuePoint",e.text=t.read(a),e;case 32:if(e.subtype="midiChannelPrefix",1!=a)throw"Expected length for midiChannelPrefix event is 1, got "+a;return e.channel=t.readInt8(),e;case 47:if(e.subtype="endOfTrack",0!=a)throw"Expected length for endOfTrack event is 0, got "+a;return e;case 81:if(e.subtype="setTempo",3!=a)throw"Expected length for setTempo event is 3, got "+a;return e.microsecondsPerBeat=(t.readInt8()<<16)+(t.readInt8()<<8)+t.readInt8(),e;case 84:if(e.subtype="smpteOffset",5!=a)throw"Expected length for smpteOffset event is 5, got "+a;var o=t.readInt8();return e.frameRate={0:24,32:25,64:29,96:30}[96&o],e.hour=31&o,e.min=t.readInt8(),e.sec=t.readInt8(),e.frame=t.readInt8(),e.subframe=t.readInt8(),e;case 88:if(e.subtype="timeSignature",4!=a)throw"Expected length for timeSignature event is 4, got "+a;return e.numerator=t.readInt8(),e.denominator=Math.pow(2,t.readInt8()),e.metronome=t.readInt8(),e.thirtyseconds=t.readInt8(),e;case 89:if(e.subtype="keySignature",2!=a)throw"Expected length for keySignature event is 2, got "+a;return e.key=t.readInt8(!0),e.scale=t.readInt8(),e;case 127:return e.subtype="sequencerSpecific",e.data=t.read(a),e;default:return e.subtype="unknown",e.data=t.read(a),e}return e.data=t.read(a),e}if(240==r){e.type="sysEx";var a=t.readVarInt();return e.data=t.read(a),e}if(247==r){e.type="dividedSysEx";var a=t.readVarInt();return e.data=t.read(a),e}throw"Unrecognised MIDI event type byte: "+r}var s;0==(128&r)?(s=r,r=n):(s=t.readInt8(),n=r);var u=r>>4;switch(e.channel=15&r,e.type="channel",u){case 8:return e.subtype="noteOff",e.noteNumber=s,e.velocity=t.readInt8(),e;case 9:return e.noteNumber=s,e.velocity=t.readInt8(),0==e.velocity?e.subtype="noteOff":e.subtype="noteOn",e;case 10:return e.subtype="noteAftertouch",e.noteNumber=s,e.amount=t.readInt8(),e;case 11:return e.subtype="controller",e.controllerType=s,e.value=t.readInt8(),e;case 12:return e.subtype="programChange",e.programNumber=s,e;case 13:return e.subtype="channelAftertouch",e.amount=s,e;case 14:return e.subtype="pitchBend",e.value=s+(t.readInt8()<<7),e;default:throw"Unrecognised MIDI event type: "+u}}(l);h[f].push(p)}}return{header:c,tracks:h}}function r(t){function e(e){var n=t.substr(s,e);return s+=e,n}function n(){var e=(t.charCodeAt(s)<<24)+(t.charCodeAt(s+1)<<16)+(t.charCodeAt(s+2)<<8)+t.charCodeAt(s+3);return s+=4,e}function r(){var e=(t.charCodeAt(s)<<8)+t.charCodeAt(s+1);return s+=2,e}function i(e){var n=t.charCodeAt(s);return e&&n>127&&(n-=256),s+=1,n}function a(){return s>=t.length}function o(){for(var t=0;;){var e=i();if(!(128&e))return t+e;t+=127&e,t<<=7}}var s=0;return{eof:a,read:e,readInt32:n,readInt16:r,readInt8:i,readVarInt:o}}t.exports=function(t){return n(t)}},function(t,e){t.exports=function(t){return t.webpackPolyfill||(t.deprecate=function(){},t.paths=[],t.children||(t.children=[]),Object.defineProperty(t,"loaded",{enumerable:!0,get:function(){return t.l}}),Object.defineProperty(t,"id",{enumerable:!0,get:function(){return t.i}}),t.webpackPolyfill=1),t}}])});
 
-},{}],263:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 'use strict'
 
 var ops = require('ndarray-ops')
@@ -41777,7 +44123,7 @@ function ndfft(dir, x, y) {
 }
 
 module.exports = ndfft
-},{"./lib/fft-matrix.js":264,"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],264:[function(require,module,exports){
+},{"./lib/fft-matrix.js":288,"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],288:[function(require,module,exports){
 var bits = require('bit-twiddle')
 
 function fft(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
@@ -41996,7 +44342,7 @@ function fftBluestein(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
   }
 }
 
-},{"bit-twiddle":249}],265:[function(require,module,exports){
+},{"bit-twiddle":273}],289:[function(require,module,exports){
 "use strict"
 
 var compile = require("cwise-compiler")
@@ -42459,7 +44805,7 @@ exports.equals = compile({
 
 
 
-},{"cwise-compiler":252}],266:[function(require,module,exports){
+},{"cwise-compiler":276}],290:[function(require,module,exports){
 "use strict"
 
 var fft = require("ndarray-fft")
@@ -42563,7 +44909,7 @@ function resample(out, inp, clamp_lo, clamp_hi) {
 }
 
 module.exports = resample
-},{"cwise/lib/wrapper":255,"ndarray-fft":263,"ndarray-ops":265,"ndarray-scratch":267}],267:[function(require,module,exports){
+},{"cwise/lib/wrapper":279,"ndarray-fft":287,"ndarray-ops":289,"ndarray-scratch":291}],291:[function(require,module,exports){
 "use strict"
 
 var ndarray = require("ndarray")
@@ -42671,7 +45017,7 @@ function eye(shape, dtype) {
 }
 exports.eye = eye
 
-},{"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],268:[function(require,module,exports){
+},{"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],292:[function(require,module,exports){
 var iota = require("iota-array")
 var isBuffer = require("is-buffer")
 
@@ -43016,7 +45362,7 @@ function wrappedNDArrayCtor(data, shape, stride, offset) {
 
 module.exports = wrappedNDArrayCtor
 
-},{"iota-array":260,"is-buffer":261}],269:[function(require,module,exports){
+},{"iota-array":284,"is-buffer":285}],293:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -43202,9 +45548,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],270:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 arguments[4][50][0].apply(exports,arguments)
-},{"./src/index-minimal":271,"dup":50}],271:[function(require,module,exports){
+},{"./src/index-minimal":295,"dup":50}],295:[function(require,module,exports){
 "use strict";
 var protobuf = exports;
 
@@ -43242,7 +45588,7 @@ function configure() {
 protobuf.Writer._configure(protobuf.BufferWriter);
 configure();
 
-},{"./reader":272,"./reader_buffer":273,"./roots":274,"./rpc":275,"./util/minimal":278,"./writer":279,"./writer_buffer":280}],272:[function(require,module,exports){
+},{"./reader":296,"./reader_buffer":297,"./roots":298,"./rpc":299,"./util/minimal":302,"./writer":303,"./writer_buffer":304}],296:[function(require,module,exports){
 "use strict";
 module.exports = Reader;
 
@@ -43651,17 +45997,17 @@ Reader._configure = function(BufferReader_) {
     });
 };
 
-},{"./util/minimal":278}],273:[function(require,module,exports){
+},{"./util/minimal":302}],297:[function(require,module,exports){
 arguments[4][53][0].apply(exports,arguments)
-},{"./reader":272,"./util/minimal":278,"dup":53}],274:[function(require,module,exports){
+},{"./reader":296,"./util/minimal":302,"dup":53}],298:[function(require,module,exports){
 arguments[4][54][0].apply(exports,arguments)
-},{"dup":54}],275:[function(require,module,exports){
+},{"dup":54}],299:[function(require,module,exports){
 arguments[4][55][0].apply(exports,arguments)
-},{"./rpc/service":276,"dup":55}],276:[function(require,module,exports){
+},{"./rpc/service":300,"dup":55}],300:[function(require,module,exports){
 arguments[4][56][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":56}],277:[function(require,module,exports){
+},{"../util/minimal":302,"dup":56}],301:[function(require,module,exports){
 arguments[4][57][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":57}],278:[function(require,module,exports){
+},{"../util/minimal":302,"dup":57}],302:[function(require,module,exports){
 (function (global){
 "use strict";
 var util = exports;
@@ -44070,11 +46416,11 @@ util._configure = function() {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./longbits":277,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],279:[function(require,module,exports){
+},{"./longbits":301,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],303:[function(require,module,exports){
 arguments[4][59][0].apply(exports,arguments)
-},{"./util/minimal":278,"dup":59}],280:[function(require,module,exports){
+},{"./util/minimal":302,"dup":59}],304:[function(require,module,exports){
 arguments[4][60][0].apply(exports,arguments)
-},{"./util/minimal":278,"./writer":279,"dup":60}],281:[function(require,module,exports){
+},{"./util/minimal":302,"./writer":303,"dup":60}],305:[function(require,module,exports){
 // A library of seedable RNGs implemented in Javascript.
 //
 // Usage:
@@ -44136,7 +46482,7 @@ sr.tychei = tychei;
 
 module.exports = sr;
 
-},{"./lib/alea":282,"./lib/tychei":283,"./lib/xor128":284,"./lib/xor4096":285,"./lib/xorshift7":286,"./lib/xorwow":287,"./seedrandom":288}],282:[function(require,module,exports){
+},{"./lib/alea":306,"./lib/tychei":307,"./lib/xor128":308,"./lib/xor4096":309,"./lib/xorshift7":310,"./lib/xorwow":311,"./seedrandom":312}],306:[function(require,module,exports){
 // A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
 // http://baagoe.com/en/RandomMusings/javascript/
 // https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
@@ -44252,7 +46598,7 @@ if (module && module.exports) {
 
 
 
-},{}],283:[function(require,module,exports){
+},{}],307:[function(require,module,exports){
 // A Javascript implementaion of the "Tyche-i" prng algorithm by
 // Samuel Neves and Filipe Araujo.
 // See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
@@ -44357,7 +46703,7 @@ if (module && module.exports) {
 
 
 
-},{}],284:[function(require,module,exports){
+},{}],308:[function(require,module,exports){
 // A Javascript implementaion of the "xor128" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44440,7 +46786,7 @@ if (module && module.exports) {
 
 
 
-},{}],285:[function(require,module,exports){
+},{}],309:[function(require,module,exports){
 // A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
 //
 // This fast non-cryptographic random number generator is designed for
@@ -44588,7 +46934,7 @@ if (module && module.exports) {
   (typeof define) == 'function' && define   // present with an AMD loader
 );
 
-},{}],286:[function(require,module,exports){
+},{}],310:[function(require,module,exports){
 // A Javascript implementaion of the "xorshift7" algorithm by
 // François Panneton and Pierre L'ecuyer:
 // "On the Xorgshift Random Number Generators"
@@ -44687,7 +47033,7 @@ if (module && module.exports) {
 );
 
 
-},{}],287:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 // A Javascript implementaion of the "xorwow" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44775,7 +47121,7 @@ if (module && module.exports) {
 
 
 
-},{}],288:[function(require,module,exports){
+},{}],312:[function(require,module,exports){
 /*
 Copyright 2014 David Bau.
 
@@ -45024,7 +47370,7 @@ if ((typeof module) == 'object' && module.exports) {
   Math    // math: package containing random, pow, and seedrandom
 );
 
-},{"crypto":250}],289:[function(require,module,exports){
+},{"crypto":274}],313:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45180,7 +47526,7 @@ exports.unique = unique;
 exports.shuffle = shuffle;
 exports.permutations = permutations;
 
-},{"tonal-note":294}],290:[function(require,module,exports){
+},{"tonal-note":318}],314:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45372,7 +47718,7 @@ exports.supersets = supersets;
 exports.subsets = subsets;
 exports.tokenize = tokenize$1;
 
-},{"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],291:[function(require,module,exports){
+},{"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],315:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45744,7 +48090,7 @@ exports.scale = scale;
 exports.chord = chord;
 exports.pcset = pcset;
 
-},{"tonal-pcset":295}],292:[function(require,module,exports){
+},{"tonal-pcset":319}],316:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46023,7 +48369,7 @@ exports.subtract = subtract;
 exports.interval = interval;
 exports.semitones = semitones;
 
-},{"tonal-interval":293,"tonal-note":294}],293:[function(require,module,exports){
+},{"tonal-interval":317,"tonal-note":318}],317:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46364,7 +48710,7 @@ exports.simplify = simplify;
 exports.invert = invert;
 exports.fromSemitones = fromSemitones;
 
-},{}],294:[function(require,module,exports){
+},{}],318:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46779,7 +49125,7 @@ exports.fromMidi = fromMidi;
 exports.simplify = simplify;
 exports.enharmonic = enharmonic;
 
-},{}],295:[function(require,module,exports){
+},{}],319:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47008,7 +49354,7 @@ exports.isSupersetOf = isSupersetOf;
 exports.includes = includes;
 exports.filter = filter;
 
-},{"tonal-array":289,"tonal-interval":293,"tonal-note":294}],296:[function(require,module,exports){
+},{"tonal-array":313,"tonal-interval":317,"tonal-note":318}],320:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47245,7 +49591,7 @@ exports.toScale = toScale;
 exports.supersets = supersets;
 exports.subsets = subsets;
 
-},{"tonal-array":289,"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],297:[function(require,module,exports){
+},{"tonal-array":313,"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],321:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47383,7 +49729,7 @@ exports.freq = freq$1;
 exports.chord = chord$1;
 exports.scale = scale$1;
 
-},{"tonal-array":289,"tonal-chord":290,"tonal-dictionary":291,"tonal-distance":292,"tonal-interval":293,"tonal-note":294,"tonal-pcset":295,"tonal-scale":296}],298:[function(require,module,exports){
+},{"tonal-array":313,"tonal-chord":314,"tonal-dictionary":315,"tonal-distance":316,"tonal-interval":317,"tonal-note":318,"tonal-pcset":319,"tonal-scale":320}],322:[function(require,module,exports){
 (function(root, factory){
 
 	//UMD
@@ -71766,7 +74112,7 @@ exports.scale = scale$1;
 	
 	return Tone;
 }));
-},{}],299:[function(require,module,exports){
+},{}],323:[function(require,module,exports){
 (function (global,Buffer){
 'use strict'
 
@@ -71983,7 +74329,7 @@ exports.clearCache = function clearCache() {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"bit-twiddle":249,"buffer":251,"dup":256}],300:[function(require,module,exports){
+},{"bit-twiddle":273,"buffer":275,"dup":280}],324:[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -72042,7 +74388,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],301:[function(require,module,exports){
+},{}],325:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72090,7 +74436,7 @@ var BinaryCounter = (function (_super) {
 }(AuxiliaryInput));
 exports.BinaryCounter = BinaryCounter;
 
-},{"@tensorflow/tfjs-core":68}],302:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],326:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72284,7 +74630,7 @@ var PitchChordEncoder = (function (_super) {
 }(ChordEncoder));
 exports.PitchChordEncoder = PitchChordEncoder;
 
-},{"./constants":303,"@tensorflow/tfjs-core":68,"tonal":297}],303:[function(require,module,exports){
+},{"./constants":327,"@tensorflow/tfjs-core":68,"tonal":321}],327:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 null;
@@ -72312,7 +74658,7 @@ exports.HI_CLICK_PITCH = 90;
 exports.LO_CLICK_CLASS = 9;
 exports.HI_CLICK_CLASS = 10;
 
-},{}],304:[function(require,module,exports){
+},{}],328:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72884,7 +75230,7 @@ var MultitrackConverter = (function (_super) {
 }(DataConverter));
 exports.MultitrackConverter = MultitrackConverter;
 
-},{"../protobuf/index":320,"./constants":303,"./performance":308,"./sequences":311,"@tensorflow/tfjs-core":68}],305:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./performance":332,"./sequences":335,"@tensorflow/tfjs-core":68}],329:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -72909,7 +75255,7 @@ __export(require("./player"));
 __export(require("./recorder"));
 __export(require("./visualizer"));
 
-},{"./aux_inputs":301,"./chords":302,"./constants":303,"./data":304,"./logging":306,"./midi_io":307,"./performance":308,"./player":309,"./recorder":310,"./sequences":311,"./visualizer":313}],306:[function(require,module,exports){
+},{"./aux_inputs":325,"./chords":326,"./constants":327,"./data":328,"./logging":330,"./midi_io":331,"./performance":332,"./player":333,"./recorder":334,"./sequences":335,"./visualizer":337}],330:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Level;
@@ -72940,7 +75286,7 @@ function logWithDuration(msg, startTime, prefix, level) {
 }
 exports.logWithDuration = logWithDuration;
 
-},{}],307:[function(require,module,exports){
+},{}],331:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73086,7 +75432,7 @@ function sequenceProtoToMidi(ns) {
 }
 exports.sequenceProtoToMidi = sequenceProtoToMidi;
 
-},{"../protobuf":320,"./constants":303,"./sequences":311,"midiconvert":262}],308:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"./sequences":335,"midiconvert":286}],332:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var index_1 = require("../protobuf/index");
@@ -73289,7 +75635,7 @@ var Performance = (function () {
 }());
 exports.Performance = Performance;
 
-},{"../protobuf/index":320,"./constants":303,"./sequences":311}],309:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./sequences":335}],333:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73701,7 +76047,7 @@ var PlayerWithClick = (function (_super) {
 }(Player));
 exports.PlayerWithClick = PlayerWithClick;
 
-},{".":305,"./constants":303,"./data":304,"./soundfont":312,"tone":298}],310:[function(require,module,exports){
+},{".":329,"./constants":327,"./data":328,"./soundfont":336,"tone":322}],334:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -73927,7 +76273,7 @@ var Recorder = (function () {
 }());
 exports.Recorder = Recorder;
 
-},{"../protobuf":320,"./constants":303,"tone":298}],311:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"tone":322}],335:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74198,7 +76544,7 @@ function mergeInstruments(ns) {
 }
 exports.mergeInstruments = mergeInstruments;
 
-},{"../protobuf/index":320,"./constants":303}],312:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327}],336:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74456,7 +76802,7 @@ var SoundFont = (function () {
 }());
 exports.SoundFont = SoundFont;
 
-},{"./constants":303,"tone":298}],313:[function(require,module,exports){
+},{"./constants":327,"tone":322}],337:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require(".");
@@ -74548,7 +76894,7 @@ var Visualizer = (function () {
 }());
 exports.Visualizer = Visualizer;
 
-},{".":305,"./constants":303}],314:[function(require,module,exports){
+},{".":329,"./constants":327}],338:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -74562,7 +76908,7 @@ __export(require("./music_vae"));
 __export(require("./protobuf"));
 __export(require("./transcription"));
 
-},{"./core":305,"./music_rnn":316,"./music_vae":318,"./protobuf":320,"./transcription":324,"@tensorflow/tfjs":246}],315:[function(require,module,exports){
+},{"./core":329,"./music_rnn":340,"./music_vae":342,"./protobuf":344,"./transcription":348,"@tensorflow/tfjs":270}],339:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tf = require("@tensorflow/tfjs-core");
@@ -74626,13 +76972,13 @@ var AttentionWrapper = (function () {
 }());
 exports.AttentionWrapper = AttentionWrapper;
 
-},{"@tensorflow/tfjs-core":68}],316:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],340:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.MusicRNN = model_1.MusicRNN;
 
-},{"./model":317}],317:[function(require,module,exports){
+},{"./model":341}],341:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74931,7 +77277,7 @@ var MusicRNN = (function () {
 }());
 exports.MusicRNN = MusicRNN;
 
-},{"../core/aux_inputs":301,"../core/chords":302,"../core/data":304,"../core/logging":306,"../core/sequences":311,"./attention":315,"@tensorflow/tfjs-core":68}],318:[function(require,module,exports){
+},{"../core/aux_inputs":325,"../core/chords":326,"../core/data":328,"../core/logging":330,"../core/sequences":335,"./attention":339,"@tensorflow/tfjs-core":68}],342:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
@@ -74939,7 +77285,7 @@ exports.Decoder = model_1.Decoder;
 exports.Encoder = model_1.Encoder;
 exports.MusicVAE = model_1.MusicVAE;
 
-},{"./model":319}],319:[function(require,module,exports){
+},{"./model":343}],343:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -75683,14 +78029,14 @@ var MusicVAE = (function () {
 }());
 exports.MusicVAE = MusicVAE;
 
-},{"../core/chords":302,"../core/constants":303,"../core/data":304,"../core/logging":306,"@tensorflow/tfjs-core":68}],320:[function(require,module,exports){
+},{"../core/chords":326,"../core/constants":327,"../core/data":328,"../core/logging":330,"@tensorflow/tfjs-core":68}],344:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var proto_1 = require("./proto");
 var NoteSequence = proto_1.tensorflow.magenta.NoteSequence;
 exports.NoteSequence = NoteSequence;
 
-},{"./proto":321}],321:[function(require,module,exports){
+},{"./proto":345}],345:[function(require,module,exports){
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
@@ -81401,7 +83747,7 @@ $root.tensorflow = (function() {
 
 module.exports = $root;
 
-},{"protobufjs/minimal":270}],322:[function(require,module,exports){
+},{"protobufjs/minimal":294}],346:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -81780,7 +84126,7 @@ function max(arr) {
     return arr.reduce(function (a, b) { return Math.max(a, b); });
 }
 
-},{"../core/logging":306,"./constants":323,"fft.js":257,"ndarray":268,"ndarray-resample":266}],323:[function(require,module,exports){
+},{"../core/logging":330,"./constants":347,"fft.js":281,"ndarray":292,"ndarray-resample":290}],347:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SAMPLE_RATE = 16000;
@@ -81791,13 +84137,13 @@ exports.MIN_MIDI_PITCH = 21;
 exports.MAX_MIDI_PITCH = 108;
 exports.MIDI_PITCHES = exports.MAX_MIDI_PITCH - exports.MIN_MIDI_PITCH + 1;
 
-},{}],324:[function(require,module,exports){
+},{}],348:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.OnsetsAndFrames = model_1.OnsetsAndFrames;
 
-},{"./model":325}],325:[function(require,module,exports){
+},{"./model":349}],349:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82163,7 +84509,7 @@ var Lstm = (function () {
     return Lstm;
 }());
 
-},{"../core/logging":306,"./audio_utils":322,"./constants":323,"./transcription_utils":326,"@tensorflow/tfjs":246}],326:[function(require,module,exports){
+},{"../core/logging":330,"./audio_utils":346,"./constants":347,"./transcription_utils":350,"@tensorflow/tfjs":270}],350:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82333,4 +84679,4 @@ function pianorollToNoteSequence(frameProbs, onsetProbs, velocityValues, onsetTh
 }
 exports.pianorollToNoteSequence = pianorollToNoteSequence;
 
-},{"../protobuf":320,"./constants":323,"@tensorflow/tfjs":246}]},{},[2]);
+},{"../protobuf":344,"./constants":347,"@tensorflow/tfjs":270}]},{},[2]);

--- a/docs/music/demos/transcription_bundle.js
+++ b/docs/music/demos/transcription_bundle.js
@@ -418,7 +418,7 @@ function notesMatch(aNotes, bNotes) {
 }
 exports.notesMatch = notesMatch;
 
-},{"../src/index":316,"file-saver":260}],2:[function(require,module,exports){
+},{"../src/index":340,"file-saver":284}],2:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -607,7 +607,7 @@ function setLoadingMessage(className) {
     }
 }
 
-},{"../src/index":316,"./common":1,"@tensorflow/tfjs-core":68,"audio-recorder-polyfill":248}],3:[function(require,module,exports){
+},{"../src/index":340,"./common":1,"@tensorflow/tfjs-core":68,"audio-recorder-polyfill":272}],3:[function(require,module,exports){
 "use strict";
 module.exports = asPromise;
 
@@ -3357,7 +3357,7 @@ var FrozenModel = (function () {
         });
     };
     FrozenModel.prototype.predict = function (inputs, config) {
-        return this.execute(inputs, this.outputNodes);
+        return this.execute_(inputs, true, this.outputNodes);
     };
     FrozenModel.prototype.constructTensorMap = function (inputs) {
         var inputArray = inputs instanceof tfc.Tensor ? [inputs] : inputs;
@@ -3372,6 +3372,10 @@ var FrozenModel = (function () {
         }, {});
     };
     FrozenModel.prototype.execute = function (inputs, outputs) {
+        return this.execute_(inputs, false, outputs);
+    };
+    FrozenModel.prototype.execute_ = function (inputs, strictInputCheck, outputs) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         outputs = outputs || this.outputNodes;
         if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
             inputs = this.constructTensorMap(inputs);
@@ -3380,7 +3384,7 @@ var FrozenModel = (function () {
             throw new Error('The model contains control flow or dynamic shape ops, ' +
                 'please use executeAsync method');
         }
-        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), outputs);
+        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
         var keys = Object.keys(result);
         return (Array.isArray(outputs) && outputs.length > 1) ?
             outputs.map(function (node) { return result[node]; }) :
@@ -3494,8 +3498,9 @@ var execution_context_1 = require("./execution_context");
 var GraphExecutor = (function () {
     function GraphExecutor(graph) {
         this.graph = graph;
-        this.compiledOrder = [];
+        this.compiledMap = new Map();
         this._weightMap = {};
+        this.SEPERATOR = ',';
         this.placeholders = graph.placeholders;
         this._outputs = graph.outputs;
         this.compile();
@@ -3570,16 +3575,23 @@ var GraphExecutor = (function () {
         enumerable: true,
         configurable: true
     });
-    GraphExecutor.prototype.compile = function () {
+    GraphExecutor.prototype.compile = function (startNodes) {
         if (this.graph.withControlFlow || this.graph.withDynamicShape) {
             return;
         }
-        var stack = this.graph.inputs.slice();
+        var compiledOrder = [];
+        var inputs = startNodes || this.graph.placeholders;
+        var sortedNodeNames = inputs.map(function (node) { return node.name; }).sort();
+        var nameKey = sortedNodeNames.join(this.SEPERATOR);
+        if (this.compiledMap.get(nameKey)) {
+            return;
+        }
+        var stack = inputs.concat(this.graph.weights);
         var visited = {};
         while (stack.length > 0) {
             var node = stack.pop();
             visited[node.name] = true;
-            this.compiledOrder.push(node);
+            compiledOrder.push(node);
             node.children.forEach(function (childNode) {
                 if (!visited[childNode.name] && childNode.inputNames.every(function (name) {
                     var nodeName = utils_1.getNodeNameAndIndex(name)[0];
@@ -3589,19 +3601,33 @@ var GraphExecutor = (function () {
                 }
             });
         }
+        this.compiledMap.set(nameKey, compiledOrder);
     };
-    GraphExecutor.prototype.execute = function (inputs, outputs) {
+    GraphExecutor.prototype.execute = function (inputs, strictInputCheck, outputs) {
         var _this = this;
-        this.checkInput(inputs);
-        this.checkInputShapeAndType(inputs);
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
+        var names = Object.keys(inputs).sort();
+        this.checkInput(inputs, strictInputCheck);
+        this.checkInputShapeAndType(inputs, strictInputCheck);
+        this.compile(names.map(function (name) { return _this.graph.nodes[name]; }));
+        var outputNames = this.calculateOutputs(outputs);
+        this.checkOutput(this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
         var tensorArrayMap = {};
         var result = tfjs_core_1.tidy(function () {
             var context = new execution_context_1.ExecutionContext(_this._weightMap, tensorArrayMap);
-            var tensors = _this.compiledOrder.reduce(function (map, node) {
-                map[node.name] = operation_executor_1.executeOp(node, map, context);
-                return map;
-            }, __assign({}, _this.weightMap, inputs));
-            return _this.findOutputs(tensors, context, outputs);
+            var tensorMap = __assign({}, _this.weightMap, inputs);
+            var compiledNodes = _this.compiledMap.get(names.join(_this.SEPERATOR));
+            for (var i = 0; i < compiledNodes.length; i++) {
+                var node = compiledNodes[i];
+                if (!tensorMap[node.name]) {
+                    tensorMap[node.name] =
+                        operation_executor_1.executeOp(node, tensorMap, context);
+                }
+                if (outputNames.every(function (name) { return !!tensorMap[name]; })) {
+                    break;
+                }
+            }
+            return _this.findOutputs(tensorMap, context, outputNames);
         });
         return result;
     };
@@ -3612,8 +3638,8 @@ var GraphExecutor = (function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        this.checkInput(inputs);
-                        this.checkInputShapeAndType(inputs);
+                        this.checkInput(inputs, false);
+                        this.checkInputShapeAndType(inputs, false);
                         tensorArrayMap = {};
                         context = new execution_context_1.ExecutionContext(this._weightMap, tensorArrayMap);
                         return [4, this.executeWithControlFlow(inputs, context)];
@@ -3640,11 +3666,14 @@ var GraphExecutor = (function () {
     };
     GraphExecutor.prototype.executeWithControlFlow = function (inputs, context) {
         return __awaiter(this, void 0, void 0, function () {
-            var stack, tensorMap, added, promises;
+            var _this = this;
+            var names, inputNodes, stack, tensorMap, added, promises;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        stack = this.graph.inputs.map(function (node) {
+                        names = Object.keys(inputs);
+                        inputNodes = names.map(function (name) { return _this.graph.nodes[name]; });
+                        stack = inputNodes.concat(this.graph.weights).map(function (node) {
                             return { node: node, contexts: context.currentContext };
                         });
                         tensorMap = __assign({}, this.weightMap, inputs);
@@ -3652,7 +3681,7 @@ var GraphExecutor = (function () {
                         _a.label = 1;
                     case 1:
                         if (!(stack.length > 0)) return [3, 3];
-                        promises = this.processStack(stack, context, tensorMap, added);
+                        promises = this.processStack(inputNodes, stack, context, tensorMap, added);
                         return [4, Promise.all(promises)];
                     case 2:
                         _a.sent();
@@ -3662,7 +3691,7 @@ var GraphExecutor = (function () {
             });
         });
     };
-    GraphExecutor.prototype.processStack = function (stack, context, tensorMap, added) {
+    GraphExecutor.prototype.processStack = function (inputNodes, stack, context, tensorMap, added) {
         var _this = this;
         var promises = [];
         var _loop_1 = function () {
@@ -3673,21 +3702,26 @@ var GraphExecutor = (function () {
                 utils_1.getParamValue('isConstant', item.node, tensorMap, context)) {
                 nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
             }
-            var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
-            if (!nodeName) {
-                nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
-            }
-            var currentContext = context.currentContext;
-            if (tensors instanceof Promise) {
-                promises.push(tensors.then(function (t) {
-                    tensorMap[nodeName] = t;
-                    context.currentContext = currentContext;
-                    _this.processChildNodes(item.node, stack, context, tensorMap, added);
-                    return t;
-                }));
+            if (inputNodes.indexOf(item.node) === -1) {
+                var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
+                if (!nodeName) {
+                    nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
+                }
+                var currentContext_1 = context.currentContext;
+                if (tensors instanceof Promise) {
+                    promises.push(tensors.then(function (t) {
+                        tensorMap[nodeName] = t;
+                        context.currentContext = currentContext_1;
+                        _this.processChildNodes(item.node, stack, context, tensorMap, added);
+                        return t;
+                    }));
+                }
+                else {
+                    tensorMap[nodeName] = tensors;
+                    this_1.processChildNodes(item.node, stack, context, tensorMap, added);
+                }
             }
             else {
-                tensorMap[nodeName] = tensors;
                 this_1.processChildNodes(item.node, stack, context, tensorMap, added);
             }
         };
@@ -3718,11 +3752,14 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+    GraphExecutor.prototype.calculateOutputs = function (outputs) {
         if (outputs && !(outputs instanceof Array)) {
             outputs = [outputs];
         }
-        var requestedOutputs = (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+        return (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+    };
+    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+        var requestedOutputs = this.calculateOutputs(outputs);
         return requestedOutputs.reduce(function (map, name) {
             map[name] = utils_1.getTensor(name, tensorMap, context);
             return map;
@@ -3733,9 +3770,14 @@ var GraphExecutor = (function () {
         Object.keys(this.weightMap)
             .forEach(function (key) { return _this.weightMap[key].forEach(function (tensor) { return tensor.dispose(); }); });
     };
-    GraphExecutor.prototype.checkInputShapeAndType = function (inputs) {
+    GraphExecutor.prototype.checkInputShapeAndType = function (inputs, strictInputCheck) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         this.placeholders.forEach(function (node) {
-            var input = inputs[node.name][0];
+            var inputTensors = inputs[node.name];
+            if (!strictInputCheck && !inputTensors) {
+                return;
+            }
+            var input = inputTensors[0];
             if (node.params['shape'] && node.params['shape'].value) {
                 var shape_1 = node.params['shape'].value;
                 var match = shape_1.length === input.shape.length &&
@@ -3747,8 +3789,9 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.checkInput = function (inputs) {
+    GraphExecutor.prototype.checkInput = function (inputs, strictInputCheck) {
         var _this = this;
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         var inputKeys = Object.keys(inputs);
         var missing = [];
         var extra = [];
@@ -3760,14 +3803,31 @@ var GraphExecutor = (function () {
             if (_this.inputNodes.indexOf(name) === -1)
                 extra.push(name);
         });
-        if (missing.length > 0) {
+        var notInGraph = extra.filter(function (name) { return !_this.graph.nodes[name]; });
+        if (missing.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has the keys " +
                 ("[" + inputKeys + "], but is missing the required keys: [" + missing + "]."));
         }
-        if (extra.length > 0) {
+        if (extra.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has " +
                 ("unused keys: [" + extra + "]. Please provide only the following keys: ") +
                 ("[" + this.inputNodes + "]."));
+        }
+        if (notInGraph.length > 0) {
+            throw new Error("The dict provided in model.execute(dict) has " +
+                ("keys: [" + notInGraph + "] not part of model graph."));
+        }
+    };
+    GraphExecutor.prototype.checkOutput = function (compiledNodes, outputs) {
+        var compiledNodeNames = compiledNodes.map(function (node) { return node.name; });
+        var extra = [];
+        outputs.forEach(function (name) {
+            if (compiledNodeNames.indexOf(name) === -1)
+                extra.push(name);
+        });
+        if (extra.length > 0) {
+            throw new Error("The following outputs are not be generated by the execution: " +
+                ("[" + extra + "]."));
         }
     };
     return GraphExecutor;
@@ -4483,6 +4543,9 @@ exports.executeOp = function (node, tensorMap, context) {
             return [snapshot.clone()];
         case 'shape':
             return [tfc.tensor1d(utils_1.getParamValue('x', node, tensorMap, context).shape, 'int32')];
+        case 'shapeN':
+            return utils_1.getParamValue('x', node, tensorMap, context)
+                .map(function (t) { return tfc.tensor1d(t.shape); });
         case 'size':
             return [tfc.scalar(utils_1.getParamValue('x', node, tensorMap, context).size, 'int32')];
         case 'rank':
@@ -4525,6 +4588,15 @@ exports.executeOp = function (node, tensorMap, context) {
             var size = utils_1.getParamValue('size', node, tensorMap, context);
             var alignCorners = utils_1.getParamValue('alignCorners', node, tensorMap, context);
             return [tfc.image.resizeNearestNeighbor(images, [size[0], size[1]], alignCorners)];
+        }
+        case 'cropAndResize': {
+            var image = utils_1.getParamValue('image', node, tensorMap, context);
+            var boxes = utils_1.getParamValue('boxes', node, tensorMap, context);
+            var boxInd = utils_1.getParamValue('boxInd', node, tensorMap, context);
+            var cropSize = utils_1.getParamValue('cropSize', node, tensorMap, context);
+            var method = utils_1.getParamValue('method', node, tensorMap, context);
+            var extrapolationValue = utils_1.getParamValue('extrapolationValue', node, tensorMap, context);
+            return [tfc.image.cropAndResize(image, boxes, boxInd, cropSize, method, extrapolationValue)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4658,6 +4730,11 @@ exports.executeOp = function (node, tensorMap, context) {
         case 'argMin': {
             var axis = utils_1.getParamValue('axis', node, tensorMap, context);
             return [tfc.argMin(utils_1.getParamValue('x', node, tensorMap, context), axis)];
+        }
+        case 'prod': {
+            var axis = utils_1.getParamValue('axis', node, tensorMap, context);
+            var keepDims = utils_1.getParamValue('keepDims', node, tensorMap, context);
+            return [tfc.prod(utils_1.getParamValue('x', node, tensorMap, context), axis, keepDims)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -5014,6 +5091,20 @@ exports.json = [
     },
     {
         'tfOpName': 'Mod',
+        'dlOpName': 'mod',
+        'category': 'arithmetic',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'FloorMod',
         'dlOpName': 'mod',
         'category': 'arithmetic',
         'params': [
@@ -6173,6 +6264,17 @@ exports.json = [
         'params': [{ 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' }]
     },
     {
+        'tfOpName': 'ShapeN',
+        'dlOpName': 'shapeN',
+        'category': 'graph',
+        'params': [{
+                'tfInputIndex': 0,
+                'tfInputParamLength': 0,
+                'dlParamName': 'x',
+                'type': 'tensors'
+            }]
+    },
+    {
         'tfOpName': 'Print',
         'dlOpName': 'print',
         'category': 'graph',
@@ -6254,6 +6356,22 @@ exports.json = [
                 'dlParamName': 'dtype',
                 'type': 'dtype',
                 'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'CropAndResize',
+        'dlOpName': 'cropAndResize',
+        'category': 'image',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'image', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'boxes', 'type': 'tensor' },
+            { 'tfInputIndex': 2, 'dlParamName': 'boxInd', 'type': 'tensor' },
+            { 'tfInputIndex': 3, 'dlParamName': 'cropSize', 'type': 'number[]' },
+            { 'tfParamName': 'method', 'dlParamName': 'method', 'type': 'string' }, {
+                'tfParamName': 'extrapolation_value',
+                'dlParamName': 'extrapolationValue',
+                'type': 'number'
             }
         ]
     }
@@ -6423,6 +6541,32 @@ exports.json = [
             },
             {
                 'tfParamName': 'transpose_b',
+                'dlParamName': 'transposeB',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'BatchMatMul',
+        'dlOpName': 'matMul',
+        'category': 'matrices',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'adj_x',
+                'dlParamName': 'transposeA',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'adj_y',
                 'dlParamName': 'transposeB',
                 'type': 'bool',
                 'defaultValue': false
@@ -6620,6 +6764,19 @@ exports.json = [
         'params': [
             { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
             { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number' }
+        ]
+    },
+    {
+        'tfOpName': 'Prod',
+        'dlOpName': 'prod',
+        'category': 'reduction',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number[]' }, {
+                'tfParamName': 'keep_dims',
+                'dlParamName': 'keepDims',
+                'type': 'bool'
+            }
         ]
     }
 ];
@@ -6828,6 +6985,21 @@ exports.json = [
                 'dlParamName': 'numOrSizeSplits',
                 'type': 'number',
                 'defaultValue': 1
+            }
+        ]
+    },
+    {
+        'tfOpName': 'SplitV',
+        'dlOpName': 'split',
+        'category': 'slice_join',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'numOrSizeSplits', 'type': 'number[]' },
+            {
+                'tfInputIndex': 2,
+                'dlParamName': 'axis',
+                'type': 'number',
+                'defaultValue': 0
             }
         ]
     }
@@ -7046,6 +7218,7 @@ var OperationMapper = (function () {
         var withControlFlow = false;
         var withDynamicShape = false;
         var placeholders = [];
+        var weights = [];
         var nodes = tfNodes.reduce(function (map, node) {
             map[node.name] = _this.mapNode(node);
             if (_this.isControlFlow(node))
@@ -7054,6 +7227,8 @@ var OperationMapper = (function () {
                 withDynamicShape = true;
             if (node.op === 'Placeholder')
                 placeholders.push(map[node.name]);
+            if (node.op === 'Const')
+                weights.push(map[node.name]);
             return map;
         }, {});
         var inputs = [];
@@ -7077,6 +7252,7 @@ var OperationMapper = (function () {
             nodes: nodes,
             inputs: inputs,
             outputs: outputs,
+            weights: weights,
             placeholders: placeholders,
             withControlFlow: withControlFlow,
             withDynamicShape: withDynamicShape
@@ -7214,7 +7390,7 @@ exports.OperationMapper = OperationMapper;
 },{"../data/compiled_api":10,"./executors/utils":31,"./op_list/arithmetic":32,"./op_list/basic_math":33,"./op_list/control":34,"./op_list/convolution":35,"./op_list/creation":36,"./op_list/dynamic":37,"./op_list/evaluation":38,"./op_list/graph":39,"./op_list/image":40,"./op_list/logical":41,"./op_list/matrices":42,"./op_list/normalization":43,"./op_list/reduction":44,"./op_list/slice_join":45,"./op_list/transformation":46}],49:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.5.9';
+var version = '0.6.5';
 exports.version = version;
 
 },{}],50:[function(require,module,exports){
@@ -9153,18 +9329,24 @@ var Engine = (function () {
         this.safeMode = safeMode;
         this.debugMode = debugMode;
         this.registeredVariables = {};
-        this.refCounter = new WeakMap();
         this.nextTapeNodeId = 0;
         this.numBytes = 0;
         this.numTensors = 0;
         this.numDataBuffers = 0;
+        this.profiling = false;
         this.gradientScopeCount = 0;
         this.customGradientDepth = 0;
         this.keepTensors = new Set();
+        this.tensorInfo = new WeakMap();
         this.activeScope = { track: [], name: 'default scope' };
         this.scopeStack = [this.activeScope];
         this.profiler = new profiler_1.Profiler(backend);
+        this.activeProfile =
+            { newBytes: 0, newTensors: 0, peakBytes: 0, kernels: [], result: null };
     }
+    Engine.prototype.moveData = function (dataId) {
+        this.write(dataId, this.readSync(dataId));
+    };
     Engine.prototype.tidy = function (nameOrFn, fn, gradMode) {
         var _this = this;
         if (gradMode === void 0) { gradMode = false; }
@@ -9216,6 +9398,8 @@ var Engine = (function () {
             return x;
         };
         var scopeName = this.activeScope.name;
+        var startingBytecount = this.numBytes;
+        var startingNumTensors = this.numTensors;
         this.scopedRun(function () { return _this.customGradientDepth++; }, function () { return _this.customGradientDepth--; }, function () {
             if (!_this.debugMode()) {
                 result = forwardFunc(_this.backend, saveFunc);
@@ -9237,10 +9421,25 @@ var Engine = (function () {
             }
             this.activeTape.push(tapeNode);
         }
+        if (this.profiling) {
+            this.activeProfile.kernels.push({
+                name: scopeName,
+                bytesAdded: this.numBytes - startingBytecount,
+                totalBytesSnapshot: this.numBytes,
+                tensorsAdded: this.numTensors - startingNumTensors,
+                totalTensorsSnapshot: this.numTensors,
+                inputShapes: Object.keys(inputs).map(function (key) { return inputs[key].shape; }),
+                outputShape: Array.isArray(result) ?
+                    result.map(function (item) { return item.shape; }) :
+                    result.shape
+            });
+        }
         return result;
     };
     Engine.prototype.registerTensor = function (a) {
-        var refCount = this.refCounter.has(a.dataId) ? this.refCounter.get(a.dataId) : 0;
+        var refCount = this.tensorInfo.has(a.dataId) ?
+            this.tensorInfo.get(a.dataId).refCount :
+            0;
         this.numTensors++;
         if (refCount === 0) {
             this.numDataBuffers++;
@@ -9248,9 +9447,10 @@ var Engine = (function () {
                 this.numBytes +=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.set(a.dataId, { backend: this.backend, dtype: a.dtype, shape: a.shape, refCount: 0 });
             this.backend.register(a.dataId, a.shape, a.dtype);
         }
-        this.refCounter.set(a.dataId, refCount + 1);
+        this.tensorInfo.get(a.dataId).refCount++;
         if (!(a instanceof tensor_1.Variable)) {
             this.track(a);
         }
@@ -9262,25 +9462,26 @@ var Engine = (function () {
         this.registeredVariables[v.name] = v;
     };
     Engine.prototype.disposeTensor = function (a) {
-        if (!this.refCounter.has(a.dataId)) {
+        if (!this.tensorInfo.has(a.dataId)) {
             return;
         }
         if (this.keepTensors.has(a.id)) {
             this.keepTensors.delete(a.id);
         }
         this.numTensors--;
-        var refCount = this.refCounter.get(a.dataId);
+        var refCount = this.tensorInfo.get(a.dataId).refCount;
         if (refCount <= 1) {
-            this.refCounter.delete(a.dataId);
-            this.backend.disposeData(a.dataId);
+            var info = this.tensorInfo.get(a.dataId);
+            info.backend.disposeData(a.dataId);
             this.numDataBuffers--;
             if (a.dtype !== 'complex64') {
                 this.numBytes -=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.delete(a.dataId);
         }
         else {
-            this.refCounter.set(a.dataId, refCount - 1);
+            this.tensorInfo.get(a.dataId).refCount--;
         }
     };
     Engine.prototype.disposeVariables = function () {
@@ -9296,6 +9497,23 @@ var Engine = (function () {
         info.numDataBuffers = this.numDataBuffers;
         info.numBytes = this.numBytes;
         return info;
+    };
+    Engine.prototype.profile = function (query) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startBytes, startNumTensors;
+            return __generator(this, function (_a) {
+                this.profiling = true;
+                startBytes = this.numBytes;
+                startNumTensors = this.numTensors;
+                this.activeProfile.kernels = [];
+                this.activeProfile.result = query();
+                this.profiling = false;
+                this.activeProfile.peakBytes = Math.max.apply(Math, this.activeProfile.kernels.map(function (d) { return d.totalBytesSnapshot; }));
+                this.activeProfile.newBytes = this.numBytes - startBytes;
+                this.activeProfile.newTensors = this.numTensors - startNumTensors;
+                return [2, this.activeProfile];
+            });
+        });
     };
     Engine.prototype.shouldRecord = function () {
         return this.activeTape != null && this.customGradientDepth === 0;
@@ -9441,13 +9659,21 @@ var Engine = (function () {
         };
     };
     Engine.prototype.write = function (dataId, values) {
+        var info = this.tensorInfo.get(dataId);
+        if (this.backend !== info.backend) {
+            info.backend.disposeData(dataId);
+            info.backend = this.backend;
+            this.backend.register(dataId, info.shape, info.dtype);
+        }
         this.backend.write(dataId, values);
     };
     Engine.prototype.readSync = function (dataId) {
-        return this.backend.readSync(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.readSync(dataId);
     };
     Engine.prototype.read = function (dataId) {
-        return this.backend.read(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.read(dataId);
     };
     Engine.prototype.fromPixels = function (pixels, numChannels) {
         return this.backend.fromPixels(pixels, numChannels);
@@ -9484,7 +9710,7 @@ function ones(shape) {
     return tensor_1.Tensor.make(shape, { values: values });
 }
 
-},{"./profiler":184,"./tape":186,"./tensor":187,"./tensor_util":189,"./util":194}],64:[function(require,module,exports){
+},{"./profiler":204,"./tape":206,"./tensor":207,"./tensor_util":209,"./util":214}],64:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -9500,7 +9726,6 @@ var TEST_EPSILON_FLOAT32 = 1e-3;
 var Environment = (function () {
     function Environment(features) {
         this.features = {};
-        this.engines = {};
         this.registry = {};
         if (features != null) {
             this.features = features;
@@ -9516,10 +9741,11 @@ var Environment = (function () {
         if (!(backendName in exports.ENV.registry)) {
             throw new Error("Backend name '" + backendName + "' not found in registry");
         }
-        exports.ENV.initBackend(backendName, safeMode);
+        exports.ENV.engine.backend = exports.ENV.findBackend(backendName);
+        exports.ENV.backendName = backendName;
     };
     Environment.getBackend = function () {
-        exports.ENV.initDefaultBackend();
+        exports.ENV.initEngine();
         return exports.ENV.backendName;
     };
     Environment.disposeVariables = function () {
@@ -9527,6 +9753,9 @@ var Environment = (function () {
     };
     Environment.memory = function () {
         return exports.ENV.engine.memory();
+    };
+    Environment.profile = function (f) {
+        return exports.ENV.engine.profile(f);
     };
     Environment.tidy = function (nameOrFn, fn, gradMode) {
         if (gradMode === void 0) { gradMode = false; }
@@ -9583,6 +9812,18 @@ var Environment = (function () {
         else if (feature === 'IS_CHROME') {
             return environment_util_1.isChrome();
         }
+        else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+            return false;
+        }
+        else if (feature === 'WEBGL_CONV_IM2COL') {
+            return false;
+        }
+        else if (feature === 'WEBGL_PAGING_ENABLED') {
+            return this.get('IS_BROWSER') && !this.get('PROD');
+        }
+        else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
+            return environment_util_1.getWebGLMaxTextureSize(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+        }
         else if (feature === 'IS_TEST') {
             return false;
         }
@@ -9592,9 +9833,6 @@ var Environment = (function () {
         else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
             var webGLVersion = this.get('WEBGL_VERSION');
             if (webGLVersion === 0) {
-                return 0;
-            }
-            if (webGLVersion > 0) {
                 return 0;
             }
             return environment_util_1.getWebGLDisjointQueryTimerVersion(webGLVersion, this.get('IS_BROWSER'));
@@ -9624,6 +9862,10 @@ var Environment = (function () {
         else if (feature === 'WEBGL_FENCE_API_ENABLED') {
             return environment_util_1.isWebGLFenceEnabled(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
         }
+        else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
+            var useUniforms = this.get('WEBGL_RENDER_FLOAT32_ENABLED');
+            return useUniforms ? 4 : 0;
+        }
         else if (feature === 'TEST_EPSILON') {
             return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
                 TEST_EPSILON_FLOAT16;
@@ -9631,6 +9873,12 @@ var Environment = (function () {
         else if (feature === 'EPSILON') {
             return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
                 EPSILON_FLOAT16;
+        }
+        else if (feature === 'PROD') {
+            return false;
+        }
+        else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
+            return !this.get('PROD');
         }
         throw new Error("Unknown feature " + feature + ".");
     };
@@ -9641,20 +9889,6 @@ var Environment = (function () {
         this.features = environment_util_1.getFeaturesFromURL();
         if (this.globalEngine != null) {
             this.globalEngine = null;
-        }
-    };
-    Environment.prototype.initBackend = function (backendName, safeMode) {
-        var _this = this;
-        if (safeMode === void 0) { safeMode = false; }
-        this.backendName = backendName;
-        if (this.engines[backendName]) {
-            this.globalEngine = this.engines[backendName];
-        }
-        else {
-            var backend = this.findBackend(backendName);
-            this.globalEngine =
-                new engine_1.Engine(backend, safeMode, function () { return _this.get('DEBUG'); });
-            this.engines[backendName] = this.globalEngine;
         }
     };
     Object.defineProperty(Environment.prototype, "backend", {
@@ -9682,6 +9916,7 @@ var Environment = (function () {
         }
         try {
             var backend = factory();
+            backend.setDataMover({ moveData: function (dataId) { return _this.engine.moveData(dataId); } });
             this.registry[name] = { backend: backend, priority: priority };
             return true;
         }
@@ -9697,21 +9932,22 @@ var Environment = (function () {
         }
         this.registry[name].backend.dispose();
         delete this.registry[name];
-        if (name in this.engines) {
-            delete this.engines[name];
-        }
     };
     Object.defineProperty(Environment.prototype, "engine", {
         get: function () {
-            this.initDefaultBackend();
+            this.initEngine();
             return this.globalEngine;
         },
         enumerable: true,
         configurable: true
     });
-    Environment.prototype.initDefaultBackend = function () {
+    Environment.prototype.initEngine = function () {
+        var _this = this;
         if (this.globalEngine == null) {
-            this.initBackend(this.get('BACKEND'), false);
+            this.backendName = this.get('BACKEND');
+            var backend = this.findBackend(this.backendName);
+            this.globalEngine =
+                new engine_1.Engine(backend, false, function () { return _this.get('DEBUG'); });
         }
     };
     return Environment;
@@ -9741,7 +9977,7 @@ function getOrMakeEnvironment() {
 exports.ENV = getOrMakeEnvironment();
 
 }).call(this,require('_process'))
-},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":187,"./tensor_util":189,"_process":271}],65:[function(require,module,exports){
+},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":207,"./tensor_util":209,"_process":295}],65:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Type;
@@ -9751,14 +9987,23 @@ var Type;
     Type[Type["STRING"] = 2] = "STRING";
 })(Type = exports.Type || (exports.Type = {}));
 exports.URL_PROPERTIES = [
-    { name: 'DEBUG', type: Type.BOOLEAN }, { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'DEBUG', type: Type.BOOLEAN },
+    { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN },
+    { name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN },
+    { name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER },
+    { name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN },
     { name: 'WEBGL_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_RENDER_FLOAT32_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DOWNLOAD_FLOAT_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_FENCE_API_ENABLED', type: Type.BOOLEAN },
-    { name: 'BACKEND', type: Type.STRING }, { name: 'EPSILON', type: Type.NUMBER }
+    { name: 'WEBGL_SIZE_UPLOAD_UNIFORM', type: Type.NUMBER },
+    { name: 'BACKEND', type: Type.STRING },
+    { name: 'EPSILON', type: Type.NUMBER },
+    { name: 'PROD', type: Type.BOOLEAN },
+    { name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN },
 ];
 function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     var gl;
@@ -9775,6 +10020,15 @@ function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     return false;
 }
 exports.isWebGLVersionEnabled = isWebGLVersionEnabled;
+var MAX_TEXTURE_SIZE;
+function getWebGLMaxTextureSize(webGLVersion, isBrowser) {
+    if (MAX_TEXTURE_SIZE == null) {
+        var gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+        MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    }
+    return MAX_TEXTURE_SIZE;
+}
+exports.getWebGLMaxTextureSize = getWebGLMaxTextureSize;
 function getWebGLDisjointQueryTimerVersion(webGLVersion, isBrowser) {
     if (webGLVersion === 0) {
         return 0;
@@ -9963,6 +10217,7 @@ exports.tidy = environment_1.Environment.tidy;
 exports.keep = environment_1.Environment.keep;
 exports.dispose = environment_1.Environment.dispose;
 exports.time = environment_1.Environment.time;
+exports.profile = environment_1.Environment.profile;
 
 },{"./environment":64,"./gradients":67}],67:[function(require,module,exports){
 "use strict";
@@ -10077,7 +10332,7 @@ function checkGrads(grads) {
     }
 }
 
-},{"./environment":64,"./tensor":187,"./util":194}],68:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],68:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -10092,6 +10347,8 @@ exports.environment = environment;
 var environment_1 = require("./environment");
 var io = require("./io/io");
 exports.io = io;
+var math = require("./math");
+exports.math = math;
 var serialization = require("./serialization");
 exports.serialization = serialization;
 var tensor_1 = require("./tensor");
@@ -10138,10 +10395,12 @@ exports.setBackend = environment_1.Environment.setBackend;
 exports.getBackend = environment_1.Environment.getBackend;
 exports.disposeVariables = environment_1.Environment.disposeVariables;
 exports.memory = environment_1.Environment.memory;
+var backend_1 = require("./kernels/backend");
+exports.DataStorage = backend_1.DataStorage;
 var ops = require("./ops/ops");
 tensor_1.setOpHandler(ops);
 
-},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend_cpu":80,"./kernels/backend_webgl":82,"./ops/loss_ops":150,"./ops/ops":157,"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer":180,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183,"./serialization":185,"./tensor":187,"./test_util":191,"./train":192,"./types":193,"./util":194,"./version":195,"./webgl":196}],69:[function(require,module,exports){
+},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend":80,"./kernels/backend_cpu":81,"./kernels/backend_webgl":83,"./math":145,"./ops/loss_ops":165,"./ops/ops":172,"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer":200,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203,"./serialization":205,"./tensor":207,"./test_util":211,"./train":212,"./types":213,"./util":214,"./version":215,"./webgl":216}],69:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10633,7 +10892,7 @@ function browserHTTPRequest(path, requestInit) {
 }
 exports.browserHTTPRequest = browserHTTPRequest;
 
-},{"../util":194,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11214,7 +11473,7 @@ function getModelArtifactsInfoForJSON(modelArtifacts) {
 exports.getModelArtifactsInfoForJSON = getModelArtifactsInfoForJSON;
 
 }).call(this,require("buffer").Buffer)
-},{"../ops/tensor_ops":171,"../util":194,"./types":78,"buffer":253}],74:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214,"./types":78,"buffer":277}],74:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11462,7 +11721,7 @@ if (environment_1.ENV.get('IS_BROWSER')) {
     }
 }
 
-},{"../environment":64,"../util":194,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
+},{"../environment":64,"../util":214,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11666,7 +11925,7 @@ function moveModel(sourceURL, destURL) {
 }
 exports.moveModel = moveModel;
 
-},{"../util":194,"./router_registry":77}],76:[function(require,module,exports){
+},{"../util":214,"./router_registry":77}],76:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -11975,7 +12234,34 @@ function loadWeights(manifest, filePathPrefix, weightNames, requestOptions) {
 }
 exports.loadWeights = loadWeights;
 
-},{"../util":194,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var DataStorage = (function () {
+    function DataStorage(dataMover) {
+        this.dataMover = dataMover;
+        this.data = new WeakMap();
+    }
+    DataStorage.prototype.get = function (dataId) {
+        if (!this.data.has(dataId)) {
+            this.dataMover.moveData(dataId);
+        }
+        return this.data.get(dataId);
+    };
+    DataStorage.prototype.set = function (dataId, value) {
+        this.data.set(dataId, value);
+    };
+    DataStorage.prototype.has = function (dataId) {
+        return this.data.has(dataId);
+    };
+    DataStorage.prototype.delete = function (dataId) {
+        return this.data.delete(dataId);
+    };
+    return DataStorage;
+}());
+exports.DataStorage = DataStorage;
+
+},{}],81:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -12021,14 +12307,17 @@ var axis_util = require("../ops/axis_util");
 var broadcast_util = require("../ops/broadcast_util");
 var concat_util = require("../ops/concat_util");
 var erf_util = require("../ops/erf_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var ops = require("../ops/ops");
 var ops_1 = require("../ops/ops");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var selu_util = require("../ops/selu_util");
 var slice_util_1 = require("../ops/slice_util");
 var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -12038,12 +12327,14 @@ var where_impl_1 = require("./where_impl");
 var MathBackendCPU = (function () {
     function MathBackendCPU() {
         this.blockSize = 48;
-        this.data = new WeakMap();
         this.firstUse = true;
         if (environment_1.ENV.get('IS_BROWSER')) {
             this.canvas = document.createElement('canvas');
         }
     }
+    MathBackendCPU.prototype.setDataMover = function (dataMover) {
+        this.data = new backend_1.DataStorage(dataMover);
+    };
     MathBackendCPU.prototype.register = function (dataId, shape, dtype) {
         if (this.firstUse) {
             this.firstUse = false;
@@ -12069,7 +12360,6 @@ var MathBackendCPU = (function () {
         if (values == null) {
             throw new Error('MathBackendCPU.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         this.data.get(dataId).values = values;
     };
     MathBackendCPU.prototype.fromPixels = function (pixels, numChannels) {
@@ -12132,7 +12422,6 @@ var MathBackendCPU = (function () {
         });
     };
     MathBackendCPU.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var _a = this.data.get(dataId), dtype = _a.dtype, complexTensors = _a.complexTensors;
         if (dtype === 'complex64') {
             var realValues = complexTensors.real.dataSync();
@@ -12166,13 +12455,6 @@ var MathBackendCPU = (function () {
         return {
             unreliable: true
         };
-    };
-    MathBackendCPU.prototype.throwIfNoData = function (dataId) {
-        if (!this.data.has(dataId)) {
-            throw new Error("CPU backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
     };
     MathBackendCPU.prototype.complex = function (real, imag) {
         var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
@@ -12393,6 +12675,24 @@ var MathBackendCPU = (function () {
                 sum += aVals[offset + j];
             }
             vals[i] = sum;
+        }
+        return result;
+    };
+    MathBackendCPU.prototype.prod = function (x, axes) {
+        this.assertNotComplex(x, 'sum');
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var resultDtype = types_1.upcastType(x.dtype, 'int32');
+        var result = ops.zeros(outShape, resultDtype);
+        var reduceSize = util.sizeFromShape(reduceShape);
+        var vals = result.dataSync();
+        var aVals = x.dataSync();
+        for (var i = 0; i < vals.length; ++i) {
+            var offset = i * reduceSize;
+            var prod = 1;
+            for (var j = 0; j < reduceSize; ++j) {
+                prod *= aVals[offset + j];
+            }
+            vals[i] = prod;
         }
         return result;
     };
@@ -12889,11 +13189,19 @@ var MathBackendCPU = (function () {
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
     MathBackendCPU.prototype.abs = function (x) {
-        this.assertNotComplex(x, 'abs');
         var resultValues = new Float32Array(x.size);
         var values = x.dataSync();
-        for (var i = 0; i < values.length; ++i) {
-            resultValues[i] = Math.abs(values[i]);
+        if (x.dtype === 'complex64') {
+            for (var i = 0; i < x.size; ++i) {
+                var real = values[i * 2];
+                var imag = values[i * 2 + 1];
+                resultValues[i] = Math.sqrt(real * real + imag * imag);
+            }
+        }
+        else {
+            for (var i = 0; i < values.length; ++i) {
+                resultValues[i] = Math.abs(values[i]);
+            }
         }
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
@@ -13452,8 +13760,10 @@ var MathBackendCPU = (function () {
         this.assertNotComplex(x, 'pool');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var y = ops.buffer(convInfo.outShape, 'float32');
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
@@ -13464,16 +13774,16 @@ var MathBackendCPU = (function () {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
                     var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
                         var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var minMaxValue = initialValue;
                         var avgValue = 0;
                         var count = 0;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var pixel = x.get(b, xR, xC, d);
                                 if ((poolType === 'max' && pixel > minMaxValue)) {
                                     minMaxValue = pixel;
@@ -13501,30 +13811,38 @@ var MathBackendCPU = (function () {
         var maxPositions = ops.buffer(convInfo.outShape, 'int32');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
-                    var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMin = xRCorner;
+                    while (xRMin < 0) {
+                        xRMin += dilationHeight;
+                    }
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
-                        var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMin = xCCorner;
+                        while (xCMin < 0) {
+                            xCMin += dilationWidth;
+                        }
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var maxValue = Number.NEGATIVE_INFINITY;
                         var maxPosition = -1;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
                             var wR = xR - xRCorner;
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var wC = xC - xCCorner;
                                 var pixel = x.get(b, xR, xC, d);
                                 if (pixel > maxValue) {
                                     maxValue = pixel;
-                                    maxPosition = wR * filterWidth + wC;
+                                    maxPosition = wR * effectiveFilterWidth + wC;
                                 }
                             }
                         }
@@ -13540,10 +13858,12 @@ var MathBackendCPU = (function () {
         var maxPositions = this.maxPoolPositions(x, convInfo);
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
@@ -13552,21 +13872,21 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
                                     continue;
                                 }
-                                var maxPos = filterHeight * filterWidth - 1 -
-                                    maxPositions.get(b, dyR, dyC, d);
-                                var curPos = wR * filterWidth + wC;
+                                var maxPos = effectiveFilterHeight * effectiveFilterWidth -
+                                    1 - maxPositions.get(b, dyR, dyC, d);
+                                var curPos = wR * effectiveFilterWidth + wC;
                                 var mask = maxPos === curPos ? 1 : 0;
                                 if (mask === 0) {
                                     continue;
@@ -13588,8 +13908,12 @@ var MathBackendCPU = (function () {
         var strideWidth = convInfo.strideWidth;
         var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         var avgMultiplier = 1 / (filterHeight * filterWidth);
         for (var b = 0; b < convInfo.batchSize; ++b) {
@@ -13599,13 +13923,13 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
@@ -13635,7 +13959,8 @@ var MathBackendCPU = (function () {
     MathBackendCPU.prototype.resizeBilinear = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeBilinear');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var result = new Float32Array(util.sizeFromShape([batch, newHeight, newWidth, numChannels]));
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13644,37 +13969,46 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var outputIdx = 0;
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
         for (var b = 0; b < batch; b++) {
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceRowFloor = Math.floor(sourceFracRow);
+                var rowFrac = sourceFracRow - sourceRowFloor;
+                var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
+                var topRowOffset = b * x.strides[0] + sourceRowFloor * x.strides[1];
+                var botRowOffset = b * x.strides[0] + sourceRowCeil * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceColFloor = Math.floor(sourceFracCol);
+                    var colFrac = sourceFracCol - sourceColFloor;
+                    var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
+                    var topLeftOffest = topRowOffset + sourceColFloor * x.strides[2];
+                    var botLeftOffset = botRowOffset + sourceColFloor * x.strides[2];
+                    var topRightOffset = topRowOffset + +sourceColCeil * x.strides[2];
+                    var botRightOffest = botRowOffset + sourceColCeil * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceRowFloor = Math.floor(sourceFracRow);
-                        var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
-                        var sourceColFloor = Math.floor(sourceFracCol);
-                        var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
-                        var topLeft = x.get(b, sourceRowFloor, sourceColFloor, d);
-                        var bottomLeft = x.get(b, sourceRowCeil, sourceColFloor, d);
-                        var topRight = x.get(b, sourceRowFloor, sourceColCeil, d);
-                        var bottomRight = x.get(b, sourceRowCeil, sourceColCeil, d);
-                        var rowFrac = sourceFracRow - sourceRowFloor;
-                        var colFrac = sourceFracCol - sourceColFloor;
+                        var topLeft = xValues[topLeftOffest + d];
+                        var bottomLeft = xValues[botLeftOffset + d];
+                        var topRight = xValues[topRightOffset + d];
+                        var bottomRight = xValues[botRightOffest + d];
                         var top_1 = topLeft + (topRight - topLeft) * colFrac;
                         var bottom = bottomLeft + (bottomRight - bottomLeft) * colFrac;
                         var newValue = top_1 + (bottom - top_1) * rowFrac;
-                        output.set(newValue, b, r, c, d);
+                        result[outputIdx++] = newValue;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(result, [batch, newHeight, newWidth, numChannels]);
     };
     MathBackendCPU.prototype.resizeBilinearBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeBilinearBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13685,11 +14019,16 @@ var MathBackendCPU = (function () {
         ];
         var heightScale = effectiveXSize[0] / effectiveYSize[0];
         var widthScale = effectiveXSize[1] / effectiveYSize[1];
+        var dyValues = dy.dataSync();
+        var offset = 0;
         for (var b = 0; b < batch; b++) {
+            var bOffset = b * x.strides[0];
             for (var r = 0; r < yHeight; r++) {
                 var dxR = r * heightScale;
                 var topDxRIndex = Math.floor(dxR);
                 var bottomDxRIndex = Math.min(Math.ceil(dxR), xHeight - 1);
+                var topDxROffset = bOffset + topDxRIndex * x.strides[1];
+                var bottomDxROffset = bOffset + bottomDxRIndex * x.strides[1];
                 var dxRLerp = dxR - topDxRIndex;
                 var inverseDxRLerp = 1.0 - dxRLerp;
                 for (var c = 0; c < yWidth; c++) {
@@ -13698,30 +14037,33 @@ var MathBackendCPU = (function () {
                     var rightDxCIndex = Math.min(Math.ceil(dxC), xWidth - 1);
                     var dxCLerp = dxC - leftDxCIndex;
                     var inverseDxCLerp = 1.0 - dxCLerp;
+                    var topLeftRCOffset = topDxROffset + leftDxCIndex * x.strides[2];
+                    var topRightRCOffset = topDxROffset + rightDxCIndex * x.strides[2];
+                    var bottomLeftRCOffset = bottomDxROffset + leftDxCIndex * x.strides[2];
+                    var bottomRightRCOffset = bottomDxROffset + rightDxCIndex * x.strides[2];
+                    var inverseDxRLerpTimesInverseDxCLerp = inverseDxRLerp * inverseDxCLerp;
+                    var inverseDxRLerpTimesDxCLerp = inverseDxRLerp * dxCLerp;
+                    var dxRLerpTimesInverseDxCLerp = dxRLerp * inverseDxCLerp;
+                    var dxRLerpTimesDxCLerp = dxRLerp * dxCLerp;
                     for (var d = 0; d < depth; d++) {
-                        var dyVal = dy.get(b, r, c, d);
-                        var topLeft = output.get(b, topDxRIndex, leftDxCIndex, d);
-                        topLeft += dyVal * inverseDxRLerp * inverseDxCLerp;
-                        output.set(topLeft, b, topDxRIndex, leftDxCIndex, d);
-                        var topRight = output.get(b, topDxRIndex, rightDxCIndex, d);
-                        topRight += dyVal * inverseDxRLerp * dxCLerp;
-                        output.set(topRight, b, topDxRIndex, rightDxCIndex, d);
-                        var bottomLeft = output.get(b, bottomDxRIndex, leftDxCIndex, d);
-                        bottomLeft += dyVal * dxRLerp * inverseDxCLerp;
-                        output.set(bottomLeft, b, bottomDxRIndex, leftDxCIndex, d);
-                        var bottomRight = output.get(b, bottomDxRIndex, rightDxCIndex, d);
-                        bottomRight += dyVal * dxRLerp * dxCLerp;
-                        output.set(bottomRight, b, bottomDxRIndex, rightDxCIndex, d);
+                        var dyVal = dyValues[offset++];
+                        output[topLeftRCOffset + d] +=
+                            dyVal * inverseDxRLerpTimesInverseDxCLerp;
+                        output[topRightRCOffset + d] += dyVal * inverseDxRLerpTimesDxCLerp;
+                        output[bottomLeftRCOffset + d] +=
+                            dyVal * dxRLerpTimesInverseDxCLerp;
+                        output[bottomRightRCOffset + d] += dyVal * dxRLerpTimesDxCLerp;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, [batch, xWidth, xHeight, depth], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighbor = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeNearestNeighbor');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var output = new Float32Array(batch * newHeight * newWidth * numChannels);
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13730,29 +14072,36 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
+        var outputOffset = 0;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                    Math.floor(sourceFracRow));
+                var rowOffset = batchOffset + sourceNearestRow * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
+                        Math.floor(sourceFracCol));
+                    var colOffset = rowOffset + sourceNearestCol * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                            Math.floor(sourceFracRow));
-                        var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
-                            Math.floor(sourceFracCol));
-                        var newValue = x.get(b, sourceNearestRow, sourceNearestCol, d);
-                        output.set(newValue, b, r, c, d);
+                        var newVal = xValues[colOffset + d];
+                        output[outputOffset++] = newVal;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(output, [batch, newHeight, newWidth, numChannels], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighborBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeNearestNeighborBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
+        var dyValues = dy.dataSync();
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13768,41 +14117,49 @@ var MathBackendCPU = (function () {
         var winHeight = (Math.ceil(invHeightScale) * 2) + 2;
         var winWidth = (Math.ceil(invWidthScale) * 2) + 2;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < xHeight; r++) {
+                var rowOffset = batchOffset + r * x.strides[1];
+                var startRLerp = Math.floor(r * invHeightScale);
+                var startDyR = Math.floor(startRLerp - (winHeight / 2));
                 for (var c = 0; c < xWidth; c++) {
-                    var startRLerp = Math.floor(r * invHeightScale);
-                    var startDyR = Math.floor(startRLerp - (winHeight / 2));
+                    var colOffset = rowOffset + c * x.strides[2];
                     var startCLerp = Math.floor(c * invWidthScale);
                     var startDyC = Math.floor(startCLerp - (winWidth / 2));
                     for (var d = 0; d < depth; d++) {
                         var accum = 0;
-                        for (var dyROffset = 0; dyROffset < winHeight; dyROffset++) {
-                            var dyR = dyROffset + startDyR;
+                        for (var dyRIndex = 0; dyRIndex < winHeight; dyRIndex++) {
+                            var dyR = dyRIndex + startDyR;
                             if (dyR < 0 || dyR >= yHeight) {
                                 continue;
                             }
-                            for (var dyCOffSet = 0; dyCOffSet < winWidth; dyCOffSet++) {
-                                var dyC = dyCOffSet + startDyC;
+                            var dyROffset = batchOffset + dyR * dy.strides[1];
+                            var sourceFracRow = dyR * heightScale;
+                            var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                                Math.floor(sourceFracRow));
+                            if (r !== sourceNearestRow) {
+                                continue;
+                            }
+                            for (var dyCIndex = 0; dyCIndex < winWidth; dyCIndex++) {
+                                var dyC = dyCIndex + startDyC;
                                 if (dyC < 0 || dyC >= yWidth) {
                                     continue;
                                 }
-                                var sourceFracRow = effectiveXSize[0] * (dyR / effectiveYSize[0]);
-                                var sourceFracCol = effectiveXSize[1] * (dyC / effectiveYSize[1]);
-                                var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                                    Math.floor(sourceFracRow));
+                                var dyCOffset = dyROffset + dyC * dy.strides[2];
+                                var sourceFracCol = dyC * widthScale;
                                 var sourceNearestCol = Math.min(xWidth - 1, alignCorners ? Math.round(sourceFracCol) :
                                     Math.floor(sourceFracCol));
-                                if (r === sourceNearestRow && c === sourceNearestCol) {
-                                    accum += dy.get(b, dyR, dyC, d);
+                                if (c === sourceNearestCol) {
+                                    accum += dyValues[dyCOffset + d];
                                 }
                             }
                         }
-                        output.set(accum, b, r, c, d);
+                        output[colOffset + d] = accum;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, x.shape, x.dtype);
     };
     MathBackendCPU.prototype.batchNormalization = function (x, mean, variance, varianceEpsilon, scale, offset) {
         this.assertNotComplex([x, mean, variance, scale, offset], 'batchNormalization');
@@ -13942,6 +14299,61 @@ var MathBackendCPU = (function () {
         var scoresVals = scores.dataSync();
         return non_max_suppression_impl_1.nonMaxSuppressionImpl(boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
     };
+    MathBackendCPU.prototype.fft = function (input) {
+        if (input.shape[0] !== 1) {
+            throw new Error("tf.fft() on CPU only supports vectors.");
+        }
+        var input1D = input.as1D();
+        var n = input1D.size;
+        if (this.isExponentOf2(n)) {
+            return this.fftRadix2(input1D, n).as2D(input.shape[0], input.shape[1]);
+        }
+        else {
+            var data = input.dataSync();
+            var rawOutput = this.fourierTransformByMatmul(data, n);
+            var output = complex_util.splitRealAndImagArrays(rawOutput);
+            return ops.complex(output.real, output.imag)
+                .as2D(input.shape[0], input.shape[1]);
+        }
+    };
+    MathBackendCPU.prototype.isExponentOf2 = function (size) {
+        return (size & size - 1) === 0;
+    };
+    MathBackendCPU.prototype.fftRadix2 = function (input, size) {
+        if (size === 1) {
+            return input;
+        }
+        var data = input.dataSync();
+        var half = size / 2;
+        var evenComplex = complex_util.complexWithEvenIndex(data);
+        var evenTensor = ops.complex(evenComplex.real, evenComplex.imag).as1D();
+        var oddComplex = complex_util.complexWithOddIndex(data);
+        var oddTensor = ops.complex(oddComplex.real, oddComplex.imag).as1D();
+        evenTensor = this.fftRadix2(evenTensor, half);
+        oddTensor = this.fftRadix2(oddTensor, half);
+        var e = complex_util.exponents(size);
+        var exponent = ops.complex(e.real, e.imag).mul(oddTensor);
+        var addPart = evenTensor.add(exponent);
+        var subPart = evenTensor.sub(exponent);
+        var realTensor = ops.real(addPart).concat(ops.real(subPart));
+        var imagTensor = ops.imag(addPart).concat(ops.imag(subPart));
+        return ops.complex(realTensor, imagTensor).as1D();
+    };
+    MathBackendCPU.prototype.fourierTransformByMatmul = function (data, size) {
+        var ret = new Float32Array(size * 2);
+        for (var r = 0; r < size; r++) {
+            var real = 0.0;
+            var imag = 0.0;
+            for (var c = 0; c < size; c++) {
+                var e = complex_util.exponent(r * c, size);
+                var term = complex_util.getComplexWithIndex(data, c);
+                real += term.real * e.real - term.imag * e.imag;
+                imag += term.real * e.imag + term.imag * e.real;
+            }
+            complex_util.assignToTypedArray(ret, real, imag, r);
+        }
+        return ret;
+    };
     MathBackendCPU.prototype.depthToSpace = function (x, blockSize, dataFormat) {
         util.assert(dataFormat === 'NHWC', "Only NHWC dataFormat supported on CPU for depthToSpace. Got " + dataFormat);
         util.assert(blockSize > 1, "blockSize should be > 1 for depthToSpace, but was: " + blockSize);
@@ -14075,9 +14487,7 @@ var MathBackendCPU = (function () {
             var heightScale = (cropHeight > 1) ?
                 (y2 - y1) * (imageHeight - 1) / (cropHeight - 1) :
                 0;
-            var widthScale = (cropWidth > 1) ?
-                (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) :
-                0;
+            var widthScale = (cropWidth > 1) ? (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) : 0;
             for (var y = 0; y < cropHeight; y++) {
                 var yInd = (cropHeight > 1) ?
                     y1 * (imageHeight - 1) + y * (heightScale) :
@@ -14085,8 +14495,7 @@ var MathBackendCPU = (function () {
                 if (yInd < 0 || yInd > imageHeight - 1) {
                     for (var x = 0; x < cropWidth; x++) {
                         for (var c = 0; c < numChannels; c++) {
-                            var ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = extrapolationValue;
                         }
                     }
@@ -14102,8 +14511,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14126,8 +14534,7 @@ var MathBackendCPU = (function () {
                             var bottomRight = imageVals[ind];
                             var top_2 = topLeft + (topRight - topLeft) * xLerp;
                             var bottom = bottomLeft + (bottomRight - bottomLeft) * xLerp;
-                            ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = top_2 + ((bottom - top_2) * yLerp);
                         }
                     }
@@ -14139,8 +14546,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14148,10 +14554,9 @@ var MathBackendCPU = (function () {
                         var closestX = Math.round(xInd);
                         var closestY = Math.round(yInd);
                         for (var c = 0; c < numChannels; c++) {
-                            var inInd = c + closestX * inStride[2]
-                                + closestY * inStride[1] + bInd * inStride[0];
-                            var outInd = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var inInd = c + closestX * inStride[2] +
+                                closestY * inStride[1] + bInd * inStride[0];
+                            var outInd = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[outInd] = imageVals[inInd];
                         }
                     }
@@ -14160,12 +14565,84 @@ var MathBackendCPU = (function () {
         }
         return output.toTensor();
     };
+    MathBackendCPU.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        return this.scatter(sparseIndices, sparseValues, outputShape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        if (numSlices === 0) {
+            return ops_1.tensor([], resultShape, x.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer([numSlices, sliceSize], x.dtype);
+        var indicesData = indices.dataSync();
+        var xData = x.dataSync();
+        for (var i = 0; i < numSlices; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                flattenIndex += dim * strides[j];
+                index.push(dim);
+            }
+            if (flattenIndex < 0 || flattenIndex >= x.size / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + x.shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                buffer.values[i * sliceSize + k] = xData[flattenIndex * sliceSize + k];
+            }
+        }
+        return buffer.toTensor().reshape(resultShape);
+    };
+    MathBackendCPU.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var defaultValue = ops_1.scalar(0);
+        var sumDupeIndices = true;
+        return this.scatter(indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.scatter = function (indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices) {
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var indicesData = indices.dataSync();
+        var updatesData = updates.dataSync();
+        if (outputSize === 0) {
+            return ops_1.tensor([], shape, updates.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer(flattenShape, updates.dtype);
+        buffer.values.fill(defaultValue.dataSync()[0]);
+        for (var i = 0; i < numUpdates; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                index.push(dim);
+                flattenIndex += dim * strides[j];
+            }
+            if (flattenIndex < 0 || flattenIndex >= outputSize / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                if (sumDupeIndices) {
+                    buffer.values[flattenIndex * sliceSize + k] +=
+                        updatesData[i * sliceSize + k];
+                }
+                else {
+                    buffer.values[flattenIndex * sliceSize + k] = updates.rank === 0 ?
+                        updatesData[0] :
+                        updatesData[i * sliceSize + k];
+                }
+            }
+        }
+        return buffer.toTensor().reshape(shape);
+    };
     return MathBackendCPU;
 }());
 exports.MathBackendCPU = MathBackendCPU;
 environment_1.ENV.registerBackend('cpu', function () { return new MathBackendCPU(); }, 1, tensor_1.setTensorTracker);
 
-},{"../environment":64,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/broadcast_util":139,"../ops/concat_util":143,"../ops/erf_util":146,"../ops/ops":157,"../ops/selu_util":166,"../ops/slice_util":168,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./where_impl":132,"seedrandom":283}],81:[function(require,module,exports){
+},{"../environment":64,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/broadcast_util":151,"../ops/concat_util":155,"../ops/erf_util":159,"../ops/gather_nd_util":161,"../ops/ops":172,"../ops/scatter_nd_util":180,"../ops/selu_util":183,"../ops/slice_util":185,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./where_impl":143,"seedrandom":307}],82:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -14211,7 +14688,7 @@ function reshapeTensor(x, shape) {
 }
 exports.reshapeTensor = reshapeTensor;
 
-},{"../ops/tensor_ops":171,"../tensor":187,"../util":194}],82:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../tensor":207,"../util":214}],83:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14255,7 +14732,9 @@ var log_1 = require("../log");
 var array_ops_util = require("../ops/array_ops_util");
 var axis_util = require("../ops/axis_util");
 var concat_util_1 = require("../ops/concat_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var reduce_util = require("../ops/reduce_util");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var segment_util = require("../ops/segment_util");
 var slice_util_1 = require("../ops/slice_util");
 var softmax_1 = require("../ops/softmax");
@@ -14264,6 +14743,7 @@ var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util_1 = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -14272,31 +14752,39 @@ var topk_impl_1 = require("./topk_impl");
 var argminmax_gpu_1 = require("./webgl/argminmax_gpu");
 var avg_pool_backprop_gpu_1 = require("./webgl/avg_pool_backprop_gpu");
 var batchnorm_gpu_1 = require("./webgl/batchnorm_gpu");
+var batchnorm_packed_gpu_1 = require("./webgl/batchnorm_packed_gpu");
 var binaryop_complex_gpu = require("./webgl/binaryop_complex_gpu");
 var binaryop_complex_gpu_1 = require("./webgl/binaryop_complex_gpu");
 var binaryop_gpu = require("./webgl/binaryop_gpu");
 var binaryop_gpu_1 = require("./webgl/binaryop_gpu");
 var clip_gpu_1 = require("./webgl/clip_gpu");
+var complex_abs_gpu_1 = require("./webgl/complex_abs_gpu");
 var concat_gpu_1 = require("./webgl/concat_gpu");
 var conv_backprop_gpu_1 = require("./webgl/conv_backprop_gpu");
 var conv_backprop_gpu_depthwise_1 = require("./webgl/conv_backprop_gpu_depthwise");
 var conv_gpu_1 = require("./webgl/conv_gpu");
-var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var conv_gpu_depthwise_1 = require("./webgl/conv_gpu_depthwise");
+var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var cumsum_gpu_1 = require("./webgl/cumsum_gpu");
 var depth_to_space_gpu_1 = require("./webgl/depth_to_space_gpu");
 var encode_float_gpu_1 = require("./webgl/encode_float_gpu");
+var fft_gpu = require("./webgl/fft_gpu");
+var fft_gpu_1 = require("./webgl/fft_gpu");
 var from_pixels_gpu_1 = require("./webgl/from_pixels_gpu");
 var gather_gpu_1 = require("./webgl/gather_gpu");
+var gather_nd_gpu_1 = require("./webgl/gather_nd_gpu");
 var gpgpu_context_1 = require("./webgl/gpgpu_context");
 var gpgpu_math = require("./webgl/gpgpu_math");
 var gpgpu_util = require("./webgl/gpgpu_util");
+var im2col_gpu_1 = require("./webgl/im2col_gpu");
 var lrn_gpu_1 = require("./webgl/lrn_gpu");
 var lrn_grad_gpu_1 = require("./webgl/lrn_grad_gpu");
 var max_pool_backprop_gpu_1 = require("./webgl/max_pool_backprop_gpu");
 var mulmat_gpu_1 = require("./webgl/mulmat_gpu");
+var mulmat_packed_gpu_1 = require("./webgl/mulmat_packed_gpu");
 var multinomial_gpu_1 = require("./webgl/multinomial_gpu");
 var onehot_gpu_1 = require("./webgl/onehot_gpu");
+var pack_gpu_1 = require("./webgl/pack_gpu");
 var pad_gpu_1 = require("./webgl/pad_gpu");
 var pool_gpu_1 = require("./webgl/pool_gpu");
 var reduce_gpu_1 = require("./webgl/reduce_gpu");
@@ -14305,6 +14793,7 @@ var resize_bilinear_gpu_1 = require("./webgl/resize_bilinear_gpu");
 var resize_nearest_neighbor_backprop_gpu_1 = require("./webgl/resize_nearest_neighbor_backprop_gpu");
 var resize_nearest_neighbor_gpu_1 = require("./webgl/resize_nearest_neighbor_gpu");
 var reverse_gpu_1 = require("./webgl/reverse_gpu");
+var scatter_gpu_1 = require("./webgl/scatter_gpu");
 var segment_gpu_1 = require("./webgl/segment_gpu");
 var select_gpu_1 = require("./webgl/select_gpu");
 var slice_gpu_1 = require("./webgl/slice_gpu");
@@ -14315,16 +14804,16 @@ var tile_gpu_1 = require("./webgl/tile_gpu");
 var transpose_gpu_1 = require("./webgl/transpose_gpu");
 var unary_op = require("./webgl/unaryop_gpu");
 var unaryop_gpu_1 = require("./webgl/unaryop_gpu");
+var unpack_gpu_1 = require("./webgl/unpack_gpu");
 var webgl_util = require("./webgl/webgl_util");
 var where_impl_1 = require("./where_impl");
 var BEFORE_PAGING_CONSTANT = 300;
-exports.SIZE_UPLOAD_UNIFORM = 32;
+exports.SIZE_UPLOAD_UNIFORM = 4;
 var MathBackendWebGL = (function () {
     function MathBackendWebGL(gpgpu, delayedStorage) {
         if (delayedStorage === void 0) { delayedStorage = true; }
         this.gpgpu = gpgpu;
         this.delayedStorage = delayedStorage;
-        this.texData = new WeakMap();
         this.pendingRead = new WeakMap();
         this.pendingDisposal = new WeakSet();
         this.lruDataGPU = [];
@@ -14346,9 +14835,12 @@ var MathBackendWebGL = (function () {
         else {
             this.gpgpuCreatedLocally = false;
         }
-        this.NUM_BYTES_BEFORE_PAGING =
-            (window.screen.height * window.screen.width * window.devicePixelRatio) *
-                BEFORE_PAGING_CONSTANT;
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.NUM_BYTES_BEFORE_PAGING =
+                (window.screen.height * window.screen.width *
+                    window.devicePixelRatio) *
+                    BEFORE_PAGING_CONSTANT;
+        }
         this.textureManager = new texture_manager_1.TextureManager(this.gpgpu);
     }
     MathBackendWebGL.prototype.register = function (dataId, shape, dtype) {
@@ -14362,8 +14854,12 @@ var MathBackendWebGL = (function () {
             texture: null,
             complexTensors: null,
             texShape: null,
-            usage: tex_util_1.TextureUsage.RENDER
+            usage: tex_util_1.TextureUsage.RENDER,
+            isPacked: false
         });
+    };
+    MathBackendWebGL.prototype.setDataMover = function (dataMover) {
+        this.texData = new backend_1.DataStorage(dataMover);
     };
     MathBackendWebGL.prototype.fromPixels = function (pixels, numChannels) {
         if (pixels == null) {
@@ -14396,27 +14892,31 @@ var MathBackendWebGL = (function () {
             this.fromPixelsCanvas.getContext('2d').drawImage(pixels, 0, 0, pixels.width, pixels.height);
             pixels = this.fromPixelsCanvas;
         }
-        var tempPixelArray = tensor_1.Tensor.make(texShape, {}, 'int32');
-        this.texData.get(tempPixelArray.dataId).usage = tex_util_1.TextureUsage.PIXELS;
-        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelArray.dataId), pixels);
+        var tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
+        this.texData.get(tempPixelHandle.dataId).usage = tex_util_1.TextureUsage.PIXELS;
+        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelHandle.dataId), pixels);
         var program = new from_pixels_gpu_1.FromPixelsProgram(outShape);
-        var res = this.compileAndRun(program, [tempPixelArray]);
-        tempPixelArray.dispose();
+        var res = this.compileAndRun(program, [tempPixelHandle]);
+        this.disposeData(tempPixelHandle.dataId);
         return res;
+    };
+    MathBackendWebGL.prototype.makeTensorHandle = function (shape, dtype) {
+        var dataId = {};
+        this.register(dataId, shape, dtype);
+        return { dataId: dataId, shape: shape, dtype: dtype };
     };
     MathBackendWebGL.prototype.write = function (dataId, values) {
         if (values == null) {
             throw new Error('MathBackendWebGL.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype;
+        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype, isPacked = texData.isPacked;
         if (dtype === 'complex64') {
             throw new Error("Cannot write to a complex64 dtype. " +
                 "Please use tf.complex(real, imag).");
         }
         if (texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -14427,9 +14927,8 @@ var MathBackendWebGL = (function () {
         }
     };
     MathBackendWebGL.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype, complexTensors = texData.complexTensors;
+        var values = texData.values, dtype = texData.dtype, complexTensors = texData.complexTensors;
         if (values != null) {
             this.cacheOnCPU(dataId);
             return values;
@@ -14446,8 +14945,7 @@ var MathBackendWebGL = (function () {
             result = complex_util_1.mergeRealAndImagArrays(realValues, imagValues);
         }
         else {
-            result =
-                this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+            result = this.getValuesFromTexture(dataId);
         }
         if (shouldTimeProgram) {
             this.downloadWaitMs += performance.now() - start;
@@ -14457,7 +14955,7 @@ var MathBackendWebGL = (function () {
     };
     MathBackendWebGL.prototype.read = function (dataId) {
         return __awaiter(this, void 0, void 0, function () {
-            var subscribers_1, texData, shape, texture, values, texShape, dtype, bufferOrTexture, vals, subscribers;
+            var subscribers_1, texData, texture, values, texShape, bufferOrTexture, vals, subscribers;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14465,9 +14963,8 @@ var MathBackendWebGL = (function () {
                             subscribers_1 = this.pendingRead.get(dataId);
                             return [2, new Promise(function (resolve) { return subscribers_1.push(resolve); })];
                         }
-                        this.throwIfNoData(dataId);
                         texData = this.texData.get(dataId);
-                        shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype;
+                        texture = texData.texture, values = texData.values, texShape = texData.texShape;
                         if (values != null) {
                             this.cacheOnCPU(dataId);
                             return [2, values];
@@ -14483,7 +14980,7 @@ var MathBackendWebGL = (function () {
                     case 1:
                         _a.sent();
                         if (bufferOrTexture instanceof WebGLTexture) {
-                            vals = this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+                            vals = this.getValuesFromTexture(dataId);
                         }
                         else {
                             vals = this.gpgpu.downloadFloat32MatrixFromBuffer(bufferOrTexture, texShape[0], texShape[1]);
@@ -14501,25 +14998,33 @@ var MathBackendWebGL = (function () {
             });
         });
     };
-    MathBackendWebGL.prototype.getValuesFromTexture = function (texture, dataId, dtype, texShape, shape) {
+    MathBackendWebGL.prototype.getValuesFromTexture = function (dataId) {
+        var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype, texture = _a.texture, texShape = _a.texShape;
         if (environment_1.ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
-            return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            if (this.texData.get(dataId).isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                return this.gpgpu.downloadMatrixFromPackedTexture(texture, batch, rows, cols, texShape[0], texShape[1]);
+            }
+            else {
+                return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            }
         }
-        var tmpTarget = tensor_1.Tensor.make(shape, {});
+        var tmpTarget = this.makeTensorHandle(shape, 'float32');
+        tmpTarget.size = util_1.sizeFromShape(shape);
         this.texData.get(tmpTarget.dataId).usage = tex_util_1.TextureUsage.DOWNLOAD;
-        var tmpInput = tensor_1.Tensor.make(shape, { dataId: dataId }, dtype);
         var program = new encode_float_gpu_1.EncodeFloatProgram(shape);
         var pageToCpu = false;
-        this.compileAndRun(program, [tmpInput], tmpTarget, null, pageToCpu);
+        this.compileAndRun(program, [{ shape: shape, dtype: dtype, dataId: dataId }], tmpTarget, null, pageToCpu);
         var tmpData = this.texData.get(tmpTarget.dataId);
         var vals = this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
-        tmpInput.dispose();
-        tmpTarget.dispose();
+        this.disposeData(tmpTarget.dataId);
         return vals;
     };
     MathBackendWebGL.prototype.time = function (f) {
         return __awaiter(this, void 0, void 0, function () {
-            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimers, kernelMs, res;
+            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimerQueries, flattenedActiveTimerNames, kernelMs, res;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14535,22 +15040,26 @@ var MathBackendWebGL = (function () {
                         }
                         this.activeTimers = newActiveTimers;
                         f();
-                        flattenedActiveTimers = util.flatten(this.activeTimers);
+                        flattenedActiveTimerQueries = util.flatten(this.activeTimers.map(function (d) { return d.query; }))
+                            .filter(function (d) { return d != null; });
+                        flattenedActiveTimerNames = util.flatten(this.activeTimers.map(function (d) { return d.name; }))
+                            .filter(function (d) { return d != null; });
                         this.activeTimers = oldActiveTimers;
                         if (outerMostTime) {
                             this.programTimersStack = null;
                         }
-                        return [4, Promise.all(flattenedActiveTimers).then(function (results) {
-                                var sum = 0;
-                                results.forEach(function (result) { return sum += result; });
-                                return sum;
-                            })];
+                        return [4, Promise.all(flattenedActiveTimerQueries)];
                     case 1:
                         kernelMs = _a.sent();
                         res = {
                             uploadWaitMs: this.uploadWaitMs,
                             downloadWaitMs: this.downloadWaitMs,
-                            kernelMs: kernelMs,
+                            kernelMs: util.sum(kernelMs),
+                            getExtraProfileInfo: function () {
+                                return kernelMs.map(function (d, i) { return ({ name: flattenedActiveTimerNames[i], ms: d }); })
+                                    .map(function (d) { return d.name + ": " + d.ms; })
+                                    .join(', ');
+                            },
                             wallMs: null
                         };
                         this.uploadWaitMs = 0;
@@ -14598,9 +15107,9 @@ var MathBackendWebGL = (function () {
             return;
         }
         if (this.texData.has(dataId)) {
-            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors;
+            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors, isPacked = _a.isPacked;
             if (texture != null) {
-                this.releaseTexture(dataId, texture, texShape, usage);
+                this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             }
             if (complexTensors != null) {
                 complexTensors.real.dispose();
@@ -14620,7 +15129,7 @@ var MathBackendWebGL = (function () {
         return this.canvas;
     };
     MathBackendWebGL.prototype.complex = function (real, imag) {
-        var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
+        var result = this.makeOutputArray(real.shape, 'complex64');
         var resultData = this.texData.get(result.dataId);
         resultData.complexTensors = {
             real: environment_1.ENV.engine.keep(real.clone()),
@@ -14677,8 +15186,18 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.batchMatMul = function (a, b, transposeA, transposeB) {
-        var program = new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-        return this.compileAndRun(program, [a, b]);
+        var outerShapeA = transposeA ? a.shape[2] : a.shape[1];
+        var outerShapeB = transposeB ? b.shape[1] : b.shape[2];
+        if (a.shape[0] === 1 && b.shape[0] === 1) {
+            var aSqueezed = a.as2D(a.shape[1], a.shape[2]);
+            var bSqueezed = b.as2D(b.shape[1], b.shape[2]);
+            var program = new mulmat_packed_gpu_1.MatMulPackedProgram(aSqueezed.shape, bSqueezed.shape, [outerShapeA, outerShapeB], transposeA, transposeB);
+            var result = this.unpackTensor(this.compileAndRun(program, [aSqueezed, bSqueezed], this.makePackedTensor(program.outputShape)));
+            return result.reshape([1, result.shape[0], result.shape[1]]);
+        }
+        else {
+            return this.compileAndRun(new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB), [a, b]);
+        }
     };
     MathBackendWebGL.prototype.multiply = function (a, b) {
         if (a.dtype === 'complex64') {
@@ -14715,8 +15234,14 @@ var MathBackendWebGL = (function () {
             scaleShape = scale.shape;
             inputs.push(scale);
         }
-        var program = new batchnorm_gpu_1.BatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
-        return this.compileAndRun(program, inputs);
+        var output = null;
+        var envSpecificBatchNormProgram = batchnorm_gpu_1.BatchNormProgram;
+        if (environment_1.ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
+            output = this.makePackedTensor(x.shape);
+            envSpecificBatchNormProgram = batchnorm_packed_gpu_1.BatchNormPackedProgram;
+        }
+        var program = new envSpecificBatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
+        return this.compileAndRun(program, inputs, output);
     };
     MathBackendWebGL.prototype.localResponseNormalization4D = function (x, radius, bias, alpha, beta) {
         var program = new lrn_gpu_1.LRNProgram(x.shape, radius, bias, alpha, beta);
@@ -14815,6 +15340,13 @@ var MathBackendWebGL = (function () {
         var a2D = x.as2D(-1, inSize);
         var outputDType = types_1.sumOutType(x.dtype);
         return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+    };
+    MathBackendWebGL.prototype.prod = function (x, axes) {
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var inSize = util.sizeFromShape(reduceShape);
+        var a2D = x.as2D(-1, inSize);
+        var outputDType = types_1.sumOutType(x.dtype);
+        return this.reduce(a2D, 'prod', outputDType).reshape(outShape);
     };
     MathBackendWebGL.prototype.unsortedSegmentSum = function (x, segmentIds, numSegments) {
         var axis = 0;
@@ -15123,6 +15655,15 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.abs = function (x) {
+        if (x.dtype === 'complex64') {
+            var xData = this.texData.get(x.dataId);
+            var program_1 = new complex_abs_gpu_1.ComplexAbsProgram(x.shape);
+            var inputs = [
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+            ];
+            return this.compileAndRun(program_1, inputs);
+        }
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.ABS);
         return this.compileAndRun(program, [x]);
     };
@@ -15196,7 +15737,23 @@ var MathBackendWebGL = (function () {
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.STEP(alpha));
         return this.compileAndRun(program, [x]);
     };
+    MathBackendWebGL.prototype.conv2dWithIm2Row = function (x, filter, convInfo) {
+        var filterWidth = convInfo.filterWidth, filterHeight = convInfo.filterHeight, inChannels = convInfo.inChannels, outWidth = convInfo.outWidth, outHeight = convInfo.outHeight;
+        var sharedDim = filterWidth * filterHeight * inChannels;
+        var numCols = outHeight * outWidth;
+        var x2ColShape = [sharedDim, numCols];
+        var xSqueezed = x.squeeze([0]);
+        var w2Row = filter.reshape([sharedDim, -1]);
+        var im2ColProgram = new im2col_gpu_1.Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
+        var im2Col = this.compileAndRun(im2ColProgram, [xSqueezed], this.makePackedTensor(x2ColShape));
+        var matmulProgram = new mulmat_packed_gpu_1.MatMulPackedProgram(im2Col.shape, w2Row.shape, [numCols, convInfo.outChannels], true, false);
+        var product = this.unpackTensor(this.compileAndRun(matmulProgram, [im2Col, w2Row], this.makePackedTensor(matmulProgram.outputShape)));
+        return product.reshape([1, outHeight, outWidth, convInfo.outChannels]);
+    };
     MathBackendWebGL.prototype.conv2d = function (x, filter, convInfo) {
+        if (environment_1.ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
+            return this.conv2dWithIm2Row(x, filter, convInfo);
+        }
         var program = new conv_gpu_1.Conv2DProgram(convInfo);
         return this.compileAndRun(program, [x, filter]);
     };
@@ -15309,14 +15866,69 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.split = function (x, sizeSplits, axis) {
         return split_shared_1.split(x, sizeSplits, axis);
     };
+    MathBackendWebGL.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var flattenIndices = indices.reshape([numUpdates, sliceRank]);
+        var flattenX = updates.reshape([numUpdates, sliceSize]);
+        if (outputSize === 0) {
+            return backend_util.reshapeTensor(tensor_ops_1.tensor([]), shape);
+        }
+        var defaultValue = tensor_ops_1.scalar(0);
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, flattenIndices.rank, flattenX.rank, strides, flattenShape);
+        return this.compileAndRun(program, [flattenX, flattenIndices, defaultValue])
+            .reshape(shape);
+    };
+    MathBackendWebGL.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, sparseIndices.rank, sparseValues.rank, strides, [outputSize, 1], sumDupeIndices);
+        return this.compileAndRun(program, [sparseValues, sparseIndices, defaultValue])
+            .reshape(outputShape);
+    };
+    MathBackendWebGL.prototype.fft = function (x) {
+        var xData = this.texData.get(x.dataId);
+        var realProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
+        var imagProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+        var inputs = [
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+        ];
+        var real = this.compileAndRun(realProgram, inputs);
+        var imag = this.compileAndRun(imagProgram, inputs);
+        var complex = this.complex(real, imag).as2D(x.shape[0], x.shape[1]);
+        real.dispose();
+        imag.dispose();
+        return complex;
+    };
+    MathBackendWebGL.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        var flattenIndices = indices.reshape([numSlices, sliceRank]);
+        var flattenX = x.reshape([x.size / sliceSize, sliceSize]);
+        var program = new gather_nd_gpu_1.GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+        return this.compileAndRun(program, [flattenX, flattenIndices])
+            .reshape(resultShape);
+    };
     MathBackendWebGL.prototype.makeOutputArray = function (shape, dtype) {
         return tensor_1.Tensor.make(shape, {}, dtype);
+    };
+    MathBackendWebGL.prototype.makePackedTensor = function (shape) {
+        var packedTensor = tensor_1.Tensor.make(shape, {});
+        this.texData.get(packedTensor.dataId).isPacked = true;
+        return packedTensor;
+    };
+    MathBackendWebGL.prototype.unpackTensor = function (input) {
+        var program = new unpack_gpu_1.UnpackProgram(input.shape);
+        return this.compileAndRun(program, [input]);
     };
     MathBackendWebGL.prototype.compileAndRun = function (program, inputs, output, customSetup, pageToCpu) {
         var _this = this;
         if (pageToCpu === void 0) { pageToCpu = true; }
         if (output == null) {
-            output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+            output =
+                this.makeOutputArray(program.outputShape, inputs[0].dtype);
         }
         if (output.size === 0) {
             this.texData.get(output.dataId).values =
@@ -15331,13 +15943,29 @@ var MathBackendWebGL = (function () {
             }
             var texData = _this.texData.get(input.dataId);
             if (texData.texture == null &&
-                util.sizeFromShape(input.shape) <= exports.SIZE_UPLOAD_UNIFORM) {
+                !(!texData.isPacked && program.usesPackedTextures) &&
+                util.sizeFromShape(input.shape) <=
+                    environment_1.ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
                 return {
                     shape: input.shape,
                     texData: null,
                     isUniform: true,
                     uniformValues: _this.readSync(input.dataId)
                 };
+            }
+            if (texData.isPacked !== !!program.usesPackedTextures) {
+                var preProcessProgram = void 0;
+                var processedInput = void 0;
+                if (texData.isPacked) {
+                    preProcessProgram = new unpack_gpu_1.UnpackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input]);
+                }
+                else {
+                    preProcessProgram = new pack_gpu_1.PackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input], _this.makePackedTensor(input.shape));
+                }
+                texData = _this.texData.get(processedInput.dataId);
+                input = processedInput;
             }
             _this.uploadToGPU(input.dataId);
             return { shape: input.shape, texData: texData, isUniform: false };
@@ -15358,7 +15986,8 @@ var MathBackendWebGL = (function () {
             query = this.startTimer();
         }
         gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-        if (pageToCpu && this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED') && pageToCpu &&
+            this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
             var numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
             while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
                 var dataId = this.lruDataGPU.shift();
@@ -15369,7 +15998,7 @@ var MathBackendWebGL = (function () {
         }
         if (shouldTimeProgram) {
             query = this.endTimer(query);
-            this.activeTimers.push(this.getQueryTime(query));
+            this.activeTimers.push({ name: program.constructor.name, query: this.getQueryTime(query) });
         }
         return output;
     };
@@ -15408,22 +16037,16 @@ var MathBackendWebGL = (function () {
             return 16;
         });
     };
-    MathBackendWebGL.prototype.throwIfNoData = function (dataId) {
-        if (!this.texData.has(dataId)) {
-            throw new Error("WebGL backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
-    };
     MathBackendWebGL.prototype.uploadToGPU = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage;
+        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (texture != null) {
-            var index = this.lruDataGPU.indexOf(dataId);
-            if (index >= 0) {
-                this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
-                this.lruDataGPU.push(dataId);
+            if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+                var index = this.lruDataGPU.indexOf(dataId);
+                if (index >= 0) {
+                    this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
+                    this.lruDataGPU.push(dataId);
+                }
             }
             return;
         }
@@ -15432,12 +16055,20 @@ var MathBackendWebGL = (function () {
         if (shouldTimeProgram) {
             start = performance.now();
         }
-        var texShape = webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        var texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
         texData.texShape = texShape;
-        var newTexture = this.acquireTexture(dataId, texShape, usage);
+        var newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
         texData.texture = newTexture;
         if (values != null) {
-            this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            if (isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                this.gpgpu.uploadMatrixToPackedTexture(newTexture, batch, rows, cols, typedArrayToFloat32(values, dtype));
+            }
+            else {
+                this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            }
             texData.values = null;
             if (shouldTimeProgram) {
                 this.uploadWaitMs += performance.now() - start;
@@ -15447,9 +16078,9 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.cacheOnCPU = function (dataId, float32Values) {
         var dontKeepCopyOnGPU = this.delayedStorage;
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage;
+        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (dontKeepCopyOnGPU && texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -15458,20 +16089,24 @@ var MathBackendWebGL = (function () {
             texData.values = float32ToTypedArray(float32Values, dtype);
         }
     };
-    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType) {
+    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        var idx = this.lruDataGPU.indexOf(dataId);
-        if (idx >= 0) {
-            this.lruDataGPU.splice(idx, 1);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            var idx = this.lruDataGPU.indexOf(dataId);
+            if (idx >= 0) {
+                this.lruDataGPU.splice(idx, 1);
+            }
         }
         this.numBytesInGPU -= this.computeBytes(shape, dtype);
-        this.textureManager.releaseTexture(texture, texShape, texType);
+        this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
     };
-    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType) {
+    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        this.lruDataGPU.push(dataId);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.lruDataGPU.push(dataId);
+        }
         this.numBytesInGPU += this.computeBytes(shape, dtype);
-        return this.textureManager.acquireTexture(texShape, texType);
+        return this.textureManager.acquireTexture(texShape, texType, isPacked);
     };
     MathBackendWebGL.prototype.computeBytes = function (shape, dtype) {
         return util.sizeFromShape(shape) * util.bytesPerElement(dtype);
@@ -15502,7 +16137,7 @@ function typedArrayToFloat32(a, dtype) {
     return (a instanceof Float32Array) ? a : new Float32Array(a);
 }
 
-},{"../environment":64,"../globals":66,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/concat_util":143,"../ops/reduce_util":160,"../ops/segment_util":165,"../ops/slice_util":168,"../ops/softmax":169,"../ops/tensor_ops":171,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./webgl/argminmax_gpu":87,"./webgl/avg_pool_backprop_gpu":88,"./webgl/batchnorm_gpu":89,"./webgl/binaryop_complex_gpu":90,"./webgl/binaryop_gpu":91,"./webgl/clip_gpu":92,"./webgl/concat_gpu":93,"./webgl/conv_backprop_gpu":94,"./webgl/conv_backprop_gpu_depthwise":95,"./webgl/conv_gpu":96,"./webgl/conv_gpu_depthwise":97,"./webgl/crop_and_resize_gpu":98,"./webgl/cumsum_gpu":99,"./webgl/depth_to_space_gpu":100,"./webgl/encode_float_gpu":101,"./webgl/from_pixels_gpu":102,"./webgl/gather_gpu":103,"./webgl/gpgpu_context":104,"./webgl/gpgpu_math":105,"./webgl/gpgpu_util":106,"./webgl/lrn_gpu":107,"./webgl/lrn_grad_gpu":108,"./webgl/max_pool_backprop_gpu":109,"./webgl/mulmat_gpu":110,"./webgl/multinomial_gpu":111,"./webgl/onehot_gpu":112,"./webgl/pad_gpu":113,"./webgl/pool_gpu":114,"./webgl/reduce_gpu":115,"./webgl/resize_bilinear_backprop_gpu":116,"./webgl/resize_bilinear_gpu":117,"./webgl/resize_nearest_neighbor_backprop_gpu":118,"./webgl/resize_nearest_neighbor_gpu":119,"./webgl/reverse_gpu":120,"./webgl/segment_gpu":121,"./webgl/select_gpu":122,"./webgl/slice_gpu":124,"./webgl/strided_slice_gpu":125,"./webgl/tex_util":126,"./webgl/texture_manager":127,"./webgl/tile_gpu":128,"./webgl/transpose_gpu":129,"./webgl/unaryop_gpu":130,"./webgl/webgl_util":131,"./where_impl":132}],83:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/concat_util":155,"../ops/gather_nd_util":161,"../ops/reduce_util":175,"../ops/scatter_nd_util":180,"../ops/segment_util":182,"../ops/slice_util":185,"../ops/softmax":186,"../ops/tensor_ops":191,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./webgl/argminmax_gpu":89,"./webgl/avg_pool_backprop_gpu":90,"./webgl/batchnorm_gpu":91,"./webgl/batchnorm_packed_gpu":92,"./webgl/binaryop_complex_gpu":93,"./webgl/binaryop_gpu":94,"./webgl/clip_gpu":95,"./webgl/complex_abs_gpu":96,"./webgl/concat_gpu":97,"./webgl/conv_backprop_gpu":98,"./webgl/conv_backprop_gpu_depthwise":99,"./webgl/conv_gpu":100,"./webgl/conv_gpu_depthwise":101,"./webgl/crop_and_resize_gpu":102,"./webgl/cumsum_gpu":103,"./webgl/depth_to_space_gpu":104,"./webgl/encode_float_gpu":105,"./webgl/fft_gpu":106,"./webgl/from_pixels_gpu":107,"./webgl/gather_gpu":108,"./webgl/gather_nd_gpu":109,"./webgl/gpgpu_context":110,"./webgl/gpgpu_math":111,"./webgl/gpgpu_util":112,"./webgl/im2col_gpu":113,"./webgl/lrn_gpu":114,"./webgl/lrn_grad_gpu":115,"./webgl/max_pool_backprop_gpu":116,"./webgl/mulmat_gpu":117,"./webgl/mulmat_packed_gpu":118,"./webgl/multinomial_gpu":119,"./webgl/onehot_gpu":120,"./webgl/pack_gpu":121,"./webgl/pad_gpu":122,"./webgl/pool_gpu":123,"./webgl/reduce_gpu":124,"./webgl/resize_bilinear_backprop_gpu":125,"./webgl/resize_bilinear_gpu":126,"./webgl/resize_nearest_neighbor_backprop_gpu":127,"./webgl/resize_nearest_neighbor_gpu":128,"./webgl/reverse_gpu":129,"./webgl/scatter_gpu":130,"./webgl/segment_gpu":131,"./webgl/select_gpu":132,"./webgl/slice_gpu":134,"./webgl/strided_slice_gpu":135,"./webgl/tex_util":136,"./webgl/texture_manager":137,"./webgl/tile_gpu":138,"./webgl/transpose_gpu":139,"./webgl/unaryop_gpu":140,"./webgl/unpack_gpu":141,"./webgl/webgl_util":142,"./where_impl":143}],84:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function mergeRealAndImagArrays(real, imag) {
@@ -15528,8 +16163,59 @@ function splitRealAndImagArrays(complex) {
     return { real: real, imag: imag };
 }
 exports.splitRealAndImagArrays = splitRealAndImagArrays;
+function complexWithEvenIndex(complex) {
+    var len = Math.ceil(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 0; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithEvenIndex = complexWithEvenIndex;
+function complexWithOddIndex(complex) {
+    var len = Math.floor(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 2; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithOddIndex = complexWithOddIndex;
+function getComplexWithIndex(complex, index) {
+    var real = complex[index * 2];
+    var imag = complex[index * 2 + 1];
+    return { real: real, imag: imag };
+}
+exports.getComplexWithIndex = getComplexWithIndex;
+function assignToTypedArray(data, real, imag, index) {
+    data[index * 2] = real;
+    data[index * 2 + 1] = imag;
+}
+exports.assignToTypedArray = assignToTypedArray;
+function exponents(n) {
+    var real = new Float32Array(n / 2);
+    var imag = new Float32Array(n / 2);
+    for (var i = 0; i < Math.ceil(n / 2); i++) {
+        var x = -2 * Math.PI * (i / n);
+        real[i] = Math.cos(x);
+        imag[i] = Math.sin(x);
+    }
+    return { real: real, imag: imag };
+}
+exports.exponents = exponents;
+function exponent(k, n) {
+    var x = -2 * Math.PI * (k / n);
+    var real = Math.cos(x);
+    var imag = Math.sin(x);
+    return { real: real, imag: imag };
+}
+exports.exponent = exponent;
 
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15587,7 +16273,33 @@ function intersectionOverUnion(boxes, i, j) {
     return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 
-},{"../ops/tensor_ops":171}],85:[function(require,module,exports){
+},{"../ops/tensor_ops":191}],86:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function getChannels(name) {
+    return ['x', 'y', 'z', 'w'].map(function (d) { return name + "." + d; });
+}
+exports.getChannels = getChannels;
+function getInnerDims(rank, dims) {
+    return dims.slice(0, rank).slice(-2);
+}
+exports.getInnerDims = getInnerDims;
+function getSourceCoords(rank, dims) {
+    if (rank === 1) {
+        return 'rc';
+    }
+    var coords = '';
+    for (var i = 0; i < rank; i++) {
+        coords += dims[i];
+        if (i < rank - 1) {
+            coords += ',';
+        }
+    }
+    return coords;
+}
+exports.getSourceCoords = getSourceCoords;
+
+},{}],87:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function split(x, sizeSplits, axis) {
@@ -15602,7 +16314,7 @@ function split(x, sizeSplits, axis) {
 }
 exports.split = split;
 
-},{}],86:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15637,7 +16349,7 @@ function topkImpl(x, xShape, xDtype, k, sorted) {
 }
 exports.topkImpl = topkImpl;
 
-},{"../ops/tensor_ops":171,"../util":194}],87:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214}],89:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ArgMinMaxProgram = (function () {
@@ -15655,13 +16367,13 @@ var ArgMinMaxProgram = (function () {
         var indexSnippet = firstPass ?
             'inOffset + i;' :
             'round(getBestIndicesA(batch, inOffset + i));';
-        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = 0;\n        float bestValue = getA(batch, inOffset);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
+        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = inOffset;\n        float bestValue = getA(batch, bestIndex);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
     }
     return ArgMinMaxProgram;
 }());
 exports.ArgMinMaxProgram = ArgMinMaxProgram;
 
-},{}],88:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var AvgPool2DBackpropProgram = (function () {
@@ -15672,16 +16384,20 @@ var AvgPool2DBackpropProgram = (function () {
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
         var avgMultiplier = 1 / (filterHeight * filterWidth);
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + ";\n            wC+= " + dilationWidth + ") {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return AvgPool2DBackpropProgram;
 }());
 exports.AvgPool2DBackpropProgram = AvgPool2DBackpropProgram;
 
-},{}],89:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15705,13 +16421,52 @@ var BatchNormProgram = (function () {
             scaleSnippet = 'getScaleAtOutCoords()';
         }
         this.outputShape = xShape;
-        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput(dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));\n      }\n    ";
     }
     return BatchNormProgram;
 }());
 exports.BatchNormProgram = BatchNormProgram;
 
-},{"../../ops/broadcast_util":139}],90:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],92:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var broadcast_util = require("../../ops/broadcast_util");
+var BatchNormPackedProgram = (function () {
+    function BatchNormPackedProgram(xShape, meanShape, varianceShape, offsetShape, scaleShape, varianceEpsilon) {
+        this.supportsBroadcasting = true;
+        this.usesPackedTextures = true;
+        this.variableNames = ['x', 'mean', 'variance'];
+        broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+        broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+        var meanSnippet = broadcastSample('mean', meanShape.length);
+        var varianceSnippet = broadcastSample('variance', varianceShape.length);
+        var offsetSnippet = 'vec4 offset = vec4(0.0)';
+        if (offsetShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+            this.variableNames.push('offset');
+            offsetSnippet = broadcastSample('offset', offsetShape.length);
+        }
+        var scaleSnippet = 'vec4 scale = vec4(1.0)';
+        if (scaleShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+            this.variableNames.push('scale');
+            scaleSnippet = broadcastSample('scale', scaleShape.length);
+        }
+        this.outputShape = xShape;
+        this.userCode = "\n      void main() {\n        ivec4 rc = getOutputCoords();\n\n        " + offsetSnippet + ";\n        " + scaleSnippet + ";\n\n        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);\n        " + meanSnippet + ";\n        " + varianceSnippet + ";\n\n        vec4 inv = scale * inversesqrt(variance + vec4(" + varianceEpsilon + "));\n\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+    }
+    return BatchNormPackedProgram;
+}());
+exports.BatchNormPackedProgram = BatchNormPackedProgram;
+function broadcastSample(texName, rank) {
+    var texSampler = "get" + texName.charAt(0).toUpperCase() + texName.slice(1);
+    if (rank === 1) {
+        return "\n      vec4 " + texName + "Sample = " + texSampler + "(rc.w);\n      vec4 " + texName + " = vec4(" + texName + "Sample.xy, " + texName + "Sample.xy);\n    ";
+    }
+    return "vec4 " + texName + " = " + texSampler + "(rc.x, rc.y, rc.z, rc.w)";
+}
+
+},{"../../ops/broadcast_util":151}],93:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15731,7 +16486,7 @@ var BinaryOpComplexProgram = (function () {
 }());
 exports.BinaryOpComplexProgram = BinaryOpComplexProgram;
 
-},{"../../ops/broadcast_util":139}],91:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],94:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15780,7 +16535,7 @@ var BinaryOpProgram = (function () {
 }());
 exports.BinaryOpProgram = BinaryOpProgram;
 
-},{"../../ops/broadcast_util":139}],92:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],95:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ClipProgram = (function () {
@@ -15793,7 +16548,20 @@ var ClipProgram = (function () {
 }());
 exports.ClipProgram = ClipProgram;
 
-},{}],93:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var ComplexAbsProgram = (function () {
+    function ComplexAbsProgram(shape) {
+        this.variableNames = ['real', 'imag'];
+        this.outputShape = shape;
+        this.userCode = "\n      void main() {\n        float real = getRealAtOutCoords();\n        float imag = getImagAtOutCoords();\n        vec2 v = vec2(real, imag);\n\n        setOutput(sqrt(dot(v, v)));\n      }\n    ";
+    }
+    return ComplexAbsProgram;
+}());
+exports.ComplexAbsProgram = ComplexAbsProgram;
+
+},{}],97:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var concat_util = require("../../ops/concat_util");
@@ -15809,7 +16577,7 @@ var ConcatProgram = (function () {
 }());
 exports.ConcatProgram = ConcatProgram;
 
-},{"../../ops/concat_util":143}],94:[function(require,module,exports){
+},{"../../ops/concat_util":155}],98:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DDerFilterProgram = (function () {
@@ -15841,7 +16609,7 @@ var Conv2DDerInputProgram = (function () {
 }());
 exports.Conv2DDerInputProgram = Conv2DDerInputProgram;
 
-},{}],95:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DDerFilterProgram = (function () {
@@ -15875,7 +16643,7 @@ var DepthwiseConv2DDerInputProgram = (function () {
 }());
 exports.DepthwiseConv2DDerInputProgram = DepthwiseConv2DDerInputProgram;
 
-},{}],96:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DProgram = (function () {
@@ -15898,7 +16666,7 @@ var Conv2DProgram = (function () {
 }());
 exports.Conv2DProgram = Conv2DProgram;
 
-},{}],97:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DProgram = (function () {
@@ -15922,7 +16690,7 @@ var DepthwiseConv2DProgram = (function () {
 }());
 exports.DepthwiseConv2DProgram = DepthwiseConv2DProgram;
 
-},{}],98:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var CropAndResizeProgram = (function () {
@@ -15963,7 +16731,7 @@ var CropAndResizeProgram = (function () {
 }());
 exports.CropAndResizeProgram = CropAndResizeProgram;
 
-},{}],99:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16014,7 +16782,7 @@ function getFinalCoord(rank, name) {
     }
 }
 
-},{"./shader_compiler":123}],100:[function(require,module,exports){
+},{"./shader_compiler":133}],104:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthToSpaceProgram = (function () {
@@ -16070,7 +16838,7 @@ var DepthToSpaceProgram = (function () {
 }());
 exports.DepthToSpaceProgram = DepthToSpaceProgram;
 
-},{}],101:[function(require,module,exports){
+},{}],105:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var EncodeFloatProgram = (function () {
@@ -16083,7 +16851,25 @@ var EncodeFloatProgram = (function () {
 }());
 exports.EncodeFloatProgram = EncodeFloatProgram;
 
-},{}],102:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COMPLEX_FFT = {
+    REAL: 'return real * expR - imag * expI;',
+    IMAG: 'return real * expI + imag * expR;'
+};
+var FFTProgram = (function () {
+    function FFTProgram(op, inputShape) {
+        this.variableNames = ['real', 'imag'];
+        var innerDim = inputShape[1];
+        this.outputShape = inputShape;
+        this.userCode = "\n      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;\n\n      float unaryOpComplex(float real, float expR, float imag, float expI) {\n        " + op + "\n      }\n\n      float mulMatDFT(int batch, int index) {\n        float indexRatio = float(index) / float(" + innerDim + ");\n        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;\n\n        float result = 0.0;\n\n        for (int i = 0; i < " + innerDim + "; i++) {\n          // x = (-2 * PI / N) * index * i;\n          float x = negativeTwoPiTimesIndexRatio * float(i);\n          float expR = cos(x);\n          float expI = sin(x);\n          float real = getReal(batch, i);\n          float imag = getImag(batch, i);\n\n          result += unaryOpComplex(real, expR, imag, expI);\n        }\n\n        return result;\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        setOutput(mulMatDFT(coords[0], coords[1]));\n      }\n    ";
+    }
+    return FFTProgram;
+}());
+exports.FFTProgram = FFTProgram;
+
+},{}],107:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var FromPixelsProgram = (function () {
@@ -16097,7 +16883,7 @@ var FromPixelsProgram = (function () {
 }());
 exports.FromPixelsProgram = FromPixelsProgram;
 
-},{}],103:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16136,7 +16922,26 @@ function getSourceCoords(aShape, axis) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],104:[function(require,module,exports){
+},{"./shader_compiler":133}],109:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var GatherNDProgram = (function () {
+    function GatherNDProgram(sliceDim, strides, shape) {
+        this.sliceDim = sliceDim;
+        this.strides = strides;
+        this.variableNames = ['x', 'indices'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + this.strides + ");\n         void main() {\n          " + dtype + " coords = getOutputCoords();\n          int flattenIndex = 0;\n          for (int j = 0; j < " + this.sliceDim + "; j++) {\n            int index = round(getIndices(coords[0], j));\n            flattenIndex += index * " + strideString + ";\n          }\n          setOutput(getX(flattenIndex, coords[1]));\n        }\n      ";
+    }
+    return GatherNDProgram;
+}());
+exports.GatherNDProgram = GatherNDProgram;
+
+},{"./shader_compiler":133}],110:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16264,6 +17069,10 @@ var GPGPUContext = (function () {
         this.throwIfDisposed();
         gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
     };
+    GPGPUContext.prototype.createFloat16PackedMatrixTexture = function (rows, columns) {
+        this.throwIfDisposed();
+        return gpgpu_util.createFloat16PackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
+    };
     GPGPUContext.prototype.createPackedMatrixTexture = function (rows, columns) {
         this.throwIfDisposed();
         return gpgpu_util.createPackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
@@ -16282,9 +17091,9 @@ var GPGPUContext = (function () {
         var numChannels = webgl_util.getNumChannels();
         return gpgpu_util.uploadMatrixToTexture(this.gl, texture, rows, columns, matrix, numChannels, this.textureConfig);
     };
-    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, rows, columns, matrix) {
+    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, batch, rows, columns, matrix) {
         this.throwIfDisposed();
-        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, rows, columns, matrix, this.textureConfig);
+        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, batch, rows, columns, matrix, this.textureConfig);
     };
     GPGPUContext.prototype.downloadFloat32MatrixFromOutputTexture = function (texture, rows, columns) {
         var _this = this;
@@ -16332,9 +17141,9 @@ var GPGPUContext = (function () {
         }
         return { query: query, isFencePassed: isFencePassed };
     };
-    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, rows, columns) {
+    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, batch, rows, columns, physicalRows, physicalCols) {
         var _this = this;
-        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, rows, columns, _this.textureConfig); });
+        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, batch, rows, columns, physicalRows, physicalCols, _this.textureConfig); });
     };
     GPGPUContext.prototype.createProgram = function (fragmentShaderSource) {
         this.throwIfDisposed();
@@ -16616,7 +17425,7 @@ function binSearchLastTrue(arr) {
 }
 exports.binSearchLastTrue = binSearchLastTrue;
 
-},{"../../environment":64,"../../util":194,"./gpgpu_util":106,"./tex_util":126,"./webgl_util":131}],105:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./gpgpu_util":112,"./tex_util":136,"./webgl_util":142}],111:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../../util");
@@ -16627,7 +17436,8 @@ function compileProgram(gpgpu, program, inputs, output) {
         var shapeInfo = {
             logicalShape: input.shape,
             texShape: input.isUniform ? null : input.texData.texShape,
-            isUniform: input.isUniform
+            isUniform: input.isUniform,
+            isPacked: input.isUniform ? false : input.texData.isPacked
         };
         return { name: program.variableNames[i], shapeInfo: shapeInfo };
     });
@@ -16635,7 +17445,8 @@ function compileProgram(gpgpu, program, inputs, output) {
     var outShapeInfo = {
         logicalShape: output.shape,
         texShape: output.texData.texShape,
-        isUniform: false
+        isUniform: false,
+        isPacked: output.texData.isPacked
     };
     var source = shader_compiler.makeShader(inputInfos, outShapeInfo, userCode, program.supportsBroadcasting === true);
     var webGLProgram = gpgpu.createProgram(source);
@@ -16687,7 +17498,12 @@ function runProgram(binary, inputs, output, customSetup) {
     var outTex = output.texData.texture;
     var outTexShape = output.texData.texShape;
     var gpgpu = binary.gpgpu;
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    if (output.texData.isPacked) {
+        gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
+    else {
+        gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
     gpgpu.setProgram(binary.webGLProgram);
     inputs.forEach(function (input, i) {
         var variableName = binary.program.variableNames[i];
@@ -16729,10 +17545,11 @@ function makeShaderKey(program, inputs, output) {
 }
 exports.makeShaderKey = makeShaderKey;
 
-},{"../../util":194,"./shader_compiler":123}],106:[function(require,module,exports){
+},{"../../util":214,"./shader_compiler":133}],112:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 var tex_util = require("./tex_util");
 var webgl_util = require("./webgl_util");
 function getWebGLContextAttributes() {
@@ -16827,7 +17644,7 @@ function getTextureConfig(gl, textureHalfFloatExtension) {
 }
 exports.getTextureConfig = getTextureConfig;
 function createAndConfigureTexture(gl, width, height, internalFormat, textureFormat, textureType) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     var texture = webgl_util.createTexture(gl);
     var tex2d = gl.TEXTURE_2D;
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(tex2d, texture); });
@@ -16859,6 +17676,11 @@ function createPackedMatrixTexture(gl, rows, columns, textureConfig) {
     return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatPackedFloat, gl.RGBA, gl.FLOAT);
 }
 exports.createPackedMatrixTexture = createPackedMatrixTexture;
+function createFloat16PackedMatrixTexture(gl, rows, columns, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), width = _a[0], height = _a[1];
+    return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA, textureConfig.textureTypeHalfFloat);
+}
+exports.createFloat16PackedMatrixTexture = createFloat16PackedMatrixTexture;
 function bindVertexProgramAttributeStreams(gl, program, vertexBuffer) {
     var posOffset = 0;
     var uvOffset = 3 * 4;
@@ -16876,7 +17698,7 @@ function uploadPixelDataToTexture(gl, texture, pixels) {
 }
 exports.uploadPixelDataToTexture = uploadPixelDataToTexture;
 function uploadDataToTexture(gl, texture, width, height, data, textureFormat) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, texture); });
     webgl_util.callAndCheck(gl, function () { return gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, textureFormat, gl.FLOAT, data); });
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, null); });
@@ -16895,10 +17717,10 @@ function uploadMatrixToTexture(gl, texture, rows, columns, matrix, numChannels, 
     uploadDataToTexture(gl, texture, w, h, unpackedArray, textureConfig.textureFormatFloat);
 }
 exports.uploadMatrixToTexture = uploadMatrixToTexture;
-function uploadMatrixToPackedTexture(gl, texture, rows, columns, matrix, textureConfig) {
+function uploadMatrixToPackedTexture(gl, texture, batch, rows, columns, matrix, textureConfig) {
     var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
     var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
-    tex_util.encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA);
+    tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
     uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }
 exports.uploadMatrixToPackedTexture = uploadMatrixToPackedTexture;
@@ -16947,16 +17769,32 @@ function downloadByteEncodedFloatMatrixFromOutputTexture(gl, rows, columns, text
     return new Float32Array(downloadTarget.buffer);
 }
 exports.downloadByteEncodedFloatMatrixFromOutputTexture = downloadByteEncodedFloatMatrixFromOutputTexture;
-function downloadMatrixFromPackedOutputTexture(gl, rows, columns, textureConfig) {
-    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
-    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+function downloadMatrixFromPackedOutputTexture(gl, batch, rows, cols, physicalRows, physicalCols, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(physicalRows, physicalCols), w = _a[0], h = _a[1];
+    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
     webgl_util.callAndCheck(gl, function () { return gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, packedRGBA); });
-    var matrix = new Float32Array(rows * columns);
-    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix);
+    var matrix = new Float32Array(util.sizeFromShape([batch, rows, cols]));
+    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, batch, rows, cols, matrix);
 }
 exports.downloadMatrixFromPackedOutputTexture = downloadMatrixFromPackedOutputTexture;
 
-},{"../../environment":64,"./tex_util":126,"./webgl_util":131}],107:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./tex_util":136,"./webgl_util":142}],113:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Im2ColProgram = (function () {
+    function Im2ColProgram(outputShape, inputShape, convInfo) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var filterWidth = convInfo.filterWidth, inChannels = convInfo.inChannels, strideWidth = convInfo.strideWidth, strideHeight = convInfo.strideHeight, padInfo = convInfo.padInfo, outWidth = convInfo.outWidth, dilationWidth = convInfo.dilationWidth, dilationHeight = convInfo.dilationHeight;
+        var left = padInfo.left, top = padInfo.top;
+        var itemsPerBlockRow = inChannels * filterWidth;
+        this.userCode = "\n      void main() {\n        ivec2 rc = getOutputCoords();\n\n        vec4 result = vec4(0);\n\n        for(int row=0; row<=1; row++) {\n          for(int col=0; col<=1; col++) {\n            int blockIndex = rc.y + col;\n            int pos = rc.x + row;\n\n            if(blockIndex >= " + outputShape[1] + " || pos >= " + outputShape[0] + ") continue;\n\n            int offsetY = int(blockIndex / (" + outWidth + ")) * " + strideHeight + " - " + top + ";\n            int d0 = offsetY + " + dilationHeight + " * (pos / " + itemsPerBlockRow + ");\n\n            if(d0 >= " + inputShape[0] + " || d0 < 0) continue;\n\n            int offsetX = int(mod(float(blockIndex), " + outWidth + ".) * " + strideWidth + ". - " + left + ".);\n            int d1 = offsetX + " + dilationWidth + " * (int(mod(float(pos), " + itemsPerBlockRow + ".) / " + inChannels + ".));\n\n            if(d1 >= " + inputShape[1] + " || d1 < 0) continue;\n\n            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), " + inChannels + ".)));\n          }\n        }\n\n        gl_FragColor = result;\n      }\n    ";
+    }
+    return Im2ColProgram;
+}());
+exports.Im2ColProgram = Im2ColProgram;
+
+},{}],114:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNProgram = (function () {
@@ -16983,7 +17821,7 @@ var LRNProgram = (function () {
 }());
 exports.LRNProgram = LRNProgram;
 
-},{}],108:[function(require,module,exports){
+},{}],115:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNGradProgram = (function () {
@@ -17002,27 +17840,28 @@ var LRNGradProgram = (function () {
 }());
 exports.LRNGradProgram = LRNGradProgram;
 
-},{}],109:[function(require,module,exports){
+},{}],116:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MaxPool2DBackpropProgram = (function () {
     function MaxPool2DBackpropProgram(convInfo) {
         this.variableNames = ['dy', 'maxPos'];
         this.outputShape = convInfo.inShape;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var lastIndex = filterHeight * filterWidth - 1;
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + filterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        var dilationHeight = convInfo.dilationHeight;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var lastIndex = effectiveFilterHeight * effectiveFilterWidth - 1;
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n          wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + effectiveFilterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return MaxPool2DBackpropProgram;
 }());
 exports.MaxPool2DBackpropProgram = MaxPool2DBackpropProgram;
 
-},{}],110:[function(require,module,exports){
+},{}],117:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MatMulProgram = (function () {
@@ -17051,7 +17890,29 @@ var MatMulProgram = (function () {
 }());
 exports.MatMulProgram = MatMulProgram;
 
-},{}],111:[function(require,module,exports){
+},{}],118:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var MatMulPackedProgram = (function () {
+    function MatMulPackedProgram(aShape, bShape, outputShape, transposeA, transposeB) {
+        if (transposeA === void 0) { transposeA = false; }
+        if (transposeB === void 0) { transposeB = false; }
+        this.variableNames = ['matrixA', 'matrixB'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var sharedDim = transposeA ? aShape[0] : aShape[1];
+        var sharedDimensionPacked = Math.ceil(sharedDim / 2);
+        var aSample = transposeA ? 'i * 2, rc.x' : 'rc.x, i * 2';
+        var bSample = transposeB ? 'rc.y, i * 2' : 'i * 2, rc.y';
+        var aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
+        var bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
+        this.userCode = "\n      const float sharedDimension = " + sharedDimensionPacked + ".0;\n\n      vec4 dot2x2ARowBCol(ivec2 rc) {\n        vec4 result = vec4(0);\n        for (int i = 0; i < " + sharedDimensionPacked + "; i++) {\n          vec4 a = getMatrixA(" + aSample + ");\n          vec4 b = getMatrixB(" + bSample + ");\n\n          result += (" + aSwizzle[0] + " * " + bSwizzle[0] + ") + (" + aSwizzle[1] + " * " + bSwizzle[1] + ");\n        }\n        return result;\n      }\n\n      void main() {\n        ivec2 rc = getOutputCoords();\n        setOutput(dot2x2ARowBCol(rc));\n      }\n    ";
+    }
+    return MatMulPackedProgram;
+}());
+exports.MatMulPackedProgram = MatMulPackedProgram;
+
+},{}],119:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MultinomialProgram = (function () {
@@ -17073,7 +17934,7 @@ var MultinomialProgram = (function () {
 }());
 exports.MultinomialProgram = MultinomialProgram;
 
-},{}],112:[function(require,module,exports){
+},{}],120:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var OneHotProgram = (function () {
@@ -17086,7 +17947,69 @@ var OneHotProgram = (function () {
 }());
 exports.OneHotProgram = OneHotProgram;
 
-},{}],113:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var PackProgram = (function () {
+    function PackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var outOfBoundsCondition = getOutOfBoundsCondition(rank, outputShape, channels);
+        var setup = getSetup(rank, outputShape[outputShape.length - 1], outputShape[outputShape.length - 2], channels);
+        var output = getOutput(outputShape, channels);
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n\n        if(" + outOfBoundsCondition + ") {\n          gl_FragColor = vec4(0);\n        } else {\n          " + setup + "\n\n          setOutput(vec4(" + output + "));\n        }\n      }\n    ";
+    }
+    return PackProgram;
+}());
+exports.PackProgram = PackProgram;
+function getSourceCoordsArr(rank, dims) {
+    var coords = [];
+    for (var row = 0; row <= 1; row++) {
+        for (var col = 0; col <= 1; col++) {
+            var coord = (row === 0 ? 'r' : 'rp1') + ", " + (col === 0 ? 'c' : 'cp1');
+            for (var d = 2; d < rank; d++) {
+                coord = dims[dims.length - 1 - d] + "," + coord;
+            }
+            coords.push(coord);
+        }
+    }
+    return coords;
+}
+function getOutOfBoundsCondition(rank, shape, dims) {
+    if (rank === 1) {
+        return "rc > " + shape[0];
+    }
+    var cond = '';
+    for (var i = 0; i < rank; i++) {
+        cond += dims[i] + " >= " + shape[i];
+        if (i < rank - 1) {
+            cond += '||';
+        }
+    }
+    return cond;
+}
+function getSetup(rank, cols, rows, dims) {
+    if (rank === 1) {
+        return '';
+    }
+    var innerDims = packing_util_1.getInnerDims(rank, dims);
+    return "\n    int r = " + innerDims[0] + ";\n    int c = " + innerDims[1] + ";\n    int rp1 = r + 1;\n    int cp1 = c + 1;\n\n    bool cEdge = cp1 >= " + cols + ";\n    bool rEdge = rp1 >= " + rows + ";\n  ";
+}
+function getOutput(shape, dims) {
+    var rank = shape.length;
+    var sourceCoords = getSourceCoordsArr(rank, dims);
+    if (rank === 1) {
+        return "getA(rc),\n            rc + 1 >= " + shape[0] + " ? 0. : getA(rc + 1),\n            0, 0";
+    }
+    return "getA(" + sourceCoords[0] + "),\n          cEdge ? 0. : getA(" + sourceCoords[1] + "),\n          rEdge ? 0. : getA(" + sourceCoords[2] + "),\n          rEdge || cEdge ? 0. : getA(" + sourceCoords[3] + ")";
+}
+
+},{"../packing_util":86,"./shader_compiler":133}],122:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17109,7 +18032,7 @@ var PadProgram = (function () {
 }());
 exports.PadProgram = PadProgram;
 
-},{"./shader_compiler":123}],114:[function(require,module,exports){
+},{"./shader_compiler":133}],123:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Pool2DProgram = (function () {
@@ -17118,10 +18041,13 @@ var Pool2DProgram = (function () {
         if (poolType === 'avg' && computePositions) {
             throw new Error('Cannot compute positions for average pool.');
         }
-        var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         this.outputShape = convInfo.outShape;
@@ -17132,7 +18058,7 @@ var Pool2DProgram = (function () {
         }
         if (computePositions) {
             var compareOp_1 = '>=';
-            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + filterHeight + "; wR++) {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + filterWidth + "; wC++) {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + filterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
+            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + effectiveFilterHeight + ";\n              wR += " + dilationHeight + ") {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + effectiveFilterWidth + ";\n                wC += " + dilationWidth + ") {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + effectiveFilterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
             return;
         }
         var compareOp = 'max';
@@ -17144,13 +18070,13 @@ var Pool2DProgram = (function () {
         var filterWidthNearestVec4 = Math.floor(filterWidth / 4) * 4;
         var filterWidthVec4Remainder = filterWidth % 4;
         var updateSnippet = "\n      if (" + isAvgPool + ") {\n        avgValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
-        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC;\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              getValue(batch, xR, xC + 3, d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC * " + dilationWidth + ";\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 3 * " + dilationWidth + ", d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return Pool2DProgram;
 }());
 exports.Pool2DProgram = Pool2DProgram;
 
-},{}],115:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ReduceProgram = (function () {
@@ -17163,7 +18089,10 @@ var ReduceProgram = (function () {
         this.outputShape = [batchSize, outSize];
         var initializationValue = '0.0';
         var compareOp = "";
-        if (reduceType === 'min') {
+        if (reduceType === 'prod') {
+            initializationValue = '1.0';
+        }
+        else if (reduceType === 'min') {
             initializationValue = '1.0 / 0.0';
             compareOp = "min";
         }
@@ -17176,6 +18105,9 @@ var ReduceProgram = (function () {
         if (reduceType === 'sum') {
             returnValue = "sumValue";
         }
+        else if (reduceType === 'prod') {
+            returnValue = "prodValue";
+        }
         else if (reduceType === 'all') {
             returnValue = "allValue";
         }
@@ -17184,7 +18116,7 @@ var ReduceProgram = (function () {
         }
         var windowSizeNearestVec4 = Math.floor(windowSize / 4) * 4;
         var windowSizeVec4Remainder = windowSize % 4;
-        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
+        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else if (" + (reduceType === 'prod') + ") {\n        vec2 tmp = vec2(values[0], values[1]) * vec2(values[2], values[3]);\n        prodValue *= tmp[0] * tmp[1];\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
         var vecType = "vec4";
         if (reduceType === 'all') {
             initializationValue = '1.0';
@@ -17200,13 +18132,13 @@ var ReduceProgram = (function () {
         if (inSize % windowSize > 0) {
             checkOutOfBounds = "\n        if (inIdx < 0 || inIdx >= " + inSize + ") {\n          return initializationValue;\n        }\n      ";
         }
-        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float prodValue = 1.0;\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return ReduceProgram;
 }());
 exports.ReduceProgram = ReduceProgram;
 
-},{}],116:[function(require,module,exports){
+},{}],125:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearBackpropProgram = (function () {
@@ -17236,7 +18168,7 @@ var ResizeBilinearBackpropProgram = (function () {
 }());
 exports.ResizeBilinearBackpropProgram = ResizeBilinearBackpropProgram;
 
-},{}],117:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearProgram = (function () {
@@ -17259,7 +18191,7 @@ var ResizeBilinearProgram = (function () {
 }());
 exports.ResizeBilinearProgram = ResizeBilinearProgram;
 
-},{}],118:[function(require,module,exports){
+},{}],127:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeigborBackpropProgram = (function () {
@@ -17289,7 +18221,7 @@ var ResizeNearestNeigborBackpropProgram = (function () {
 }());
 exports.ResizeNearestNeigborBackpropProgram = ResizeNearestNeigborBackpropProgram;
 
-},{}],119:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeighborProgram = (function () {
@@ -17313,7 +18245,7 @@ var ResizeNearestNeighborProgram = (function () {
 }());
 exports.ResizeNearestNeighborProgram = ResizeNearestNeighborProgram;
 
-},{}],120:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17343,7 +18275,41 @@ var ReverseProgram = (function () {
 }());
 exports.ReverseProgram = ReverseProgram;
 
-},{"./shader_compiler":123}],121:[function(require,module,exports){
+},{"./shader_compiler":133}],130:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var ScatterProgram = (function () {
+    function ScatterProgram(updateSize, sliceDim, indicesRank, updatesRank, strides, shape, summingDupeIndex) {
+        if (summingDupeIndex === void 0) { summingDupeIndex = true; }
+        this.variableNames = ['updates', 'indices', 'defaultValue'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var indicesString = '';
+        if (indicesRank === 1) {
+            indicesString = 'i';
+        }
+        else if (indicesRank === 2) {
+            indicesString = 'i, j';
+        }
+        var indicesSnippet = "getIndices(" + indicesString + ")";
+        var updatesString = '';
+        if (updatesRank === 1) {
+            updatesString = 'i';
+        }
+        else if (updatesRank === 2) {
+            updatesString = 'i, coords[1]';
+        }
+        var updatesSnippet = "getUpdates(" + updatesString + ")";
+        var strideString = sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + strides + ");\n\n        void main() {\n          " + dtype + " coords = getOutputCoords();\n          float sum = 0.0;\n          bool found = false;\n          for (int i = 0; i < " + updateSize + "; i++) {\n            int flattenedIndex = 0;\n            for (int j = 0; j < " + sliceDim + "; j++) {\n              int index = round(" + indicesSnippet + ");\n              flattenedIndex += index * " + strideString + ";\n            }\n            if (flattenedIndex == coords[0]) {\n              sum += " + updatesSnippet + ";\n              found = true;\n            }\n          }\n          setOutput(mix(getDefaultValue(), sum, float(found)));\n        }\n      ";
+    }
+    return ScatterProgram;
+}());
+exports.ScatterProgram = ScatterProgram;
+
+},{"./shader_compiler":133}],131:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var SegmentOpProgram = (function () {
@@ -17374,7 +18340,7 @@ var SegmentOpProgram = (function () {
 }());
 exports.SegmentOpProgram = SegmentOpProgram;
 
-},{}],122:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17411,7 +18377,7 @@ var SelectProgram = (function () {
 }());
 exports.SelectProgram = SelectProgram;
 
-},{"./shader_compiler":123}],123:[function(require,module,exports){
+},{"./shader_compiler":133}],133:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -17428,11 +18394,21 @@ function makeShader(inputsInfo, outputShape, userCode, broadcast) {
     var inputSamplingSnippet = inputsInfo.map(function (x) { return getInputSamplingSnippet(x, outputShape, broadcast); })
         .join('\n');
     var outTexShape = outputShape.texShape;
-    var outputSamplingSnippet = getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    var outputSamplingSnippet;
+    var floatTextureSetOutputSnippet;
+    if (outputShape.isPacked) {
+        outputSamplingSnippet =
+            getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    }
+    else {
+        outputSamplingSnippet =
+            getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    }
     var source = [
-        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-        FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-        inputSamplingSnippet, userCode
+        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+        inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
     ].join('\n');
     return source;
 }
@@ -17459,14 +18435,47 @@ function getSamplerFromInInfo(inInfo) {
                 " is not yet supported");
     }
 }
+function getPackedSamplerFromInInfo(inInfo) {
+    var shape = inInfo.shapeInfo.logicalShape;
+    switch (shape.length) {
+        case 1:
+            return getPackedSampler1D(inInfo);
+        case 2:
+            return getPackedSampler2D(inInfo);
+        case 4:
+            return getPackedSampler4D(inInfo);
+        default:
+            throw new Error("Packed " + shape.length + "-D input sampling" +
+                " is not yet supported");
+    }
+}
 function getInputSamplingSnippet(inInfo, outShapeInfo, broadcast) {
     var res = getSamplerFlat(inInfo);
-    res += getSamplerFromInInfo(inInfo);
+    if (inInfo.shapeInfo.isPacked) {
+        res += getPackedSamplerFromInInfo(inInfo);
+    }
+    else {
+        res += getSamplerFromInInfo(inInfo);
+    }
     if (broadcast ||
         util.arraysEqual(inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
         res += getSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     }
     return res;
+}
+function getPackedOutputSamplingSnippet(outShape, outTexShape) {
+    switch (outShape.length) {
+        case 0:
+            return getOutputScalarCoords();
+        case 1:
+            return getOutputPacked1DCoords(outShape, outTexShape);
+        case 2:
+            return getOutputPacked2DCoords(outShape, outTexShape);
+        case 4:
+            return getOutputPacked4DCoords(outShape, outTexShape);
+        default:
+            throw new Error(outShape.length + "-D output packed sampling is not yet supported");
+    }
 }
 function getOutputSamplingSnippet(outShape, outTexShape) {
     switch (outShape.length) {
@@ -17488,17 +18497,28 @@ function getOutputSamplingSnippet(outShape, outTexShape) {
             throw new Error(outShape.length + "-D output sampling is not yet supported");
     }
 }
-var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom1D(int texNumR, int texNumC, int index) {\n  int texelIndex = index / 2;\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom2D(int texelsInLogicalRow, int texNumR,\n  int texNumC, int row, int col) {\n  int texelIndex = (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_3D_SNIPPET = "\nvec2 UVfrom3D(int texNumR, int texNumC, int stride0,\n    int stride1, int row, int col, int depth) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,\n    int texelsInBatch, int texelsInLogicalRow, int b2, int b,\n    int row, int col) {\n  int index = b2 * texelsInBatch2 + b * texelsInBatch +\n    (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_5D_SNIPPET = "\nvec2 UVfrom5D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int row, int col, int depth,\n    int depth2, int depth3) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 +\n              depth * stride2 + depth2 * stride3 + depth3;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_6D_SNIPPET = "\nvec2 UVfrom6D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int stride4,\n    int row, int col, int depth, int depth2, int depth3, int depth4) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2 *\n    stride3 + depth3 * stride4 + depth4;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var FLOAT_TEXTURE_SAMPLE_SNIPPET = "\n  float sampleTexture(sampler2D textureSampler, vec2 uv) {\n    return texture2D(textureSampler, uv).r;\n  }\n";
-var FLOAT_TEXTURE_SETOUTPUT_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
-var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
+var FLOAT_TEXTURE_SET_R_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
+var FLOAT_TEXTURE_SET_RGBA_SNIPPET = "\n  void setOutput(vec4 val) {\n    gl_FragColor = val;\n  }\n";
+var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
 function getOutputScalarCoords() {
     return "\n    int getOutputCoords() {\n      return 0;\n    }\n  ";
+}
+function getOutputPacked1DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (texShape[0] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.x * " + packedTexShape[1] + ".0);\n      }\n    ";
+    }
+    if (texShape[1] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.y * " + packedTexShape[0] + ".0);\n      }\n    ";
+    }
+    return "\n    int getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      return resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n    }\n  ";
 }
 function getOutput1DCoords(shape, texShape) {
     if (texShape[0] === 1) {
@@ -17513,6 +18533,13 @@ function getOutput3DCoords(shape, texShape) {
     var stride0 = shape[1] * shape[2];
     var stride1 = shape[2];
     return "\n    ivec3 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n      int c = index / " + stride1 + ";\n      int d = index - c * " + stride1 + ";\n      return ivec3(r, c, d);\n    }\n  ";
+}
+function getOutputPacked4DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texelsInLogicalRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    ivec4 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n\n      int b2 = index / " + texelsInBatch2 + ";\n      index -= b2 * " + texelsInBatch2 + ";\n\n      int b = index / " + texelsInBatch + ";\n      index -= b * " + texelsInBatch + ";\n\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = int(mod(float(index), " + texelsInLogicalRow + ".)) * 2;\n\n      return ivec4(b2, b, r, c);\n    }\n  ";
 }
 function getOutput4DCoords(shape, texShape) {
     var stride2 = shape[3];
@@ -17535,6 +18562,14 @@ function getOutput6DCoords(shape, texShape) {
     var stride0 = shape[1] * stride1;
     return "\n    ivec6 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n        vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n\n      int c = index / " + stride1 + ";\n      index -= c * " + stride1 + ";\n\n      int d = index / " + stride2 + ";\n      index -= d * " + stride2 + ";\n\n      int d2 = index / " + stride3 + ";\n      index -= d2 * " + stride3 + ";\n\n      int d3 = index / " + stride4 + ";\n      int d4 = index - d3 * " + stride4 + ";\n\n      ivec6 result = ivec6(r, c, d, d2, d3, d4);\n      return result;\n    }\n  ";
 }
+function getOutputPacked2DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (util.arraysEqual(shape, texShape)) {
+        return "\n      ivec2 getOutputCoords() {\n        return 2 * ivec2(resultUV.yx * vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      }\n    ";
+    }
+    var texelsInLogicalRow = Math.ceil(shape[1] / 2);
+    return "\n    ivec2 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = imod(index, " + texelsInLogicalRow + ") * 2;\n\n      return ivec2(r, c);\n    }\n  ";
+}
 function getOutput2DCoords(shape, texShape) {
     if (util.arraysEqual(shape, texShape)) {
         return "\n      ivec2 getOutputCoords() {\n        return ivec2(resultUV.yx * vec2(" + texShape[0] + ", " + texShape[1] + "));\n      }\n    ";
@@ -17555,10 +18590,31 @@ function getSamplerScalar(inputInfo) {
     }
     return "\n    float " + funcName + "() {\n      return sampleTexture(" + texName + ", halfCR);\n    }\n  ";
 }
+function getPackedSampler1D(inputInfo) {
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    return "\n    vec4 " + funcName + "(int index) {\n      vec2 uv = packedUVfrom1D(\n        " + packedTexShape[0] + ", " + packedTexShape[1] + ", index);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
+}
 function getSampler1D(inputInfo) {
     var texName = inputInfo.name;
     var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
     return "\n    float " + funcName + "(int index) {\n      return " + funcName + "Flat(index);\n    }\n  ";
+}
+function getPackedSampler2D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var texNumR = texShape[0];
+    var texNumC = texShape[1];
+    if (texShape != null && util.arraysEqual(shape, texShape)) {
+        return "\n      vec4 " + funcName + "(int row, int col) {\n        vec2 uv = (vec2(col, row) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n\n        return texture2D(" + texName + ", uv);\n      }\n    ";
+    }
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var valuesPerRow = Math.ceil(shape[1] / 2);
+    return "\n    vec4 " + funcName + "(int row, int col) {\n      vec2 uv = packedUVfrom2D(" + valuesPerRow + ", " + packedTexShape[0] + ", " + packedTexShape[1] + ", row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler2D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17578,15 +18634,15 @@ function getSampler2D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col) {\n        int index = row * " + shape[1] + " + col;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col) {\n        float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2(0.5, (float(index) + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2(0.5, (index + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     if (texNumR === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2((float(index) + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2((index + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n  float " + funcName + "(int row, int col) {\n    vec2 uv = UVfrom2D(" + texNumR + ", " + texNumC + ", " + shape[1] + ", row, col);\n    return sampleTexture(" + texName + ", uv);\n  }\n";
 }
@@ -17604,18 +18660,31 @@ function getSampler3D(inputInfo) {
         return "\n        " + getSamplerFromInInfo(newInputInfo) + "\n        float " + funcName + "(int row, int col, int depth) {\n          return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n        }\n      ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth) {\n        int index = row * " + stride0 + " + col * " + stride1 + " + depth;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth) {\n        float index = dot(vec3(row, col, depth),\n                          vec3(" + stride0 + ", " + stride1 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n        float " + funcName + "(int row, int col, int depth) {\n          int texR = row;\n          int texC = col * " + stride1 + " + depth;\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
+        return "\n        float " + funcName + "(int row, int col, int depth) {\n          float texR = float(row);\n          float texC = dot(vec2(col, depth), vec2(" + stride1 + ", 1));\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
     }
     if (texNumC === stride1) {
-        return "\n    float " + funcName + "(int row, int col, int depth) {\n      int texR = row * " + shape[1] + " + col;\n      int texC = depth;\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col, int depth) {\n      float texR = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      float texC = float(depth);\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n      float " + funcName + "(int row, int col, int depth) {\n        vec2 uv = UVfrom3D(\n            " + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ", row, col, depth);\n        return sampleTexture(" + texName + ", uv);\n      }\n  ";
+}
+function getPackedSampler4D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texNumR = packedTexShape[0];
+    var texNumC = packedTexShape[1];
+    var valuesPerRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    vec4 " + funcName + "(int b2, int b, int row, int col) {\n      vec2 uv = packedUVfrom4D(\n        " + texNumR + ", " + texNumC + ", " + texelsInBatch2 + ",\n        " + texelsInBatch + ", " + valuesPerRow + ", b2, b, row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler4D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17631,16 +18700,16 @@ function getSampler4D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float index = dot(vec4(row, col, depth, depth2),\n                          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = float(row);\n        float texC =\n            dot(vec3(col, depth, depth2), vec3(" + stride1 + ", " + stride2 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride2) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = dot(vec3(row, col, depth),\n                         vec3(" + shape[1] * shape[2] + ", " + shape[2] + ", 1));\n        float texC = float(depth2);\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2) {\n      vec2 uv = UVfrom4D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", row, col, depth, depth2);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17659,16 +18728,16 @@ function getSampler5D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " +\n                   depth2 * " + stride3 + " + depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride3) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " +\n                   depth * " + shape[3] + " + depth2;\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] + ", " + shape[2] * shape[3] + ",\n            " + shape[3] + ", 1));\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n      vec2 uv = UVfrom5D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", row, col, depth, depth2, depth3);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17688,16 +18757,16 @@ function getSampler6D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3 * " + stride3 + "\n            + depth4\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          dot(\n            vec2(depth3, depth4),\n            vec2(" + stride4 + ", 1));\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", " + stride4 + ")) + depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride4) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] * shape[4] + ",\n               " + shape[2] * shape[3] * shape[4] + ",\n               " + shape[3] * shape[4] + ",\n               " + shape[4] + ")) + depth3;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n      vec2 uv = UVfrom6D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", " + stride4 + "\n          ,row, col, depth, depth2, depth3, depth4);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17826,7 +18895,7 @@ function getSqueezedParams(params, keptDims) {
     return keptDims.map(function (d) { return params[d]; }).join(', ');
 }
 
-},{"../../ops/broadcast_util":139,"../../util":194}],124:[function(require,module,exports){
+},{"../../ops/broadcast_util":151,"../../util":214}],134:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17890,7 +18959,7 @@ function getCoords(rank) {
     }
 }
 
-},{"./shader_compiler":123}],125:[function(require,module,exports){
+},{"./shader_compiler":133}],135:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17928,9 +18997,10 @@ var StridedSliceProgram = (function () {
 }());
 exports.StridedSliceProgram = StridedSliceProgram;
 
-},{"./shader_compiler":123}],126:[function(require,module,exports){
+},{"./shader_compiler":133}],136:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var util = require("../../util");
 var TextureUsage;
 (function (TextureUsage) {
     TextureUsage[TextureUsage["RENDER"] = 0] = "RENDER";
@@ -17940,9 +19010,11 @@ var TextureUsage;
 })(TextureUsage = exports.TextureUsage || (exports.TextureUsage = {}));
 var PhysicalTextureType;
 (function (PhysicalTextureType) {
-    PhysicalTextureType[PhysicalTextureType["FLOAT16"] = 0] = "FLOAT16";
-    PhysicalTextureType[PhysicalTextureType["FLOAT32"] = 1] = "FLOAT32";
-    PhysicalTextureType[PhysicalTextureType["UNSIGNED_BYTE"] = 2] = "UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT16"] = 0] = "UNPACKED_FLOAT16";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT32"] = 1] = "UNPACKED_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_4X1_UNSIGNED_BYTE"] = 2] = "PACKED_4X1_UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT32"] = 3] = "PACKED_2X2_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT16"] = 4] = "PACKED_2X2_FLOAT16";
 })(PhysicalTextureType = exports.PhysicalTextureType || (exports.PhysicalTextureType = {}));
 function getUnpackedMatrixTextureShapeWidthHeight(rows, columns) {
     return [columns, rows];
@@ -18010,118 +19082,130 @@ function getPackedRGBAArraySizeFromMatrixShape(rows, columns) {
     return w * h * 4;
 }
 exports.getPackedRGBAArraySizeFromMatrixShape = getPackedRGBAArraySizeFromMatrixShape;
-function encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA) {
+function encodeMatrixToPackedRGBA(matrix, batches, rows, columns, packedRGBA) {
     var requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
     if (packedRGBA.length < requiredSize) {
-        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >= " + requiredSize);
+        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >=\n        " + requiredSize);
     }
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    {
-        var dstStride = (oddWidth ? 4 : 0);
-        var oneRow = columns;
-        var dst = 0;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            var matrixSrcRow = (blockY * 2 * columns);
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                var matrixSrcCol = blockX * 2;
-                var src = matrixSrcRow + matrixSrcCol;
-                packedRGBA[dst] = matrix[src];
-                packedRGBA[dst + 1] = matrix[src + 1];
-                packedRGBA[dst + 2] = matrix[src + oneRow];
-                packedRGBA[dst + 3] = matrix[src + oneRow + 1];
-                dst += 4;
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var sourceOffset = batch * rows * columns;
+        var batchOffset = batch * flattenedMatrixSize;
+        {
+            var dstStride = (oddWidth ? 4 : 0);
+            var oneRow = columns;
+            var dst = batchOffset;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                var matrixSrcRow = (blockY * 2 * columns);
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    var matrixSrcCol = blockX * 2;
+                    var src = sourceOffset + matrixSrcRow + matrixSrcCol;
+                    packedRGBA[dst] = matrix[src];
+                    packedRGBA[dst + 1] = matrix[src + 1];
+                    packedRGBA[dst + 2] = matrix[src + oneRow];
+                    packedRGBA[dst + 3] = matrix[src + oneRow + 1];
+                    dst += 4;
+                }
+                dst += dstStride;
             }
-            dst += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = columns - 1;
-        var dst = (textureWidth - 1) * 4;
-        var srcStride = 2 * columns;
-        var dstStride = textureWidth * 4;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            packedRGBA[dst] = matrix[src];
-            packedRGBA[dst + 2] = matrix[src + columns];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + columns - 1;
+            var dst = batchOffset + (texelsPerRow - 1) * 4;
+            var srcStride = 2 * columns;
+            var dstStride = texelsPerRow * 4;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                packedRGBA[dst] = matrix[src];
+                packedRGBA[dst + 2] = matrix[src + columns];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (rows - 1) * columns;
-        var dst = (textureHeight - 1) * textureWidth * 4;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            packedRGBA[dst++] = matrix[src++];
-            packedRGBA[dst++] = matrix[src++];
-            dst += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (rows - 1) * columns;
+            var dst = batchOffset + (texelsPerBatch - texelsPerRow) * 4;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                packedRGBA[dst++] = matrix[src++];
+                packedRGBA[dst++] = matrix[src++];
+                dst += 2;
+            }
+            if (oddWidth && oddHeight) {
+                packedRGBA[batchOffset + flattenedMatrixSize - 4] = matrix[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        packedRGBA[packedRGBA.length - 4] = matrix[matrix.length - 1];
     }
     return packedRGBA;
 }
 exports.encodeMatrixToPackedRGBA = encodeMatrixToPackedRGBA;
-function decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix) {
+function decodeMatrixFromPackedRGBA(packedRGBA, batches, rows, columns, matrix) {
     var requiredSize = rows * columns;
-    if (requiredSize < matrix.length) {
+    if (matrix.length < requiredSize) {
         throw new Error("matrix length (" + matrix.length + ") must be >= " + requiredSize);
     }
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
-    {
-        var srcStride = oddWidth ? 4 : 0;
-        var dstStride = columns + (oddWidth ? 1 : 0);
-        var src = 0;
-        var dstRow1 = 0;
-        var dstRow2 = columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var batchOffset = batch * rows * columns;
+        var sourceOffset = batch * flattenedMatrixSize;
+        {
+            var srcStride = oddWidth ? 4 : 0;
+            var dstStride = columns + (oddWidth ? 1 : 0);
+            var src = sourceOffset;
+            var dstRow1 = batchOffset;
+            var dstRow2 = batchOffset + columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                }
+                src += srcStride;
+                dstRow1 += dstStride;
+                dstRow2 += dstStride;
             }
-            src += srcStride;
-            dstRow1 += dstStride;
-            dstRow2 += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = (textureWidth - 1) * 4;
-        var dst = columns - 1;
-        var srcStride = textureWidth * 4;
-        var dstStride = 2 * columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            matrix[dst] = packedRGBA[src];
-            matrix[dst + columns] = packedRGBA[src + 2];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + (texelsPerRow - 1) * 4;
+            var dst = batchOffset + columns - 1;
+            var srcStride = texelsPerRow * 4;
+            var dstStride = 2 * columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                matrix[dst] = packedRGBA[src];
+                matrix[dst + columns] = packedRGBA[src + 2];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (textureHeight - 1) * textureWidth * 4;
-        var dst = (rows - 1) * columns;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            matrix[dst++] = packedRGBA[src++];
-            matrix[dst++] = packedRGBA[src++];
-            src += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (texelsPerBatch - texelsPerRow) * 4;
+            var dst = batchOffset + (rows - 1) * columns;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                matrix[dst++] = packedRGBA[src++];
+                matrix[dst++] = packedRGBA[src++];
+                src += 2;
+            }
+            if (oddWidth) {
+                matrix[batchOffset + (rows * columns) - 1] = packedRGBA[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        matrix[matrix.length - 1] = packedRGBA[packedRGBA.length - 4];
     }
     return matrix;
 }
 exports.decodeMatrixFromPackedRGBA = decodeMatrixFromPackedRGBA;
 
-},{}],127:[function(require,module,exports){
+},{"../../util":214}],137:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
@@ -18135,9 +19219,9 @@ var TextureManager = (function () {
         this.logEnabled = false;
         this.usedTextures = {};
     }
-    TextureManager.prototype.acquireTexture = function (shapeRC, usage) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(usage);
-        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType);
+    TextureManager.prototype.acquireTexture = function (shapeRC, usage, isPacked) {
+        var physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
+        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18155,24 +19239,34 @@ var TextureManager = (function () {
         this.numUsedTextures++;
         this.log();
         var newTexture;
-        if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT32) {
+        if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32) {
+            newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16) {
+            newTexture =
+                this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32) {
             newTexture =
                 this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT16) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16) {
             newTexture =
                 this.gpgpu.createFloat16MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNSIGNED_BYTE) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE) {
             newTexture =
                 this.gpgpu.createUnsignedBytesMatrixTexture(shapeRC[0], shapeRC[1]);
         }
         this.usedTextures[shapeKey].push(newTexture);
         return newTexture;
     };
-    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType);
-        var shapeKey = getKeyFromTextureShape(shape, physicalTexType);
+    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType, isPacked) {
+        if (this.freeTextures == null) {
+            return;
+        }
+        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+        var shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18224,26 +19318,31 @@ var TextureManager = (function () {
     return TextureManager;
 }());
 exports.TextureManager = TextureManager;
-function getPhysicalFromLogicalTextureType(logicalTexType) {
-    if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
+function getPhysicalFromLogicalTextureType(logicalTexType, isPacked) {
+    if (isPacked) {
+        return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32 :
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    else if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
         logicalTexType === tex_util_1.TextureUsage.PIXELS) {
-        return tex_util_1.PhysicalTextureType.UNSIGNED_BYTE;
+        return tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.UPLOAD) {
-        return tex_util_1.PhysicalTextureType.FLOAT32;
+        return tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.RENDER) {
         return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-            tex_util_1.PhysicalTextureType.FLOAT32 :
-            tex_util_1.PhysicalTextureType.FLOAT16;
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32 :
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16;
     }
     throw new Error("Unknown logical texture type " + logicalTexType);
 }
-function getKeyFromTextureShape(shapeRowsCol, physicalTexType) {
-    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType;
+function getKeyFromTextureShape(shapeRowsCol, physicalTexType, isPacked) {
+    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType + "_" + isPacked;
 }
 
-},{"../../environment":64,"./tex_util":126}],128:[function(require,module,exports){
+},{"../../environment":64,"./tex_util":136}],138:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18279,7 +19378,7 @@ function getSourceCoords(aShape) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],129:[function(require,module,exports){
+},{"./shader_compiler":133}],139:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18312,7 +19411,7 @@ function getSwitchedCoords(newDim) {
     return switchedCoords.join();
 }
 
-},{"./shader_compiler":123}],130:[function(require,module,exports){
+},{"./shader_compiler":133}],140:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var erf_util = require("../../ops/erf_util");
@@ -18379,12 +19478,33 @@ exports.RECIPROCAL = "return 1.0 / x;";
 exports.LOGICAL_NOT = "return float(!(x >= 1.0));";
 exports.TO_INT = "return float(int(x));";
 
-},{"../../ops/erf_util":146,"../../ops/selu_util":166}],131:[function(require,module,exports){
+},{"../../ops/erf_util":159,"../../ops/selu_util":183}],141:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var MAX_TEXTURE_SIZE = null;
-var util = require("../../util");
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var UnpackProgram = (function () {
+    function UnpackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var sourceCoords = packing_util_1.getSourceCoords(rank, channels);
+        var innerDims = packing_util_1.getInnerDims(rank, channels);
+        var coords = rank === 1 ? 'rc' : innerDims.join(',');
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n        vec2 modCoord = mod(vec2(" + coords + "), 2.);\n        vec4 packedInput = getA(" + sourceCoords + ");\n\n        setOutput(\n          modCoord.x == 0. ?\n            (modCoord.y == 0. ? packedInput.r : packedInput.g) :\n            (modCoord.y == 0. ? packedInput.b : packedInput.a)\n        );\n      }\n    ";
+    }
+    return UnpackProgram;
+}());
+exports.UnpackProgram = UnpackProgram;
+
+},{"../packing_util":86,"./shader_compiler":133}],142:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 function createWebGLRenderingContext(attributes) {
     var canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -18535,15 +19655,6 @@ function createStaticIndexBuffer(gl, data) {
     return buffer;
 }
 exports.createStaticIndexBuffer = createStaticIndexBuffer;
-function queryMaxTextureSize(gl) {
-    if (MAX_TEXTURE_SIZE != null) {
-        return MAX_TEXTURE_SIZE;
-    }
-    MAX_TEXTURE_SIZE =
-        callAndCheck(gl, function () { return gl.getParameter(gl.MAX_TEXTURE_SIZE); });
-    return MAX_TEXTURE_SIZE;
-}
-exports.queryMaxTextureSize = queryMaxTextureSize;
 function getNumChannels() {
     if (environment_1.ENV.get('WEBGL_VERSION') === 2) {
         return 1;
@@ -18555,8 +19666,8 @@ function createTexture(gl) {
     return throwIfNull(gl, function () { return gl.createTexture(); }, 'Unable to create WebGLTexture.');
 }
 exports.createTexture = createTexture;
-function validateTextureSize(gl, width, height) {
-    var maxTextureSize = queryMaxTextureSize(gl);
+function validateTextureSize(width, height) {
+    var maxTextureSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
     if ((width <= 0) || (height <= 0)) {
         var requested = "[" + width + "x" + height + "]";
         throw new Error('Requested texture size ' + requested + ' is invalid.');
@@ -18662,12 +19773,19 @@ function validateTextureUnit(gl, textureUnit) {
         throw new Error("textureUnit must be in " + textureUnitRange + ".");
     }
 }
-function getTextureShapeFromLogicalShape(gl, logShape) {
+function getTextureShapeFromLogicalShape(logShape, isPacked) {
+    if (isPacked === void 0) { isPacked = false; }
+    var maxTexSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    if (isPacked) {
+        maxTexSize = maxTexSize * 2;
+        logShape = logShape.map(function (d, i) { return i >= logShape.length - 2 ?
+            util.nearestLargerEven(logShape[i]) :
+            logShape[i]; });
+    }
     if (logShape.length !== 2) {
         var squeezeResult = util.squeezeShape(logShape);
         logShape = squeezeResult.newShape;
     }
-    var maxTexSize = queryMaxTextureSize(gl);
     var size = util.sizeFromShape(logShape);
     if (logShape.length <= 1 && size <= maxTexSize) {
         return [size, 1];
@@ -18676,9 +19794,18 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
         logShape[1] <= maxTexSize) {
         return logShape;
     }
+    else if (logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+        logShape[2] <= maxTexSize) {
+        return [logShape[0] * logShape[1], logShape[2]];
+    }
     else if (logShape.length === 3 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] <= maxTexSize) {
         return [logShape[0], logShape[1] * logShape[2]];
+    }
+    else if (logShape.length === 4 &&
+        logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+        logShape[3] <= maxTexSize) {
+        return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
     }
     else if (logShape.length === 4 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
@@ -18690,7 +19817,7 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
 }
 exports.getTextureShapeFromLogicalShape = getTextureShapeFromLogicalShape;
 
-},{"../../environment":64,"../../util":194}],132:[function(require,module,exports){
+},{"../../environment":64,"../../util":214}],143:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var array_ops_1 = require("../ops/array_ops");
@@ -18712,7 +19839,7 @@ function whereImpl(condShape, condVals) {
 }
 exports.whereImpl = whereImpl;
 
-},{"../ops/array_ops":134}],133:[function(require,module,exports){
+},{"../ops/array_ops":146}],144:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -18737,7 +19864,13 @@ function log() {
 }
 exports.log = log;
 
-},{"./environment":64}],134:[function(require,module,exports){
+},{"./environment":64}],145:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var confusion_matrix_1 = require("./ops/confusion_matrix");
+exports.confusionMatrix = confusion_matrix_1.confusionMatrix;
+
+},{"./ops/confusion_matrix":156}],146:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -19136,9 +20269,10 @@ function stack_(tensors, axis) {
 function batchToSpaceND_(x, blockShape, crops) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'batchToSpaceND');
     var prod = blockShape.reduce(function (a, b) { return a * b; });
-    util.assert($x.rank >= 1 + blockShape.length, "input rank should be > than [blockShape] but got " + $x.rank);
-    util.assert(crops.length === blockShape.length, "crops.shape[0] must be equal to [blockShape] but got " + crops.length);
-    util.assert($x.shape[0] % prod === 0, "input tensor batch must be divisible by prod( blockShape )");
+    util.assert($x.rank >= 1 + blockShape.length, "input rank is " + $x.rank + " but should be > than blockShape.length " + blockShape.length);
+    util.assert(crops.length === blockShape.length, "crops.length is " + crops.length + " but should be equal to blockShape.length  " + blockShape.length);
+    util.assert($x.shape[0] % prod === 0, "input tensor batch is " + $x.shape[0] + " but is not divisible by the product of " +
+        ("the elements of blockShape " + blockShape.join(' * ') + " === " + prod));
     var grad = function (dy) {
         return { $x: function () { return dy.spaceToBatchND(blockShape, crops); } };
     };
@@ -19265,7 +20399,7 @@ exports.tile = operation_1.op({ tile_: tile_ });
 exports.truncatedNormal = operation_1.op({ truncatedNormal_: truncatedNormal_ });
 exports.unstack = operation_1.op({ unstack_: unstack_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_split":142,"./operation":156,"./rand":159,"./tensor_ops":171}],135:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_split":154,"./operation":171,"./rand":174,"./tensor_ops":191}],147:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getReshaped(inputShape, blockShape, prod, batchToSpace) {
@@ -19363,7 +20497,7 @@ function getSliceSize(uncroppedShape, crops, blockShape) {
 }
 exports.getSliceSize = getSliceSize;
 
-},{}],136:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -19453,7 +20587,7 @@ function getInnerMostAxes(numAxes, rank) {
 }
 exports.getInnerMostAxes = getInnerMostAxes;
 
-},{"../util":194}],137:[function(require,module,exports){
+},{"../util":214}],149:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19673,7 +20807,7 @@ exports.batchNormalization3d = operation_1.op({ batchNormalization3d_: batchNorm
 exports.batchNormalization4d = operation_1.op({ batchNormalization4d_: batchNormalization4d_ });
 exports.batchNormalization = operation_1.op({ batchNormalization_: batchNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],138:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],150:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20039,7 +21173,7 @@ exports.squaredDifferenceStrict = operation_1.op({ squaredDifferenceStrict_: squ
 exports.sub = operation_1.op({ sub_: sub_ });
 exports.subStrict = operation_1.op({ subStrict_: subStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../types":193,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],139:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../types":213,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],151:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getBroadcastDims(inShape, outShape) {
@@ -20109,7 +21243,7 @@ function assertAndGetBroadcastShape(shapeA, shapeB) {
 }
 exports.assertAndGetBroadcastShape = assertAndGetBroadcastShape;
 
-},{}],140:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20213,7 +21347,7 @@ exports.lessStrict = operation_1.op({ lessStrict_: lessStrict_ });
 exports.notEqual = operation_1.op({ notEqual_: notEqual_ });
 exports.notEqualStrict = operation_1.op({ notEqualStrict_: notEqualStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],141:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],153:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20239,7 +21373,7 @@ exports.complex = operation_1.op({ complex_: complex_ });
 exports.real = operation_1.op({ real_: real_ });
 exports.imag = operation_1.op({ imag_: imag_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],142:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],154:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20265,6 +21399,7 @@ function concat_(tensors, axis) {
     if (axis === void 0) { axis = 0; }
     util_1.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     var $tensors = tensor_util_env_1.convertToTensorArray(tensors, 'tensors', 'concat');
+    axis = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var outShape = concat_util_1.computeOutShape($tensors.map(function (t) { return t.shape; }), axis);
     if (util_1.sizeFromShape(outShape) === 0) {
         return tensor_ops_1.tensor([], outShape);
@@ -20273,16 +21408,15 @@ function concat_(tensors, axis) {
     if ($tensors.length === 1) {
         return $tensors[0];
     }
-    var axes = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var shapes = $tensors.map(function (t) { return t.shape; });
-    concat_util_1.assertParamsConsistent(shapes, axes);
+    concat_util_1.assertParamsConsistent(shapes, axis);
     var der = function (dy) {
         var sizeSplits = shapes.map(function (s) { return s[axis]; });
         var derTensors = exports.split(dy, sizeSplits, axis);
         return derTensors.map(function (t) { return function () { return t; }; });
     };
     var inputs = $tensors;
-    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axes); }, inputs, der);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axis); }, inputs, der);
 }
 function split_(x, numOrSizeSplits, axis) {
     if (axis === void 0) { axis = 0; }
@@ -20307,7 +21441,7 @@ exports.concat3d = operation_1.op({ concat3d_: concat3d_ });
 exports.concat4d = operation_1.op({ concat4d_: concat4d_ });
 exports.split = operation_1.op({ split_: split_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_util":143,"./operation":156,"./tensor_ops":171}],143:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_util":155,"./operation":171,"./tensor_ops":191}],155:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -20337,13 +21471,40 @@ function computeOutShape(shapes, axis) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194}],144:[function(require,module,exports){
+},{"../util":214}],156:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tensor_util_env_1 = require("../tensor_util_env");
+var util = require("../util");
+var array_ops_1 = require("./array_ops");
+var operation_1 = require("./operation");
+function confusionMatrix_(labels, predictions, numClasses) {
+    var $labels = tensor_util_env_1.convertToTensor(labels, 'label', 'confusionMatrix', 'int32');
+    var $predictions = tensor_util_env_1.convertToTensor(predictions, 'label', 'confusionMatrix', 'int32');
+    util.assert(numClasses == null || numClasses > 0 && Number.isInteger(numClasses), "If provided, numClasses must be a positive integer, " +
+        ("but got " + numClasses));
+    util.assert($labels.rank === 1, "Expected the rank of labels to be 1, but got " + $labels.rank);
+    util.assert($predictions.rank === 1, "Expected the rank of predictions to be 1, " +
+        ("but got " + $predictions.rank));
+    util.assert($labels.shape[0] === $predictions.shape[0], "Mismatch in the number of examples: " +
+        ($labels.shape[0] + " vs. " + $predictions.shape[0] + ". ") +
+        "Labels and predictions should have the same number of elements.");
+    util.assert(numClasses > 0 && Number.isInteger(numClasses), "numClasses is required to be a positive integer, but got " + numClasses);
+    var oneHotLabels = array_ops_1.oneHot($labels, numClasses);
+    var oneHotPredictions = array_ops_1.oneHot($predictions, numClasses);
+    return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+exports.confusionMatrix_ = confusionMatrix_;
+exports.confusionMatrix = operation_1.op({ confusionMatrix_: confusionMatrix_ });
+
+},{"../tensor_util_env":210,"../util":214,"./array_ops":146,"./operation":171}],157:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
+var matmul_1 = require("./matmul");
 var operation_1 = require("./operation");
 function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) {
     if (dataFormat === void 0) { dataFormat = 'NWC'; }
@@ -20365,7 +21526,7 @@ function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) 
     }
     util.assert(x3D.shape[2] === $filter.shape[1], "Error in conv1d: depth of input (" + x3D.shape[2] + ") must match " +
         ("input depth for filter " + $filter.shape[1] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
         ("Got stride " + stride + " and dilation '" + dilation + "'"));
     util.assert(dataFormat === 'NWC', "Error in conv1d: got dataFormat of " + dataFormat + " but only NWC is currently supported.");
     var filter4D = $filter.as4D(1, $filter.shape[0], $filter.shape[1], $filter.shape[2]);
@@ -20399,19 +21560,30 @@ function conv2d_(x, filter, strides, pad, dataFormat, dilations, dimRoundingMode
     }
     util.assert(x4D.shape[3] === $filter.shape[2], "Error in conv2d: depth of input (" + x4D.shape[3] + ") must match " +
         ("input depth for filter " + $filter.shape[2] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert(dataFormat === 'NHWC', "Error in conv2d: got dataFormat of " + dataFormat + " but only NHWC is currently supported.");
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
-    var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
-            ("yet supported in gradients. Got dilations '" + dilations + "'"));
-        return {
-            x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
-            $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+    var res;
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' || convInfo.padInfo.type === 'VALID')) {
+        var x2d = x4D.reshape([-1, convInfo.inChannels]);
+        var w2d = $filter.reshape([convInfo.inChannels, convInfo.outChannels]);
+        res = matmul_1.matMul(x2d, w2d).reshape(convInfo.outShape);
+    }
+    else {
+        var grad = function (dy) {
+            util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+                ("yet supported in gradients. Got dilations '" + dilations + "'"));
+            return {
+                x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
+                $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+            };
         };
-    };
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+        res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+    }
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20445,8 +21617,15 @@ function conv2dDerInput_(xShape, dy, filter, strides, pad, dimRoundingMode) {
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
     var dilations = 1;
+    var grad = function (ddx) {
+        var dataFormat = 'NHWC';
+        return {
+            dy4D: function () { return exports.conv2d(ddx, filter, strides, pad, dataFormat, dilations, dimRoundingMode); },
+            filter: function () { return exports.conv2dDerFilter(ddx, dy4D, filter.shape, strides, pad, dimRoundingMode); }
+        };
+    };
     var convInfo = conv_util.computeConv2DInfo(xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D });
+    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D, filter: filter }, grad);
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20505,7 +21684,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     if (dilations == null) {
         dilations = [1, 1];
     }
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in depthwiseConv2d: pad must be an integer when using, " +
@@ -20513,7 +21692,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     }
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode, true);
     var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+        util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
             ("1 are not yet supported. Got dilations '" + dilations + "'"));
         return {
             x: function () { return depthwiseConv2dDerInput(x4D.shape, dy, $filter, convInfo); },
@@ -20565,16 +21744,6 @@ function separableConv2d_(x, depthwiseFilter, pointwiseFilter, strides, pad, dil
     }
     return res;
 }
-function parseTupleParam(param) {
-    return typeof param === 'number' ? [param, param] : param;
-}
-function tupleValuesAreOne(param) {
-    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
-    return dimA === 1 && dimB === 1;
-}
-function eitherStridesOrDilationsAreOne(strides, dilations) {
-    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
-}
 function depthwiseConv2dDerInput(xShape, dy, filter, convInfo) {
     var dy4D = dy;
     var reshapedTo4D = false;
@@ -20601,15 +21770,16 @@ function depthwiseConv2dDerFilter(x, dy, filterShape, convInfo) {
 }
 exports.conv1d = operation_1.op({ conv1d_: conv1d_ });
 exports.conv2d = operation_1.op({ conv2d_: conv2d_ });
+exports.conv2dDerFilter = operation_1.op({ conv2dDerFilter_: conv2dDerFilter_ });
 exports.depthwiseConv2d = operation_1.op({ depthwiseConv2d_: depthwiseConv2d_ });
 exports.separableConv2d = operation_1.op({ separableConv2d_: separableConv2d_ });
 exports.conv2dTranspose = operation_1.op({ conv2dTranspose_: conv2dTranspose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],145:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./matmul":168,"./operation":171}],158:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
-function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, dataFormat) {
+function computePool2DInfo(inShape, filterSize, strides, dilations, pad, roundingMode, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var _a = parseTupleParam(filterSize), filterHeight = _a[0], filterWidth = _a[1];
     var filterShape;
@@ -20622,7 +21792,6 @@ function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, data
     else {
         throw new Error("Unknown dataFormat " + dataFormat);
     }
-    var dilations = 1;
     return computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundingMode, false, dataFormat);
 }
 exports.computePool2DInfo = computePool2DInfo;
@@ -20667,6 +21836,8 @@ function computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundi
         strideWidth: strideWidth,
         filterHeight: filterHeight,
         filterWidth: filterWidth,
+        effectiveFilterHeight: effectiveFilterHeight,
+        effectiveFilterWidth: effectiveFilterWidth,
         dilationHeight: dilationHeight,
         dilationWidth: dilationWidth,
         inShape: inShape,
@@ -20751,8 +21922,17 @@ function conditionalRound(value, roundingMode) {
             throw new Error("Unknown roundingMode " + roundingMode);
     }
 }
+function tupleValuesAreOne(param) {
+    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
+    return dimA === 1 && dimB === 1;
+}
+exports.tupleValuesAreOne = tupleValuesAreOne;
+function eitherStridesOrDilationsAreOne(strides, dilations) {
+    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+exports.eitherStridesOrDilationsAreOne = eitherStridesOrDilationsAreOne;
 
-},{"../util":194}],146:[function(require,module,exports){
+},{"../util":214}],159:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ERF_P = 0.3275911;
@@ -20762,7 +21942,64 @@ exports.ERF_A3 = 1.421413741;
 exports.ERF_A4 = -1.453152027;
 exports.ERF_A5 = 1.061405429;
 
-},{}],147:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function gatherND_(x, indices) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'gatherND', 'int32');
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'gatherND');
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.gatherND($x, $indices); }, { $x: $x, $indices: $indices });
+}
+exports.gatherND = operation_1.op({ gatherND_: gatherND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],161:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function prepareAndValidate(tensor, indices) {
+    if (tensor.rank < 1) {
+        throw new Error('tf.gatherND() expects the input to be rank 1 or higher,' +
+            (" but the rank was " + tensor.rank + "."));
+    }
+    if (indices.rank < 1) {
+        throw new Error('tf.gatherND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error('tf.gatherND() expects the indices to be int32 type,' +
+            (" but the dtype was " + indices.dtype + "."));
+    }
+    if (indices.shape[indices.rank - 1] > tensor.rank) {
+        throw new Error('index innermost dimension length must be <= tensor rank; saw: ' +
+            (indices.shape[indices.rank - 1] + " vs. " + tensor.rank));
+    }
+    if (tensor.size === 0) {
+        throw new Error('Requested more than 0 entries, but input is empty.' +
+            (" Input shape: " + tensor.shape + "."));
+    }
+    var indicesShape = indices.shape;
+    var sliceRank = indicesShape[indicesShape.length - 1];
+    var nResult = 1;
+    for (var i = 0; i < indicesShape.length - 1; ++i) {
+        nResult *= indicesShape[i];
+    }
+    var inputShape = tensor.shape;
+    var resultShape = indicesShape.slice();
+    resultShape.pop();
+    var sliceSize = 1;
+    for (var i = sliceRank; i < tensor.rank; ++i) {
+        sliceSize *= inputShape[i];
+        resultShape.push(inputShape[i]);
+    }
+    var strides = util_1.computeStrides(tensor.shape).map(function (stride) { return stride / sliceSize; }).concat([1]).slice(0, sliceRank);
+    return [resultShape, nResult, sliceSize, strides];
+}
+exports.prepareAndValidate = prepareAndValidate;
+
+},{"../util":214}],162:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -20957,7 +22194,7 @@ exports.nonMaxSuppression = operation_1.op({ nonMaxSuppression_: nonMaxSuppressi
 exports.nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
 exports.cropAndResize = cropAndResize_;
 
-},{"../environment":64,"../kernels/non_max_suppression_impl":84,"../tensor_util_env":190,"../util":194,"./operation":156}],148:[function(require,module,exports){
+},{"../environment":64,"../kernels/non_max_suppression_impl":85,"../tensor_util_env":210,"../util":214,"./operation":171}],163:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21103,7 +22340,7 @@ function qr2d(x, fullMatrices) {
 exports.gramSchmidt = operation_1.op({ gramSchmidt_: gramSchmidt_ });
 exports.qr = operation_1.op({ qr_: qr_ });
 
-},{"../environment":64,"../globals":66,"../util":194,"./array_ops":134,"./concat_split":142,"./norm":155,"./operation":156,"./reduction_ops":161,"./tensor_ops":171}],149:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../util":214,"./array_ops":146,"./concat_split":154,"./norm":170,"./operation":171,"./reduction_ops":176,"./tensor_ops":191}],164:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21220,7 +22457,7 @@ exports.logicalXor = operation_1.op({ logicalXor_: logicalXor_ });
 exports.where = operation_1.op({ where_: where_ });
 exports.whereAsync = whereAsync_;
 
-},{"../environment":64,"../kernels/where_impl":132,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],150:[function(require,module,exports){
+},{"../environment":64,"../kernels/where_impl":143,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],165:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var globals_1 = require("../globals");
@@ -21445,7 +22682,7 @@ exports.meanSquaredError = operation_1.op({ meanSquaredError_: meanSquaredError_
 exports.sigmoidCrossEntropy = operation_1.op({ sigmoidCrossEntropy_: sigmoidCrossEntropy_ });
 exports.softmaxCrossEntropy = operation_1.op({ softmaxCrossEntropy_: softmaxCrossEntropy_ });
 
-},{"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],151:[function(require,module,exports){
+},{"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],166:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21482,7 +22719,7 @@ function localResponseNormalization_(x, depthRadius, bias, alpha, beta) {
 }
 exports.localResponseNormalization = operation_1.op({ localResponseNormalization_: localResponseNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],152:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],167:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21531,7 +22768,7 @@ function basicLSTMCell_(forgetBias, lstmKernel, lstmBias, data, c, h) {
 exports.basicLSTMCell = operation_1.op({ basicLSTMCell_: basicLSTMCell_ });
 exports.multiRNNCell = operation_1.op({ multiRNNCell_: multiRNNCell_ });
 
-},{"../tensor_util_env":190,"./operation":156}],153:[function(require,module,exports){
+},{"../tensor_util_env":210,"./operation":171}],168:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21627,7 +22864,7 @@ exports.matMul = operation_1.op({ matMul_: matMul_ });
 exports.dot = operation_1.op({ dot_: dot_ });
 exports.outerProduct = operation_1.op({ outerProduct_: outerProduct_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],154:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],169:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_1 = require("../tensor_util");
@@ -21655,7 +22892,7 @@ function movingAverage_(v, x, decay, step, zeroDebias) {
 }
 exports.movingAverage = operation_1.op({ movingAverage_: movingAverage_ });
 
-},{"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],155:[function(require,module,exports){
+},{"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],170:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21718,7 +22955,7 @@ function normImpl(x, p, axis) {
 }
 exports.norm = operation_1.op({ norm_: norm_ });
 
-},{"../tensor_util_env":190,"./axis_util":136,"./operation":156,"./tensor_ops":171}],156:[function(require,module,exports){
+},{"../tensor_util_env":210,"./axis_util":148,"./operation":171,"./tensor_ops":191}],171:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21758,7 +22995,7 @@ function op(f) {
 }
 exports.op = op;
 
-},{"../environment":64}],157:[function(require,module,exports){
+},{"../environment":64}],172:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -21789,6 +23026,10 @@ __export(require("./lstm"));
 __export(require("./moving_average"));
 __export(require("./strided_slice"));
 __export(require("./topk"));
+__export(require("./scatter_nd"));
+__export(require("./spectral_ops"));
+__export(require("./sparse_to_dense"));
+__export(require("./gather_nd"));
 var operation_1 = require("./operation");
 exports.op = operation_1.op;
 var losses = require("./loss_ops");
@@ -21797,8 +23038,10 @@ var linalg = require("./linalg_ops");
 exports.linalg = linalg;
 var image = require("./image_ops");
 exports.image = image;
+var spectral = require("./spectral_ops");
+exports.spectral = spectral;
 
-},{"./array_ops":134,"./batchnorm":137,"./binary_ops":138,"./compare":140,"./complex_ops":141,"./concat_split":142,"./conv":144,"./image_ops":147,"./linalg_ops":148,"./logical_ops":149,"./loss_ops":150,"./lrn":151,"./lstm":152,"./matmul":153,"./moving_average":154,"./norm":155,"./operation":156,"./pool":158,"./reduction_ops":161,"./relu_ops":162,"./reverse":163,"./segment_ops":164,"./slice":167,"./softmax":169,"./strided_slice":170,"./tensor_ops":171,"./topk":172,"./transpose":173,"./unary_ops":174}],158:[function(require,module,exports){
+},{"./array_ops":146,"./batchnorm":149,"./binary_ops":150,"./compare":152,"./complex_ops":153,"./concat_split":154,"./conv":157,"./gather_nd":160,"./image_ops":162,"./linalg_ops":163,"./logical_ops":164,"./loss_ops":165,"./lrn":166,"./lstm":167,"./matmul":168,"./moving_average":169,"./norm":170,"./operation":171,"./pool":173,"./reduction_ops":176,"./relu_ops":177,"./reverse":178,"./scatter_nd":179,"./segment_ops":181,"./slice":184,"./softmax":186,"./sparse_to_dense":187,"./spectral_ops":189,"./strided_slice":190,"./tensor_ops":191,"./topk":192,"./transpose":193,"./unary_ops":194}],173:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21806,7 +23049,7 @@ var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
 var operation_1 = require("./operation");
-function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'maxPool');
     var x4D = $x;
     var reshapedTo4D = false;
@@ -21814,18 +23057,21 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
         reshapedTo4D = true;
         x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
     }
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
     util.assert(x4D.rank === 4, "Error in maxPool: input must be rank 4 but got rank " + x4D.rank + ".");
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in maxPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var grad = function (dy, saved) {
         var y4D = saved[0];
         return {
-            x: function () {
-                return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, pad);
-            }
+            x: function () { return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, dilations, pad); }
         };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.maxPool(x4D, convInfo)); }, { x: x4D }, grad);
@@ -21834,9 +23080,17 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return maxPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function avgPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'avgPool');
     util.assert($x.dtype === 'float32', 'The input dtype to avgPool must be float32');
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var x4D = $x;
     var reshapedTo4D = false;
     if ($x.rank === 3) {
@@ -21848,9 +23102,11 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
         util.assert(util.isInt(pad), "Error in avgPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad);
     var grad = function (dy) {
-        return { x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, pad); } };
+        return {
+            x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, dilations, pad); }
+        };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPool(x4D, convInfo); }, { x: x4D }, grad);
     res = res.cast($x.dtype);
@@ -21859,11 +23115,33 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundingMode) {
+function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return avgPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function pool_(input, windowShape, poolingType, padding, dilationRate, strides) {
+    if (dilationRate == null) {
+        dilationRate = 1;
+    }
+    if (strides == null) {
+        strides = 1;
+    }
+    if (poolingType === 'avg') {
+        return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+    else {
+        return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+}
+function maxPoolBackprop(dy, input, output, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'maxPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'maxPoolBackprop');
     var $output = tensor_util_env_1.convertToTensor(output, 'output', 'maxPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPoolBackProp: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert($dy.rank === 4, "Error in maxPoolBackprop: dy must be rank 4 but got rank " +
         ($dy.rank + "."));
     util.assert($input.rank === 4, "Error in maxPoolBackprop: input must be rank 4 but got rank " +
@@ -21872,14 +23150,19 @@ function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundin
         util.assert(util.isInt(pad), "Error in maxPoolBackprop: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.maxPoolBackprop($dy, $input, $output, convInfo); }, { $dy: $dy, $input: $input });
     return res;
 }
-function avgPoolBackprop(dy, input, filterSize, strides, pad) {
+function avgPoolBackprop(dy, input, filterSize, strides, dilations, pad) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'avgPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'avgPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPoolBackprop: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var input4D = $input;
     var dy4D = $dy;
     var reshapedTo4D = false;
@@ -21892,7 +23175,7 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
         (dy4D.rank + "."));
     util.assert(input4D.rank === 4, "Error in avgPoolBackprop: input must be rank 4 but got rank " +
         (input4D.rank + "."));
-    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, dilations, pad);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPoolBackprop(dy4D, input4D, convInfo); }, { dy4D: dy4D, input4D: input4D });
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
@@ -21901,8 +23184,9 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
 }
 exports.maxPool = operation_1.op({ maxPool_: maxPool_ });
 exports.avgPool = operation_1.op({ avgPool_: avgPool_ });
+exports.pool = operation_1.op({ pool_: pool_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],159:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./operation":171}],174:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var seedrandom = require("seedrandom");
@@ -21960,7 +23244,7 @@ var MPRandGauss = (function () {
 }());
 exports.MPRandGauss = MPRandGauss;
 
-},{"seedrandom":283}],160:[function(require,module,exports){
+},{"seedrandom":307}],175:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -21973,7 +23257,7 @@ function computeOptimalWindowSize(inSize) {
 }
 exports.computeOptimalWindowSize = computeOptimalWindowSize;
 
-},{"../util":194}],161:[function(require,module,exports){
+},{"../util":214}],176:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22034,6 +23318,28 @@ function sum_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function prod_(x, axis, keepDims) {
+    if (axis === void 0) { axis = null; }
+    if (keepDims === void 0) { keepDims = false; }
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'prod');
+    if ($x.dtype === 'bool') {
+        $x = $x.toInt();
+    }
+    var axes = axis_util.parseAxisParam(axis, $x.shape);
+    var permutation = axis_util.getAxesPermutation(axes, $x.rank);
+    var reductionAxes = axes;
+    var permutedX = $x;
+    if (permutation != null) {
+        permutedX = $x.transpose(permutation);
+        reductionAxes = axis_util.getInnerMostAxes(reductionAxes.length, $x.rank);
+    }
+    var value = environment_1.ENV.engine.runKernel(function (backend) { return backend.prod(permutedX, reductionAxes); }, { permutedX: permutedX });
+    if (keepDims) {
+        var newShape = axis_util.expandShapeToKeepDim(value.shape, axes);
+        value = value.reshape(newShape);
+    }
+    return value;
+}
 function mean_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
@@ -22060,10 +23366,26 @@ function mean_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes) {
+    var y = saved[0];
+    if (y.rank < xOrig.rank) {
+        y = y.reshape(axis_util.expandShapeToKeepDim(y.shape, origAxes));
+    }
+    if (dy.rank < xOrig.rank) {
+        dy = dy.reshape(axis_util.expandShapeToKeepDim(dy.shape, origAxes));
+    }
+    return {
+        $x: function () {
+            var dx = dy.mul(xOrig.equal(y).cast(dy.dtype));
+            return permutedAxes == null ? dx : dx.transpose(permutedAxes);
+        }
+    };
+}
 function min_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'min');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22071,10 +23393,13 @@ function min_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.min($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.min($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22082,6 +23407,7 @@ function max_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'max');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -22089,10 +23415,13 @@ function max_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.max($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.max($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22192,8 +23521,9 @@ exports.mean = operation_1.op({ mean_: mean_ });
 exports.min = operation_1.op({ min_: min_ });
 exports.moments = operation_1.op({ moments_: moments_ });
 exports.sum = operation_1.op({ sum_: sum_ });
+exports.prod = operation_1.op({ prod_: prod_ });
 
-},{"../environment":64,"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156,"./tensor_ops":171}],162:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171,"./tensor_ops":191}],177:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22259,7 +23589,7 @@ exports.prelu = operation_1.op({ prelu_: prelu_ });
 exports.relu = operation_1.op({ relu_: relu_ });
 exports.selu = operation_1.op({ selu_: selu_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./binary_ops":138,"./logical_ops":149,"./operation":156,"./selu_util":166,"./tensor_ops":171}],163:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./binary_ops":150,"./logical_ops":164,"./operation":171,"./selu_util":183,"./tensor_ops":191}],178:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22305,7 +23635,99 @@ exports.reverse2d = operation_1.op({ reverse2d_: reverse2d_ });
 exports.reverse3d = operation_1.op({ reverse3d_: reverse3d_ });
 exports.reverse4d = operation_1.op({ reverse4d_: reverse4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],164:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],179:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+var scatter_nd_util = require("./scatter_nd_util");
+function scatterND_(indices, updates, shape) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'scatterND', 'int32');
+    var $updates = tensor_util_env_1.convertToTensor(updates, 'updates', 'scatterND');
+    scatter_nd_util.validateInput($updates, $indices, shape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.scatterND($indices, $updates, shape); }, { $indices: $indices, $updates: $updates });
+}
+exports.scatterND = operation_1.op({ scatterND_: scatterND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171,"./scatter_nd_util":180}],180:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function validateUpdateShape(shape, indices, updates) {
+    var sliceDim = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var batchDim = (indices.rank > 1) ? indices.rank - 1 : 1;
+    var shapeError = 'Must have updates.shape = indices.shape[:batchDim] + ' +
+        ("shape[sliceDim:], got updates.shape: " + updates.shape) +
+        (", indices.shape: " + indices.shape + ", shape: " + shape) +
+        (", sliceDim: " + sliceDim + ", and batchDim: " + batchDim + ".");
+    if (updates.rank < batchDim) {
+        throw new Error(shapeError + (" update.rank < " + batchDim + ". "));
+    }
+    if (shape.length < sliceDim + (updates.rank - batchDim)) {
+        throw new Error(shapeError +
+            (" Output shape length < " + (sliceDim + (updates.rank - batchDim))));
+    }
+    if (updates.rank !== batchDim + shape.length - sliceDim) {
+        throw new Error(shapeError + (" update.rank != " + (batchDim + shape.length - sliceDim)));
+    }
+    for (var d = 0; d < batchDim; ++d) {
+        if (updates.shape[d] !== indices.shape[d]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + d + "] (" + updates.shape[d] + ") != indices.shape[" + d + "] (" + indices.shape[d] + ")."));
+        }
+    }
+    for (var d = 0; d < updates.rank - batchDim; ++d) {
+        if (updates.shape[d + batchDim] !== shape[d + sliceDim]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + (d + batchDim) + "] (" + updates.shape[d + batchDim] + ") != shape[" + (d + batchDim) + "] (" + shape[d + batchDim] + ")"));
+        }
+    }
+}
+exports.validateUpdateShape = validateUpdateShape;
+function validateInput(updates, indices, shape) {
+    if (indices.rank < 1) {
+        throw new Error('tf.scatterND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (updates.rank < 1) {
+        throw new Error('tf.scatterND() expects the updates to be rank 1 or higher,' +
+            (" but the rank was " + updates.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error("The dtype of 'indices' should be int32, but got dtype: " + indices.dtype);
+    }
+    if (shape.length < 1) {
+        throw new Error("Output rank must be greater or equal to 1, but got shape: " + shape);
+    }
+    if (shape.length === 0) {
+        if (indices.size === 0) {
+            throw new Error("Indices specified for empty output. indices shape: " + indices.shape);
+        }
+        if (updates.size === 0) {
+            throw new Error("Updates specified for empty output. updates shape: " + updates.shape);
+        }
+    }
+    validateUpdateShape(shape, indices, updates);
+}
+exports.validateInput = validateInput;
+function calculateShapes(updates, indices, shape) {
+    var sliceRank = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var totalNd = shape.length;
+    var sliceSize = 1;
+    for (var i = sliceRank; i < totalNd; ++i) {
+        sliceSize *= shape[i];
+    }
+    var safeSliceDim = (sliceRank < 1) ? 1 : sliceRank;
+    var numUpdates = indices.size / safeSliceDim;
+    var outputStrides = util_1.computeStrides(shape).concat([1]);
+    var strides = outputStrides.slice(outputStrides.length - sliceRank, outputStrides.length);
+    var outputSize = util_1.sizeFromShape(shape);
+    return { sliceRank: sliceRank, numUpdates: numUpdates, sliceSize: sliceSize, strides: strides, outputSize: outputSize };
+}
+exports.calculateShapes = calculateShapes;
+
+},{"../util":214}],181:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22397,7 +23819,7 @@ function gatherDropNegatives(x, indices) {
 exports.gather = operation_1.op({ gather_: gather_ });
 exports.unsortedSegmentSum = operation_1.op({ unsortedSegmentSum_: unsortedSegmentSum_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./axis_util":136,"./binary_ops":138,"./compare":140,"./logical_ops":149,"./operation":156,"./tensor_ops":171}],165:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./axis_util":148,"./binary_ops":150,"./compare":152,"./logical_ops":164,"./operation":171,"./tensor_ops":191}],182:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22439,13 +23861,13 @@ function computeOutShape(aShape, axis, numSegments) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194,"./reduce_util":160}],166:[function(require,module,exports){
+},{"../util":214,"./reduce_util":175}],183:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SELU_SCALEALPHA = 1.7580993408473768599402175208123;
 exports.SELU_SCALE = 1.0507009873554804934193349852946;
 
-},{}],167:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22460,17 +23882,17 @@ function slice1d_(x, begin, size) {
 }
 function slice2d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice2d');
-    util.assert($x.rank === 2, "slice1d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 2, "slice2d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice3d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice3d');
-    util.assert($x.rank === 3, "slice1d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 3, "slice3d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice4d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice4d');
-    util.assert($x.rank === 4, "slice1d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 4, "slice4d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice_(x, begin, size) {
@@ -22527,7 +23949,7 @@ exports.slice2d = operation_1.op({ slice2d_: slice2d_ });
 exports.slice3d = operation_1.op({ slice3d_: slice3d_ });
 exports.slice4d = operation_1.op({ slice4d_: slice4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./slice_util":168}],168:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./slice_util":185}],185:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -22618,7 +24040,7 @@ function stopForAxis(endMask, stopIndices, strides, inputShape, axis) {
 }
 exports.stopForAxis = stopForAxis;
 
-},{"../util":194}],169:[function(require,module,exports){
+},{"../util":214}],186:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gradients_1 = require("../gradients");
@@ -22650,7 +24072,67 @@ function softmax_(logits, dim) {
 }
 exports.softmax = operation_1.op({ softmax_: softmax_ });
 
-},{"../gradients":67,"../tensor_util_env":190,"./operation":156}],170:[function(require,module,exports){
+},{"../gradients":67,"../tensor_util_env":210,"./operation":171}],187:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var sparse_to_dense = require("../ops/sparse_to_dense_util");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function sparseToDense_(sparseIndices, sparseValues, outputShape, defaultValue) {
+    var $sparseIndices = tensor_util_env_1.convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
+    var $sparseValues = tensor_util_env_1.convertToTensor(sparseValues, 'sparseValues', 'sparseToDense');
+    var $defaultValue = tensor_util_env_1.convertToTensor(defaultValue, 'defaultValue', 'sparseToDense');
+    sparse_to_dense.validateInput($sparseIndices, $sparseValues, outputShape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.sparseToDense($sparseIndices, $sparseValues, outputShape, $defaultValue); }, { $sparseIndices: $sparseIndices, $sparseValues: $sparseValues, $defaultValue: $defaultValue });
+}
+exports.sparseToDense = operation_1.op({ sparseToDense_: sparseToDense_ });
+
+},{"../environment":64,"../ops/sparse_to_dense_util":188,"../tensor_util_env":210,"./operation":171}],188:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateInput(sparseIndices, sparseValues, outputShape) {
+    if (sparseIndices.dtype !== 'int32') {
+        throw new Error('tf.sparseToDense() expects the indices to be int32 type,' +
+            (" but the dtype was " + sparseIndices.dtype + "."));
+    }
+    if (sparseIndices.rank > 2) {
+        throw new Error('sparseIndices should be a scalar, vector, or matrix,' +
+            (" but got shape " + sparseIndices.shape + "."));
+    }
+    var numElems = sparseIndices.rank > 0 ? sparseIndices.shape[0] : 1;
+    var numDims = sparseIndices.rank > 1 ? sparseIndices.shape[1] : 1;
+    if (outputShape.length !== numDims) {
+        throw new Error('outputShape has incorrect number of elements:,' +
+            (" " + outputShape.length + ", should be: " + numDims + "."));
+    }
+    var numValues = sparseValues.size;
+    if (!(sparseValues.rank === 0 ||
+        sparseValues.rank === 1 && numValues === numElems)) {
+        throw new Error('sparseValues has incorrect shape ' +
+            (sparseValues.shape + ", should be [] or [" + numElems + "]"));
+    }
+}
+exports.validateInput = validateInput;
+
+},{}],189:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var operation_1 = require("../ops/operation");
+var util_1 = require("../util");
+function fft_(input) {
+    util_1.assert(input.dtype === 'complex64', "The dtype for tf.spectral.fft() must be complex64 " +
+        ("but got " + input.dtype + "."));
+    var innerDimensionSize = input.shape[input.shape.length - 1];
+    var batch = input.size / innerDimensionSize;
+    var input2D = input.as2D(batch, innerDimensionSize);
+    var ret = environment_1.ENV.engine.runKernel(function (backend) { return backend.fft(input2D); }, { input: input });
+    return ret.reshape(input.shape);
+}
+exports.fft = operation_1.op({ fft_: fft_ });
+
+},{"../environment":64,"../ops/operation":171,"../util":214}],190:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22673,12 +24155,13 @@ function stridedSlice_(x, begin, end, strides, beginMask, endMask, ellipsisMask,
 }
 exports.stridedSlice = operation_1.op({ stridedSlice_: stridedSlice_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],171:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],191:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_1 = require("../tensor");
 var tensor_util_env_1 = require("../tensor_util_env");
+var tensor_util_env_2 = require("../tensor_util_env");
 var util_1 = require("../util");
 var complex_ops_1 = require("./complex_ops");
 var operation_1 = require("./operation");
@@ -22693,7 +24176,7 @@ function tensor(values, shape, dtype) {
         throw new Error('values passed to tensor(values) must be an ' +
             'array of numbers or booleans, or a TypedArray');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (shape != null && inferredShape.length !== 1) {
         util_1.assertShapesMatch(shape, inferredShape, "Error creating a new Tensor. " +
             ("Inferred shape (" + inferredShape + ") does not match the ") +
@@ -22720,7 +24203,7 @@ exports.scalar = scalar;
 function tensor1d(values, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     util_1.assertNonNull(values);
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 1) {
         throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
@@ -22733,7 +24216,7 @@ function tensor2d(values, shape, dtype) {
     if (shape != null && shape.length !== 2) {
         throw new Error('tensor2d() requires shape to have two numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
         throw new Error('tensor2d() requires values to be number[][] or flat/TypedArray');
     }
@@ -22751,7 +24234,7 @@ function tensor3d(values, shape, dtype) {
     if (shape != null && shape.length !== 3) {
         throw new Error('tensor3d() requires shape to have three numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
         throw new Error('tensor3d() requires values to be number[][][] or flat/TypedArray');
     }
@@ -22769,7 +24252,7 @@ function tensor4d(values, shape, dtype) {
     if (shape != null && shape.length !== 4) {
         throw new Error('tensor4d() requires shape to have four numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
         throw new Error('tensor4d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22787,7 +24270,7 @@ function tensor5d(values, shape, dtype) {
     if (shape != null && shape.length !== 5) {
         throw new Error('tensor5d() requires shape to have five numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 5 && inferredShape.length !== 1) {
         throw new Error('tensor5d() requires values to be ' +
             'number[][][][][] or flat/TypedArray');
@@ -22806,7 +24289,7 @@ function tensor6d(values, shape, dtype) {
     if (shape != null && shape.length !== 6) {
         throw new Error('tensor6d() requires shape to have six numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 6 && inferredShape.length !== 1) {
         throw new Error('tensor6d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22897,7 +24380,7 @@ exports.range = range;
 exports.onesLike = operation_1.op({ onesLike_: onesLike_ });
 exports.zerosLike = operation_1.op({ zerosLike_: zerosLike_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./complex_ops":141,"./operation":156}],172:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./complex_ops":153,"./operation":171}],192:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22920,7 +24403,7 @@ function topk_(x, k, sorted) {
 }
 exports.topk = operation_1.op({ topk_: topk_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],173:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],193:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22950,7 +24433,7 @@ function transpose_(x, perm) {
 }
 exports.transpose = operation_1.op({ transpose_: transpose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],174:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],194:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23240,7 +24723,7 @@ exports.step = operation_1.op({ step_: step_ });
 exports.tan = operation_1.op({ tan_: tan_ });
 exports.tanh = operation_1.op({ tanh_: tanh_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./tensor_ops":171}],175:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./tensor_ops":191}],195:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23347,7 +24830,7 @@ var AdadeltaOptimizer = (function (_super) {
 exports.AdadeltaOptimizer = AdadeltaOptimizer;
 serialization_1.registerClass(AdadeltaOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],176:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],196:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23429,7 +24912,7 @@ var AdagradOptimizer = (function (_super) {
 exports.AdagradOptimizer = AdagradOptimizer;
 serialization_1.registerClass(AdagradOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],177:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],197:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23548,7 +25031,7 @@ var AdamOptimizer = (function (_super) {
 exports.AdamOptimizer = AdamOptimizer;
 serialization_1.registerClass(AdamOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],178:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],198:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23669,7 +25152,7 @@ var AdamaxOptimizer = (function (_super) {
 exports.AdamaxOptimizer = AdamaxOptimizer;
 serialization_1.registerClass(AdamaxOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],179:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],199:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23759,7 +25242,7 @@ var MomentumOptimizer = (function (_super) {
 exports.MomentumOptimizer = MomentumOptimizer;
 serialization_1.registerClass(MomentumOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./sgd_optimizer":183}],180:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./sgd_optimizer":203}],200:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23800,7 +25283,7 @@ var Optimizer = (function (_super) {
 }(serialization_1.Serializable));
 exports.Optimizer = Optimizer;
 
-},{"../globals":66,"../serialization":185}],181:[function(require,module,exports){
+},{"../globals":66,"../serialization":205}],201:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./adadelta_optimizer");
@@ -23856,7 +25339,7 @@ var OptimizerConstructors = (function () {
 }());
 exports.OptimizerConstructors = OptimizerConstructors;
 
-},{"./adadelta_optimizer":175,"./adagrad_optimizer":176,"./adam_optimizer":177,"./adamax_optimizer":178,"./momentum_optimizer":179,"./rmsprop_optimizer":182,"./sgd_optimizer":183}],182:[function(require,module,exports){
+},{"./adadelta_optimizer":195,"./adagrad_optimizer":196,"./adam_optimizer":197,"./adamax_optimizer":198,"./momentum_optimizer":199,"./rmsprop_optimizer":202,"./sgd_optimizer":203}],202:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24000,7 +25483,7 @@ var RMSPropOptimizer = (function (_super) {
 exports.RMSPropOptimizer = RMSPropOptimizer;
 serialization_1.registerClass(RMSPropOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],183:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],203:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24060,7 +25543,7 @@ var SGDOptimizer = (function (_super) {
 exports.SGDOptimizer = SGDOptimizer;
 serialization_1.registerClass(SGDOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],184:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],204:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("./util");
@@ -24084,7 +25567,11 @@ var Profiler = (function () {
             var vals = r.dataSync();
             util.checkComputationForNaN(vals, r.dtype, name);
             timer.then(function (timing) {
-                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+                var extraInfo = '';
+                if (timing.getExtraProfileInfo != null) {
+                    extraInfo = timing.getExtraProfileInfo();
+                }
+                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
             });
         });
         return result;
@@ -24095,19 +25582,19 @@ exports.Profiler = Profiler;
 var Logger = (function () {
     function Logger() {
     }
-    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs) {
+    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs, extraInfo) {
         var time = util.rightPad(timeMs + "ms", 9);
         var paddedName = util.rightPad(name, 25);
         var rank = result.rank;
         var size = result.size;
         var shape = util.rightPad(result.shape.toString(), 14);
-        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size + "\t%c" + extraInfo, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange', 'color: green');
     };
     return Logger;
 }());
 exports.Logger = Logger;
 
-},{"./util":194}],185:[function(require,module,exports){
+},{"./util":214}],205:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -24152,7 +25639,7 @@ function registerClass(cls) {
 }
 exports.registerClass = registerClass;
 
-},{"./util":194}],186:[function(require,module,exports){
+},{"./util":214}],206:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -24265,7 +25752,7 @@ function backpropagateGradients(tensorAccumulatedGradientMap, filteredTape) {
 }
 exports.backpropagateGradients = backpropagateGradients;
 
-},{"./tensor":187,"./util":194}],187:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],207:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24651,6 +26138,12 @@ var Tensor = (function () {
         if (keepDims === void 0) { keepDims = false; }
         this.throwIfDisposed();
         return opHandler.sum(this, axis, keepDims);
+    };
+    Tensor.prototype.prod = function (axis, keepDims) {
+        if (axis === void 0) { axis = null; }
+        if (keepDims === void 0) { keepDims = false; }
+        this.throwIfDisposed();
+        return opHandler.prod(this, axis, keepDims);
     };
     Tensor.prototype.mean = function (axis, keepDims) {
         if (axis === void 0) { axis = null; }
@@ -25052,6 +26545,10 @@ var Tensor = (function () {
         if (beta === void 0) { beta = 0.5; }
         return opHandler.localResponseNormalization(this, radius, bias, alpha, beta);
     };
+    Tensor.prototype.pool = function (windowShape, poolingType, padding, dilationRate, strides) {
+        this.throwIfDisposed();
+        return opHandler.pool(this, windowShape, poolingType, padding, dilationRate, strides);
+    };
     Tensor.prototype.variable = function (trainable, name, dtype) {
         if (trainable === void 0) { trainable = true; }
         this.throwIfDisposed();
@@ -25084,6 +26581,10 @@ var Tensor = (function () {
     Tensor.prototype.depthToSpace = function (blockSize, dataFormat) {
         this.throwIfDisposed();
         return opHandler.depthToSpace(this, blockSize, dataFormat);
+    };
+    Tensor.prototype.fft = function () {
+        this.throwIfDisposed();
+        return opHandler.spectral.fft(this);
     };
     Tensor.nextId = 0;
     return Tensor;
@@ -25147,7 +26648,7 @@ Object.defineProperty(Variable, Symbol.hasInstance, {
 var variable = Variable.variable;
 exports.variable = variable;
 
-},{"./tensor_format":188,"./util":194}],188:[function(require,module,exports){
+},{"./tensor_format":208,"./util":214}],208:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -25278,7 +26779,7 @@ function createComplexTuples(vals) {
     return complexTuples;
 }
 
-},{"./util":194}],189:[function(require,module,exports){
+},{"./util":214}],209:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -25353,12 +26854,47 @@ function isIterable(obj) {
     return Array.isArray(obj) || typeof obj === 'object';
 }
 
-},{"./tensor":187,"./util":194}],190:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],210:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
 var tensor_1 = require("./tensor");
 var util_1 = require("./util");
+function inferShape(val) {
+    var firstElem = val;
+    if (util_1.isTypedArray(val)) {
+        return [val.length];
+    }
+    if (!Array.isArray(val)) {
+        return [];
+    }
+    var shape = [];
+    while (firstElem instanceof Array) {
+        shape.push(firstElem.length);
+        firstElem = firstElem[0];
+    }
+    if (val instanceof Array && environment_1.ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+        deepAssertShapeConsistency(val, shape, []);
+    }
+    return shape;
+}
+exports.inferShape = inferShape;
+function deepAssertShapeConsistency(val, shape, indices) {
+    indices = indices || [];
+    if (!(val instanceof Array)) {
+        util_1.assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
+            ("but should be an array of " + shape[0] + " elements"); });
+        return;
+    }
+    util_1.assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
+        ("but is an array of " + val.length + " elements"); });
+    util_1.assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
+        ("elements, but has " + val.length + " elements"); });
+    var subShape = shape.slice(1);
+    for (var i = 0; i < val.length; ++i) {
+        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
+    }
+}
 function convertToTensor(x, argName, functionName, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     dtype = dtype || 'float32';
@@ -25370,7 +26906,7 @@ function convertToTensor(x, argName, functionName, dtype) {
         throw new Error("Argument '" + argName + "' passed to '" + functionName + "' must be a " +
             ("Tensor or TensorLike, but got " + x.constructor.name));
     }
-    var inferredShape = util_1.inferShape(x);
+    var inferredShape = inferShape(x);
     if (!util_1.isTypedArray(x) && !Array.isArray(x)) {
         x = [x];
     }
@@ -25387,7 +26923,7 @@ function convertToTensorArray(arg, argName, functionName) {
 }
 exports.convertToTensorArray = convertToTensorArray;
 
-},{"./environment":64,"./tensor":187,"./util":194}],191:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],211:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -25407,6 +26943,9 @@ exports.BROWSER_ENVS = {
 };
 exports.CPU_ENVS = {
     'HAS_WEBGL': false
+};
+exports.BROWSER_CPU_ENVS = {
+    'BACKEND': 'test-cpu'
 };
 exports.ALL_ENVS = {};
 function expectArraysClose(actual, expected, epsilon) {
@@ -25508,7 +27047,7 @@ function expectArrayBuffersEqual(actual, expected) {
 }
 exports.expectArrayBuffersEqual = expectArrayBuffersEqual;
 
-},{"./environment":64,"./tensor":187,"./util":194}],192:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],212:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./optimizers/adadelta_optimizer");
@@ -25531,7 +27070,7 @@ exports.train = {
     adam: optimizer_constructors_1.OptimizerConstructors.adam
 };
 
-},{"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer_constructors":181,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183}],193:[function(require,module,exports){
+},{"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer_constructors":201,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203}],213:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DType;
@@ -25593,7 +27132,7 @@ function sumOutType(type) {
 }
 exports.sumOutType = sumOutType;
 
-},{}],194:[function(require,module,exports){
+},{}],214:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -25614,6 +27153,18 @@ function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 exports.clamp = clamp;
+function nearestLargerEven(val) {
+    return val % 2 === 0 ? val : val + 1;
+}
+exports.nearestLargerEven = nearestLargerEven;
+function sum(arr) {
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) {
+        sum += arr[i];
+    }
+    return sum;
+}
+exports.sum = sum;
 function randUniform(a, b) {
     var r = Math.random();
     return (b * r) + (1 - r) * a;
@@ -25656,41 +27207,6 @@ function flatten(arr, ret) {
     return ret;
 }
 exports.flatten = flatten;
-function inferShape(val) {
-    var firstElem = val;
-    if (isTypedArray(val)) {
-        return [val.length];
-    }
-    if (!Array.isArray(val)) {
-        return [];
-    }
-    var shape = [];
-    while (firstElem instanceof Array) {
-        shape.push(firstElem.length);
-        firstElem = firstElem[0];
-    }
-    if (val instanceof Array) {
-        deepAssertShapeConsistency(val, shape, []);
-    }
-    return shape;
-}
-exports.inferShape = inferShape;
-function deepAssertShapeConsistency(val, shape, indices) {
-    indices = indices || [];
-    if (!(val instanceof Array)) {
-        assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
-            ("but should be an array of " + shape[0] + " elements"); });
-        return;
-    }
-    assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
-        ("but is an array of " + val.length + " elements"); });
-    assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
-        ("elements, but has " + val.length + " elements"); });
-    var subShape = shape.slice(1);
-    for (var i = 0; i < val.length; ++i) {
-        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
-    }
-}
 function sizeFromShape(shape) {
     if (shape.length === 0) {
         return 1;
@@ -25707,6 +27223,12 @@ function isScalarShape(shape) {
 }
 exports.isScalarShape = isScalarShape;
 function arraysEqual(n1, n2) {
+    if (n1 === n2) {
+        return true;
+    }
+    if (n1 == null || n2 == null) {
+        return false;
+    }
     if (n1.length !== n2.length) {
         return false;
     }
@@ -26024,13 +27546,13 @@ function now() {
 exports.now = now;
 
 }).call(this,require('_process'))
-},{"_process":271}],195:[function(require,module,exports){
+},{"_process":295}],215:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.17';
+var version = '0.13.8';
 exports.version = version;
 
-},{}],196:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gpgpu_util = require("./kernels/webgl/gpgpu_util");
@@ -26042,7 +27564,7 @@ exports.MathBackendWebGL = backend_webgl_1.MathBackendWebGL;
 var gpgpu_context_1 = require("./kernels/webgl/gpgpu_context");
 exports.GPGPUContext = gpgpu_context_1.GPGPUContext;
 
-},{"./kernels/backend_webgl":82,"./kernels/webgl/gpgpu_context":104,"./kernels/webgl/gpgpu_util":106,"./kernels/webgl/webgl_util":131}],197:[function(require,module,exports){
+},{"./kernels/backend_webgl":83,"./kernels/webgl/gpgpu_context":110,"./kernels/webgl/gpgpu_util":112,"./kernels/webgl/webgl_util":142}],217:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26084,7 +27606,7 @@ var Elu = (function (_super) {
     return Elu;
 }(Activation));
 exports.Elu = Elu;
-tfjs_core_1.serialization.SerializationMap.register(Elu);
+tfjs_core_1.serialization.registerClass(Elu);
 var Selu = (function (_super) {
     __extends(Selu, _super);
     function Selu() {
@@ -26097,7 +27619,7 @@ var Selu = (function (_super) {
     return Selu;
 }(Activation));
 exports.Selu = Selu;
-tfjs_core_1.serialization.SerializationMap.register(Selu);
+tfjs_core_1.serialization.registerClass(Selu);
 var Relu = (function (_super) {
     __extends(Relu, _super);
     function Relu() {
@@ -26110,7 +27632,7 @@ var Relu = (function (_super) {
     return Relu;
 }(Activation));
 exports.Relu = Relu;
-tfjs_core_1.serialization.SerializationMap.register(Relu);
+tfjs_core_1.serialization.registerClass(Relu);
 var Relu6 = (function (_super) {
     __extends(Relu6, _super);
     function Relu6() {
@@ -26123,7 +27645,7 @@ var Relu6 = (function (_super) {
     return Relu6;
 }(Activation));
 exports.Relu6 = Relu6;
-tfjs_core_1.serialization.SerializationMap.register(Relu6);
+tfjs_core_1.serialization.registerClass(Relu6);
 var Linear = (function (_super) {
     __extends(Linear, _super);
     function Linear() {
@@ -26136,7 +27658,7 @@ var Linear = (function (_super) {
     return Linear;
 }(Activation));
 exports.Linear = Linear;
-tfjs_core_1.serialization.SerializationMap.register(Linear);
+tfjs_core_1.serialization.registerClass(Linear);
 var Sigmoid = (function (_super) {
     __extends(Sigmoid, _super);
     function Sigmoid() {
@@ -26149,7 +27671,7 @@ var Sigmoid = (function (_super) {
     return Sigmoid;
 }(Activation));
 exports.Sigmoid = Sigmoid;
-tfjs_core_1.serialization.SerializationMap.register(Sigmoid);
+tfjs_core_1.serialization.registerClass(Sigmoid);
 var HardSigmoid = (function (_super) {
     __extends(HardSigmoid, _super);
     function HardSigmoid() {
@@ -26162,7 +27684,7 @@ var HardSigmoid = (function (_super) {
     return HardSigmoid;
 }(Activation));
 exports.HardSigmoid = HardSigmoid;
-tfjs_core_1.serialization.SerializationMap.register(HardSigmoid);
+tfjs_core_1.serialization.registerClass(HardSigmoid);
 var Softplus = (function (_super) {
     __extends(Softplus, _super);
     function Softplus() {
@@ -26175,7 +27697,7 @@ var Softplus = (function (_super) {
     return Softplus;
 }(Activation));
 exports.Softplus = Softplus;
-tfjs_core_1.serialization.SerializationMap.register(Softplus);
+tfjs_core_1.serialization.registerClass(Softplus);
 var Softsign = (function (_super) {
     __extends(Softsign, _super);
     function Softsign() {
@@ -26188,7 +27710,7 @@ var Softsign = (function (_super) {
     return Softsign;
 }(Activation));
 exports.Softsign = Softsign;
-tfjs_core_1.serialization.SerializationMap.register(Softsign);
+tfjs_core_1.serialization.registerClass(Softsign);
 var Tanh = (function (_super) {
     __extends(Tanh, _super);
     function Tanh() {
@@ -26201,7 +27723,7 @@ var Tanh = (function (_super) {
     return Tanh;
 }(Activation));
 exports.Tanh = Tanh;
-tfjs_core_1.serialization.SerializationMap.register(Tanh);
+tfjs_core_1.serialization.registerClass(Tanh);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax() {
@@ -26215,7 +27737,7 @@ var Softmax = (function (_super) {
     return Softmax;
 }(Activation));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 function serializeActivation(activation) {
     return activation.getClassName();
 }
@@ -26243,7 +27765,7 @@ function getActivation(identifier) {
 }
 exports.getActivation = getActivation;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],198:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],218:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26261,7 +27783,7 @@ function imageDataFormat() {
 }
 exports.imageDataFormat = imageDataFormat;
 
-},{"@tensorflow/tfjs-core":68}],199:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26306,7 +27828,7 @@ function disposeScalarCache() {
 }
 exports.disposeScalarCache = disposeScalarCache;
 
-},{"@tensorflow/tfjs-core":68}],200:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -26515,27 +28037,42 @@ function randomNormal(shape, mean, stddev, dtype, seed) {
 }
 exports.randomNormal = randomNormal;
 function dot(x, y) {
-    if (y.rank !== 2) {
-        throw new errors_1.NotImplementedError("dot support for y other than rank 2 is not yet implemented: " +
-            ("y shape = " + y.shape));
+    if ((x.rank < 2) || (y.rank < 2)) {
+        throw new errors_1.NotImplementedError("dot requires both inputs to be rank >= 2" +
+            (" but got x shape = " + x.shape + " and y shape = " + y.shape));
+    }
+    if (y.rank >= 3) {
+        var xLastDim = x.shape.slice(-1)[0];
+        var ySecondLastDim = y.shape.slice(-2)[0];
+        if (xLastDim !== ySecondLastDim) {
+            throw new errors_1.NotImplementedError("If rank y >= 3, then the second last dim" +
+                (" of y must equal the last dim of x but got x shape = " + x.shape + " and ") +
+                (" y shape = " + y.shape));
+        }
+    }
+    if ((x.rank === 2) && (y.rank === 2)) {
+        return tfc.matMul(x, y);
     }
     else {
-        if (x.rank === 2) {
-            return tfc.matMul(x, y);
-        }
-        else if (x.rank === 3) {
-            var xShape0 = x.shape[0];
-            var xShape1 = x.shape[1];
-            var xShape2 = x.shape[2];
-            x = x.reshape([xShape0 * xShape1, xShape2]);
-            return tfc.matMul(x, y).reshape([
-                xShape0, xShape1, y.shape[1]
-            ]);
-        }
-        else {
-            throw new errors_1.NotImplementedError("dot support for x of rank " + x.rank + " is not yet implemented: " +
-                ("x shape = " + x.shape));
-        }
+        var xFirstDims = x.shape.slice();
+        var xLastDim = xFirstDims.pop();
+        x = x.reshape([-1, xLastDim]);
+        var yShape = y.shape.slice();
+        var yLastDim = yShape.pop();
+        var ySecondLastDim = yShape.pop();
+        var yOtherDims = yShape.concat([yLastDim]);
+        var perm = Array.from({ length: y.rank }, function (_, i) {
+            if (i === 0) {
+                return y.rank - 2;
+            }
+            else if (i <= y.rank - 2) {
+                return i - 1;
+            }
+            return i;
+        });
+        y = y.transpose(perm).reshape([ySecondLastDim, -1]);
+        var outputShape = xFirstDims.concat(yOtherDims);
+        return tfc.matMul(x, y).reshape(outputShape);
     }
 }
 exports.dot = dot;
@@ -26703,7 +28240,7 @@ function inTrainPhase(x, alt, training) {
 }
 exports.inTrainPhase = inTrainPhase;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/math_utils":240,"./common":198,"@tensorflow/tfjs-core":68}],201:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/math_utils":264,"./common":218,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26753,8 +28290,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("./backend/state");
+var errors_1 = require("./errors");
 var logs_1 = require("./logs");
 var generic_utils = require("./utils/generic_utils");
+var ModelLoggingVerbosity;
+(function (ModelLoggingVerbosity) {
+    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
+    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
+})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
 var BaseCallback = (function () {
     function BaseCallback() {
         this.validationData = null;
@@ -26908,19 +28451,22 @@ var CallbackList = (function () {
                         if (logs == null) {
                             logs = {};
                         }
-                        _i = 0, _a = this.callbacks;
-                        _b.label = 1;
+                        return [4, logs_1.resolveScalarsInLogs(logs)];
                     case 1:
-                        if (!(_i < _a.length)) return [3, 4];
+                        _b.sent();
+                        _i = 0, _a = this.callbacks;
+                        _b.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3, 5];
                         callback = _a[_i];
                         return [4, callback.onBatchEnd(batch, logs)];
-                    case 2:
-                        _b.sent();
-                        _b.label = 3;
                     case 3:
+                        _b.sent();
+                        _b.label = 4;
+                    case 4:
                         _i++;
-                        return [3, 1];
-                    case 4: return [2];
+                        return [3, 2];
+                    case 5: return [2];
                 }
             });
         });
@@ -27404,8 +28950,70 @@ function standardizeCallbacks(callbacks) {
     return callbackConfigs.map(function (callbackConfig) { return new CustomCallback(callbackConfig); });
 }
 exports.standardizeCallbacks = standardizeCallbacks;
+var CallbackConstructorRegistry = (function () {
+    function CallbackConstructorRegistry() {
+    }
+    CallbackConstructorRegistry.registerCallbackConstructor = function (verbosityLevel, callbackConstructor) {
+        tfjs_core_1.util.assert(verbosityLevel >= 0 && Number.isInteger(verbosityLevel), "Verbosity level is expected to be an integer >= 0, " +
+            ("but got " + verbosityLevel));
+        CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
+        if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {
+            CallbackConstructorRegistry.constructors[verbosityLevel] = [];
+        }
+        CallbackConstructorRegistry.constructors[verbosityLevel].push(callbackConstructor);
+    };
+    CallbackConstructorRegistry.checkForDuplicate = function (callbackConstructor) {
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var constructors = CallbackConstructorRegistry.constructors[+levelName];
+            constructors.forEach(function (ctor) {
+                if (ctor === callbackConstructor) {
+                    throw new errors_1.ValueError('Duplicate callback constructor.');
+                }
+            });
+        }
+    };
+    CallbackConstructorRegistry.clear = function () {
+        CallbackConstructorRegistry.constructors = {};
+    };
+    CallbackConstructorRegistry.createCallbacks = function (verbosityLevel) {
+        var constructors = [];
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var level = +levelName;
+            if (verbosityLevel >= level) {
+                constructors.push.apply(constructors, CallbackConstructorRegistry.constructors[level]);
+            }
+        }
+        return constructors.map(function (ctor) { return new ctor(); });
+    };
+    CallbackConstructorRegistry.constructors = {};
+    return CallbackConstructorRegistry;
+}());
+exports.CallbackConstructorRegistry = CallbackConstructorRegistry;
+function configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics) {
+    var history = new History();
+    var actualCallbacks = [
+        new BaseLogger(yieldEvery)
+    ].concat(CallbackConstructorRegistry.createCallbacks(verbose));
+    if (callbacks != null) {
+        actualCallbacks.push.apply(actualCallbacks, callbacks);
+    }
+    actualCallbacks.push(history);
+    var callbackList = new CallbackList(actualCallbacks);
+    callbackList.setParams({
+        epochs: epochs,
+        initialEpoch: initialEpoch,
+        samples: numTrainSamples,
+        steps: stepsPerEpoch,
+        batchSize: batchSize,
+        verbose: verbose,
+        doValidation: doValidation,
+        metrics: callbackMetrics,
+    });
+    return { callbackList: callbackList, history: history };
+}
+exports.configureCallbacks = configureCallbacks;
 
-},{"./backend/state":199,"./logs":231,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],202:[function(require,module,exports){
+},{"./backend/state":219,"./errors":233,"./logs":255,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27437,7 +29045,7 @@ var Callback = (function (_super) {
 }(base_callbacks_1.BaseCallback));
 exports.Callback = Callback;
 
-},{"./base_callbacks":201,"./engine/training":209}],203:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/training":230}],223:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils_1 = require("./utils/generic_utils");
@@ -27506,13 +29114,13 @@ function getUniqueTensorName(scopedName) {
     }
 }
 exports.getUniqueTensorName = getUniqueTensorName;
-var tensorNameRegex = new RegExp(/^[A-Za-z][A-Za-z0-9\._\/]*$/);
+var tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
 function isValidTensorName(name) {
     return name.match(tensorNameRegex) ? true : false;
 }
 exports.isValidTensorName = isValidTensorName;
 
-},{"./utils/generic_utils":238}],204:[function(require,module,exports){
+},{"./utils/generic_utils":262}],224:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27570,7 +29178,7 @@ var MaxNorm = (function (_super) {
     return MaxNorm;
 }(Constraint));
 exports.MaxNorm = MaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MaxNorm);
+tfjs_core_1.serialization.registerClass(MaxNorm);
 var UnitNorm = (function (_super) {
     __extends(UnitNorm, _super);
     function UnitNorm(config) {
@@ -27590,7 +29198,7 @@ var UnitNorm = (function (_super) {
     return UnitNorm;
 }(Constraint));
 exports.UnitNorm = UnitNorm;
-tfjs_core_1.serialization.SerializationMap.register(UnitNorm);
+tfjs_core_1.serialization.registerClass(UnitNorm);
 var NonNeg = (function (_super) {
     __extends(NonNeg, _super);
     function NonNeg() {
@@ -27603,7 +29211,7 @@ var NonNeg = (function (_super) {
     return NonNeg;
 }(Constraint));
 exports.NonNeg = NonNeg;
-tfjs_core_1.serialization.SerializationMap.register(NonNeg);
+tfjs_core_1.serialization.registerClass(NonNeg);
 var MinMaxNorm = (function (_super) {
     __extends(MinMaxNorm, _super);
     function MinMaxNorm(config) {
@@ -27640,7 +29248,7 @@ var MinMaxNorm = (function (_super) {
     return MinMaxNorm;
 }(Constraint));
 exports.MinMaxNorm = MinMaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MinMaxNorm);
+tfjs_core_1.serialization.registerClass(MinMaxNorm);
 exports.CONSTRAINT_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'maxNorm': 'MaxNorm',
     'minMaxNorm': 'MinMaxNorm',
@@ -27676,7 +29284,7 @@ function getConstraint(identifier) {
 }
 exports.getConstraint = getConstraint;
 
-},{"./backend/common":198,"./backend/state":199,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],205:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28339,7 +29947,7 @@ var Container = (function (_super) {
             keptNodes = layer instanceof Container ? 1 : 0;
             for (var originalNodeIndex = 0; originalNodeIndex < layer.inboundNodes.length; originalNodeIndex++) {
                 var nodeKey = Container.nodeKey(layer, originalNodeIndex);
-                if (nodeKey in this.containerNodes) {
+                if (this.containerNodes.has(nodeKey)) {
                     nodeConversionMap[nodeKey] = keptNodes;
                     keptNodes += 1;
                 }
@@ -28422,7 +30030,7 @@ var Container = (function (_super) {
                             var tensorIndex = node.tensorIndices[i];
                             var nodeKey_1 = Container.nodeKey(inboundLayer, nodeIndex);
                             var newNodeIndex = nodeConversionMap[nodeKey_1];
-                            if (newNodeIndex === null || newNodeIndex === undefined) {
+                            if (newNodeIndex == null) {
                                 newNodeIndex = 0;
                             }
                             nodeData.push([inboundLayer.name, newNodeIndex, tensorIndex, kwargs]);
@@ -28543,19 +30151,20 @@ var Container = (function (_super) {
                 var layerData = layersFromConfig_2[_a];
                 var layer = createdLayers[layerData.name];
                 if (layer.name in unprocessedNodes) {
-                    for (var _b = 0, _c = unprocessedNodes[layer.name]; _b < _c.length; _b++) {
-                        var nodeData = _c[_b];
+                    var currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
+                    delete unprocessedNodes[layer.name];
+                    for (var _b = 0, currentUnprocessedNodesForLayer_1 = currentUnprocessedNodesForLayer; _b < currentUnprocessedNodesForLayer_1.length; _b++) {
+                        var nodeData = currentUnprocessedNodesForLayer_1[_b];
                         processNode(layer, nodeData);
                     }
-                    delete unprocessedNodes[layer.name];
                 }
             }
         }
         var inputTensors = [];
         var outputTensors = [];
         var inputLayersFromConfig = config.inputLayers;
-        for (var _d = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _d < inputLayersFromConfig_1.length; _d++) {
-            var layerData = inputLayersFromConfig_1[_d];
+        for (var _c = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _c < inputLayersFromConfig_1.length; _c++) {
+            var layerData = inputLayersFromConfig_1[_c];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28565,8 +30174,8 @@ var Container = (function (_super) {
             inputTensors.push(layerOutputTensors[tensorIndex]);
         }
         var outputLayersFromConfig = config.outputLayers;
-        for (var _e = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _e < outputLayersFromConfig_1.length; _e++) {
-            var layerData = outputLayersFromConfig_1[_e];
+        for (var _d = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _d < outputLayersFromConfig_1.length; _d++) {
+            var layerData = outputLayersFromConfig_1[_d];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28609,7 +30218,23 @@ var Container = (function (_super) {
 }(topology_1.Layer));
 exports.Container = Container;
 
-},{"../backend/state":199,"../errors":210,"../layers/serialization":229,"../utils/generic_utils":238,"../utils/serialization_utils":241,"../utils/types_utils":242,"../variables":244,"../version":245,"./input_layer":207,"./topology":208,"@tensorflow/tfjs-core":68}],206:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"../layers/serialization":253,"../utils/generic_utils":262,"../utils/serialization_utils":265,"../utils/types_utils":266,"../variables":268,"../version":269,"./input_layer":228,"./topology":229,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyIterator = (function () {
+    function LazyIterator() {
+    }
+    return LazyIterator;
+}());
+exports.LazyIterator = LazyIterator;
+var Dataset = (function () {
+    function Dataset() {
+    }
+    return Dataset;
+}());
+exports.Dataset = Dataset;
+
+},{}],227:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -28743,7 +30368,7 @@ function getNodeOutputs(fetch) {
     return layerOutputs;
 }
 
-},{"../errors":210,"./input_layer":207,"@tensorflow/tfjs-core":68}],207:[function(require,module,exports){
+},{"../errors":233,"./input_layer":228,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28822,10 +30447,7 @@ var InputLayer = (function (_super) {
             ("InputLayer's apply() method. InputLayer name: " + this.name));
     };
     InputLayer.prototype.dispose = function () {
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: 0
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: 0 };
     };
     InputLayer.prototype.getConfig = function () {
         return {
@@ -28839,7 +30461,7 @@ var InputLayer = (function (_super) {
     return InputLayer;
 }(topology_1.Layer));
 exports.InputLayer = InputLayer;
-tfjs_core_1.serialization.SerializationMap.register(InputLayer);
+tfjs_core_1.serialization.registerClass(InputLayer);
 function Input(config) {
     if (config.batchShape == null && config.shape == null) {
         throw new Error('Please provide to Input either a `shape`' +
@@ -28870,7 +30492,7 @@ function Input(config) {
 }
 exports.Input = Input;
 
-},{"../backend/state":199,"../errors":210,"./topology":208,"@tensorflow/tfjs-core":68}],208:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"./topology":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29558,10 +31180,7 @@ var Layer = (function (_super) {
         if (--this._refCount === 0) {
             numDisposedVariables = this.disposeWeights();
         }
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: numDisposedVariables
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: numDisposedVariables };
     };
     return Layer;
 }(tfjs_core_1.serialization.Serializable));
@@ -29612,7 +31231,7 @@ function getSourceInputs(tensor, layer, nodeIndex) {
 }
 exports.getSourceInputs = getSourceInputs;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"../utils/variable_utils":243,"../variables":244,"@tensorflow/tfjs-core":68}],209:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"../utils/variable_utils":267,"../variables":268,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29664,10 +31283,8 @@ var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
-var base_callbacks_1 = require("../base_callbacks");
 var common_1 = require("../common");
 var errors_1 = require("../errors");
-var logs_1 = require("../logs");
 var losses = require("../losses");
 var Metrics = require("../metrics");
 var optimizers = require("../optimizers");
@@ -29676,6 +31293,8 @@ var layer_utils_1 = require("../utils/layer_utils");
 var math_utils_1 = require("../utils/math_utils");
 var container_1 = require("./container");
 var executor_1 = require("./executor");
+var training_dataset_1 = require("./training_dataset");
+var training_tensors_1 = require("./training_tensors");
 function isDataTensor(x) {
     return x instanceof tfjs_core_1.Tensor;
 }
@@ -29840,46 +31459,6 @@ function checkLossAndTargetCompatibility(targets, lossFns, outputShapes) {
         }
     }
 }
-function makeBatches(size, batchSize) {
-    var output = [];
-    var batchStart = 0;
-    var batchEnd = null;
-    while (batchStart < size) {
-        batchEnd = batchStart + batchSize;
-        if (batchEnd >= size) {
-            batchEnd = size;
-        }
-        output.push([batchStart, batchEnd]);
-        batchStart = batchEnd;
-    }
-    return output;
-}
-exports.makeBatches = makeBatches;
-function sliceArrays(arrays, start, stop) {
-    if (arrays == null) {
-        return [null];
-    }
-    else if (Array.isArray(arrays)) {
-        return arrays.map(function (array) { return K.sliceAlongFirstAxis(array, start, stop - start); });
-    }
-    else {
-        return K.sliceAlongFirstAxis(arrays, start, stop - start);
-    }
-}
-function sliceArraysByIndices(arrays, indices) {
-    return tfc.tidy(function () {
-        if (arrays == null) {
-            return null;
-        }
-        else if (Array.isArray(arrays)) {
-            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
-        }
-        else {
-            return K.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
-        }
-    });
-}
-exports.sliceArraysByIndices = sliceArraysByIndices;
 function checkInputData(data, names, shapes, checkBatchAxis, exceptionPrefix) {
     if (checkBatchAxis === void 0) { checkBatchAxis = true; }
     if (exceptionPrefix === void 0) { exceptionPrefix = ''; }
@@ -29952,14 +31531,6 @@ function collectMetrics(metrics, outputNames) {
         throw new TypeError('Type of metrics argument not understood. Expected an Array or ' +
             'Object, found: ' + metrics);
     }
-}
-var ModelLoggingVerbosity;
-(function (ModelLoggingVerbosity) {
-    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
-    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
-})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
-function checkBatchSize(batchSize) {
-    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
 }
 var Model = (function (_super) {
     __extends(Model, _super);
@@ -30150,13 +31721,21 @@ var Model = (function (_super) {
     Model.prototype.evaluate = function (x, y, config) {
         if (config === void 0) { config = {}; }
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         var standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
         var ins = standardizedOuts[0].concat(standardizedOuts[1]);
         this.makeTestFunction();
         var f = this.testFunction;
         var testOuts = this.testLoop(f, ins, batchSize, config.verbose, config.steps);
         return generic_utils_1.singletonOrArray(testOuts);
+    };
+    Model.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                this.makeTestFunction();
+                return [2, training_dataset_1.evaluateDataset(this, dataset, config)];
+            });
+        });
     };
     Model.prototype.checkNumSamples = function (ins, batchSize, steps, stepsName) {
         if (stepsName === void 0) { stepsName = 'steps'; }
@@ -30261,13 +31840,13 @@ var Model = (function (_super) {
             if (verbose) {
                 throw new errors_1.NotImplementedError('Verbose predictLoop() is not implemented yet.');
             }
-            var batches = makeBatches(numSamples, batchSize);
+            var batches = training_tensors_1.makeBatches(numSamples, batchSize);
             var outs = [];
             var _loop_3 = function (batchIndex) {
                 var batchOuts = tfc.tidy(function () {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
-                    var insBatch = sliceArrays(ins, batchStart, batchEnd);
+                    var insBatch = training_tensors_1.sliceArrays(ins, batchStart, batchEnd);
                     var feeds = [];
                     if (Array.isArray(insBatch)) {
                         for (var i = 0; i < insBatch.length; ++i) {
@@ -30302,7 +31881,7 @@ var Model = (function (_super) {
         if (config === void 0) { config = {}; }
         checkInputData(x, this.inputNames, this.feedInputShapes, false);
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         return this.predictLoop(x, batchSize);
     };
     Model.prototype.predictOnBatch = function (x) {
@@ -30339,204 +31918,26 @@ var Model = (function (_super) {
         }
         return [x, y, null];
     };
-    Model.prototype.fitLoop = function (f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var doValidation, numTrainSamples, indexArray, baseLogger, callbackList, _loop_4, this_1, epoch, state_2;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (batchSize == null) {
-                            batchSize = 32;
-                        }
-                        if (epochs == null) {
-                            epochs = 1;
-                        }
-                        if (shuffle == null) {
-                            shuffle = true;
-                        }
-                        if (initialEpoch == null) {
-                            initialEpoch = 0;
-                        }
-                        doValidation = false;
-                        if (valF != null && valIns != null) {
-                            doValidation = true;
-                        }
-                        if (validationSteps != null) {
-                            doValidation = true;
-                            if (stepsPerEpoch == null) {
-                                throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
-                                    'i.e., `stepsPerEpoch` must be set.');
-                            }
-                        }
-                        numTrainSamples = this.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
-                        if (numTrainSamples != null) {
-                            indexArray = math_utils_1.range(0, numTrainSamples);
-                        }
-                        this.history = new base_callbacks_1.History();
-                        baseLogger = new base_callbacks_1.BaseLogger(yieldEvery);
-                        if (callbacks == null) {
-                            callbacks = [baseLogger];
-                        }
-                        else {
-                            callbacks = [baseLogger].concat(callbacks);
-                        }
-                        callbacks = callbacks.concat([this.history]);
-                        if (verbose > 0) {
-                            throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
-                        }
-                        callbackList = new base_callbacks_1.CallbackList(callbacks);
-                        callbackList.setModel(this);
-                        callbackList.setParams({
-                            epochs: epochs,
-                            initialEpoch: initialEpoch,
-                            samples: numTrainSamples,
-                            steps: stepsPerEpoch,
-                            batchSize: batchSize,
-                            verbose: verbose,
-                            doValidation: doValidation,
-                            metrics: callbackMetrics,
-                        });
-                        return [4, callbackList.onTrainBegin()];
-                    case 1:
-                        _a.sent();
-                        this.stopTraining_ = false;
-                        _loop_4 = function (epoch) {
-                            var epochLogs, epochIndexArray1D_1, batches_1, _loop_5, batchIndex, state_3;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4, callbackList.onEpochBegin(epoch)];
-                                    case 1:
-                                        _a.sent();
-                                        epochLogs = {};
-                                        if (!(stepsPerEpoch != null)) return [3, 2];
-                                        throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
-                                    case 2:
-                                        if (shuffle === 'batch') {
-                                            throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
-                                        }
-                                        else if (shuffle) {
-                                            tfjs_core_1.util.shuffle(indexArray);
-                                        }
-                                        epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
-                                        batches_1 = makeBatches(numTrainSamples, batchSize);
-                                        _loop_5 = function (batchIndex) {
-                                            var batchLogs;
-                                            return __generator(this, function (_a) {
-                                                switch (_a.label) {
-                                                    case 0:
-                                                        batchLogs = {};
-                                                        return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
-                                                    case 1:
-                                                        _a.sent();
-                                                        tfc.tidy(function () {
-                                                            var batchStart = batches_1[batchIndex][0];
-                                                            var batchEnd = batches_1[batchIndex][1];
-                                                            var batchIds = K.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
-                                                            batchLogs['batch'] = batchIndex;
-                                                            batchLogs['size'] = batchEnd - batchStart;
-                                                            var insBatch = sliceArraysByIndices(ins, batchIds);
-                                                            var outs = f(insBatch);
-                                                            for (var i = 0; i < outLabels.length; ++i) {
-                                                                var label = outLabels[i];
-                                                                var out = outs[i];
-                                                                batchLogs[label] = out;
-                                                                tfc.keep(out);
-                                                            }
-                                                            if (batchIndex === batches_1.length - 1) {
-                                                                if (doValidation) {
-                                                                    var valOuts = _this.testLoop(valF, valIns, batchSize);
-                                                                    for (var i = 0; i < outLabels.length; ++i) {
-                                                                        var label = outLabels[i];
-                                                                        var out = valOuts[i];
-                                                                        tfc.keep(out);
-                                                                        epochLogs['val_' + label] = out;
-                                                                    }
-                                                                }
-                                                            }
-                                                        });
-                                                        return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
-                                                    case 2:
-                                                        _a.sent();
-                                                        logs_1.disposeTensorsInLogs(batchLogs);
-                                                        if (this_1.stopTraining_) {
-                                                            return [2, "break"];
-                                                        }
-                                                        return [2];
-                                                }
-                                            });
-                                        };
-                                        batchIndex = 0;
-                                        _a.label = 3;
-                                    case 3:
-                                        if (!(batchIndex < batches_1.length)) return [3, 6];
-                                        return [5, _loop_5(batchIndex)];
-                                    case 4:
-                                        state_3 = _a.sent();
-                                        if (state_3 === "break")
-                                            return [3, 6];
-                                        _a.label = 5;
-                                    case 5:
-                                        ++batchIndex;
-                                        return [3, 3];
-                                    case 6:
-                                        epochIndexArray1D_1.dispose();
-                                        _a.label = 7;
-                                    case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
-                                    case 8:
-                                        _a.sent();
-                                        if (this_1.stopTraining_) {
-                                            return [2, "break"];
-                                        }
-                                        return [2];
-                                }
-                            });
-                        };
-                        this_1 = this;
-                        epoch = initialEpoch;
-                        _a.label = 2;
-                    case 2:
-                        if (!(epoch < epochs)) return [3, 5];
-                        return [5, _loop_4(epoch)];
-                    case 3:
-                        state_2 = _a.sent();
-                        if (state_2 === "break")
-                            return [3, 5];
-                        _a.label = 4;
-                    case 4:
-                        ++epoch;
-                        return [3, 2];
-                    case 5: return [4, callbackList.onTrainEnd()];
-                    case 6:
-                        _a.sent();
-                        return [4, this.history.syncData()];
-                    case 7:
-                        _a.sent();
-                        return [2, this.history];
-                }
-            });
-        });
-    };
     Model.prototype.testLoop = function (f, ins, batchSize, verbose, steps) {
         var _this = this;
         if (verbose === void 0) { verbose = 0; }
         return tfc.tidy(function () {
             var numSamples = _this.checkNumSamples(ins, batchSize, steps, 'steps');
             var outs = [];
-            if (verbose === 1) {
+            if (verbose > 0) {
                 throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
             }
             if (steps != null) {
                 throw new errors_1.NotImplementedError('steps mode in testLoop() is not implemented yet');
             }
             else {
-                var batches = makeBatches(numSamples, batchSize);
+                var batches = training_tensors_1.makeBatches(numSamples, batchSize);
                 var indexArray = tfjs_core_1.tensor1d(math_utils_1.range(0, numSamples));
                 for (var batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
                     var batchIds = K.sliceAlongFirstAxis(indexArray, batchStart, batchEnd - batchStart);
-                    var insBatch = sliceArraysByIndices(ins, batchIds);
+                    var insBatch = training_tensors_1.sliceArraysByIndices(ins, batchIds);
                     var batchOuts = f(insBatch);
                     if (batchIndex === 0) {
                         for (var i = 0; i < batchOuts.length; ++i) {
@@ -30569,6 +31970,54 @@ var Model = (function (_super) {
             dedupedOutLabels.push(newLabel);
         }
         return dedupedOutLabels;
+    };
+    Model.prototype.makeTrainFunction = function () {
+        var _this = this;
+        return function (data) {
+            var losses = [];
+            var lossValues = [];
+            var inputs = data.slice(0, _this.inputs.length);
+            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
+            var metricsValues = [];
+            var totalLossFunction = function () {
+                var feeds = [];
+                for (var i = 0; i < _this.inputs.length; ++i) {
+                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
+                }
+                var feedDict = new executor_1.FeedDict(feeds);
+                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
+                var totalLoss;
+                for (var i = 0; i < _this.lossFunctions.length; ++i) {
+                    var lossFunction = _this.lossFunctions[i];
+                    var loss = lossFunction(targets[i], outputs[i]);
+                    losses.push(loss);
+                    var meanLoss = tfc.mean(loss);
+                    lossValues.push(meanLoss);
+                    if (i === 0) {
+                        totalLoss = loss;
+                    }
+                    else {
+                        totalLoss = tfc.add(totalLoss, loss);
+                    }
+                }
+                for (var i = 0; i < _this.metricsTensors.length; ++i) {
+                    var metric = _this.metricsTensors[i][0];
+                    var outputIndex = _this.metricsTensors[i][1];
+                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
+                    tfc.keep(meanMetric);
+                    metricsValues.push(meanMetric);
+                }
+                totalLoss = tfc.mean(totalLoss);
+                _this.calculateLosses().forEach(function (regularizerLoss) {
+                    totalLoss = tfc.add(totalLoss, regularizerLoss);
+                });
+                return totalLoss;
+            };
+            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
+            var returnCost = true;
+            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
+            return [totalLossValue].concat(metricsValues);
+        };
     };
     Model.prototype.makeTestFunction = function () {
         var _this = this;
@@ -30608,139 +32057,15 @@ var Model = (function (_super) {
     Model.prototype.fit = function (x, y, config) {
         if (config === void 0) { config = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (this.isTraining) {
-                            throw new Error('Cannot start training because another fit() call is ongoing.');
-                        }
-                        this.isTraining = true;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, , 3, 4]);
-                        batchSize = config.batchSize == null ? 32 : config.batchSize;
-                        checkBatchSize(batchSize);
-                        standardizedOuts = this.standardizeUserData(x, y, false, batchSize);
-                        inputs = standardizedOuts[0];
-                        targets = standardizedOuts[1];
-                        doValidation = false;
-                        valX = void 0;
-                        valY = void 0;
-                        valIns = void 0;
-                        needValidationDisposal = false;
-                        if (config.validationData != null && config.validationData.length > 0) {
-                            doValidation = true;
-                            if (config.validationData.length === 2) {
-                                valX = config.validationData[0];
-                                valY = config.validationData[1];
-                            }
-                            else if (config.validationData.length === 3) {
-                                throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
-                            }
-                            else {
-                                throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
-                                    "or 3 (valX, valY, valSampleWeight) items; " +
-                                    (config.validationData + " is invalid."));
-                            }
-                            valStandardized = this.standardizeUserData(valX, valY, true, batchSize);
-                            valX = valStandardized[0];
-                            valY = valStandardized[1];
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSplit != null && config.validationSplit > 0 &&
-                            config.validationSplit < 1) {
-                            doValidation = true;
-                            splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
-                            originalBatchSize = inputs[0].shape[0];
-                            valX = sliceArrays(inputs, splitAt, originalBatchSize);
-                            inputs = sliceArrays(inputs, 0, splitAt);
-                            valY = sliceArrays(targets, splitAt, originalBatchSize);
-                            targets = sliceArrays(targets, 0, splitAt);
-                            needValidationDisposal = true;
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSteps != null) {
-                            doValidation = true;
-                        }
-                        ins = inputs.concat(targets);
-                        this.checkTrainableWeightsConsistency();
-                        trainFunction = function (data) {
-                            var losses = [];
-                            var lossValues = [];
-                            var inputs = data.slice(0, _this.inputs.length);
-                            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
-                            var metricsValues = [];
-                            var totalLossFunction = function () {
-                                var feeds = [];
-                                for (var i = 0; i < _this.inputs.length; ++i) {
-                                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
-                                }
-                                var feedDict = new executor_1.FeedDict(feeds);
-                                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
-                                var totalLoss;
-                                for (var i = 0; i < _this.lossFunctions.length; ++i) {
-                                    var lossFunction = _this.lossFunctions[i];
-                                    var loss = lossFunction(targets[i], outputs[i]);
-                                    losses.push(loss);
-                                    var meanLoss = tfc.mean(loss);
-                                    lossValues.push(meanLoss);
-                                    if (i === 0) {
-                                        totalLoss = loss;
-                                    }
-                                    else {
-                                        totalLoss = tfc.add(totalLoss, loss);
-                                    }
-                                }
-                                for (var i = 0; i < _this.metricsTensors.length; ++i) {
-                                    var metric = _this.metricsTensors[i][0];
-                                    var outputIndex = _this.metricsTensors[i][1];
-                                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
-                                    tfc.keep(meanMetric);
-                                    metricsValues.push(meanMetric);
-                                }
-                                totalLoss = tfc.mean(totalLoss);
-                                _this.calculateLosses().forEach(function (regularizerLoss) {
-                                    totalLoss = tfc.add(totalLoss, regularizerLoss);
-                                });
-                                return totalLoss;
-                            };
-                            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
-                            var returnCost = true;
-                            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
-                            return [totalLossValue].concat(metricsValues);
-                        };
-                        outLabels = this.getDedupedMetricsNames();
-                        valFunction = void 0;
-                        callbackMetrics = void 0;
-                        if (doValidation) {
-                            this.makeTestFunction();
-                            valFunction = this.testFunction;
-                            callbackMetrics =
-                                outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
-                        }
-                        else {
-                            valFunction = null;
-                            valIns = [];
-                            callbackMetrics = outLabels.slice();
-                        }
-                        callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
-                        return [4, this.fitLoop(trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
-                    case 2:
-                        out = _a.sent();
-                        if (needValidationDisposal) {
-                            valIns.forEach(function (tensor) { return tensor.dispose(); });
-                            inputs.forEach(function (tensor) { return tensor.dispose(); });
-                            targets.forEach(function (tensor) { return tensor.dispose(); });
-                        }
-                        this.isTraining = false;
-                        return [2, out];
-                    case 3:
-                        this.isTraining = false;
-                        return [7];
-                    case 4: return [2];
-                }
+                return [2, training_tensors_1.fitTensors(this, x, y, config)];
+            });
+        });
+    };
+    Model.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, training_dataset_1.fitDataset(this, dataset, config)];
             });
         });
     };
@@ -30804,9 +32129,699 @@ var Model = (function (_super) {
     return Model;
 }(container_1.Container));
 exports.Model = Model;
-tfjs_core_1.serialization.SerializationMap.register(Model);
+tfjs_core_1.serialization.registerClass(Model);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../base_callbacks":201,"../common":203,"../errors":210,"../logs":231,"../losses":232,"../metrics":233,"../optimizers":235,"../utils/generic_utils":238,"../utils/layer_utils":239,"../utils/math_utils":240,"./container":205,"./executor":206,"@tensorflow/tfjs-core":68}],210:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../errors":233,"../losses":256,"../metrics":257,"../optimizers":259,"../utils/generic_utils":262,"../utils/layer_utils":263,"../utils/math_utils":264,"./container":225,"./executor":227,"./training_dataset":231,"./training_tensors":232,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var state_1 = require("../backend/state");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var generic_utils_1 = require("../utils/generic_utils");
+var dataset_stub_1 = require("./dataset_stub");
+var DEFAULT_VALIDATION_BATCH_SIZE = 32;
+function standardizeDataIteratorOutput(model, iteratorOut) {
+    if (model.outputs.length > 1) {
+        throw new errors_1.NotImplementedError("Support for training a model with multiple output tensors with " +
+            "a dataset object is not implemented yet.");
+    }
+    tfc.util.assert(Array.isArray(iteratorOut) && iteratorOut.length === 2, 'Dataset iterator for fitDataset() is expected to generate ' +
+        'an Array of length 2: `[xs, ys]`, but instead generates ' +
+        iteratorOut);
+    iteratorOut = iteratorOut;
+    var ys = iteratorOut[1];
+    var xs = iteratorOut[0];
+    if (xs instanceof tfc.Tensor) {
+        tfc.util.assert(model.inputs.length === 1, "Model has multiple " + model.inputs.length + " inputs, hence it " +
+            "expects the input dataset to generate a dictionary of tensors " +
+            (" (with keys " + JSON.stringify(model.inputNames) + ", ") +
+            "but received a single tensor.");
+        tfc.util.assert(xs.shape[0] === ys.shape[0], "Mismatch in batch size between x and y tensors (" + xs.shape[0] + " vs. " +
+            (ys.shape[0] + ")"));
+        return [xs, ys];
+    }
+    else {
+        var batchSize = void 0;
+        xs = xs;
+        var flattendXs = [];
+        for (var _i = 0, _a = model.inputNames; _i < _a.length; _i++) {
+            var inputName = _a[_i];
+            if (xs[inputName] == null) {
+                throw new errors_1.ValueError("The feature data generated by the dataset lacks the required " +
+                    ("input key '" + inputName + "'."));
+            }
+            flattendXs.push(xs[inputName]);
+            if (batchSize == null) {
+                batchSize = xs[inputName].shape[0];
+            }
+            else {
+                tfc.util.assert(xs[inputName].shape[0] === batchSize, "Mismatch in batch size between x and y tensors " +
+                    ("(" + xs[inputName].shape[0] + " vs. " + ys.shape[0] + ")"));
+            }
+        }
+        return flattendXs.concat(ys);
+    }
+}
+function standardizeTensorValidationData(data) {
+    if (data.length === 3) {
+        throw new errors_1.NotImplementedError('Validation with sample weights is not implemented yet.');
+    }
+    return { xs: data[0], ys: data[1] };
+}
+function fitDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, validationDataIterator, valXs, valYs, validationData, trainFunction, outLabels, callbackMetrics, callbacks, _a, callbackList, history_1, epoch, epochLogs, dataIterator, stepsDone, batchIndex, iteratorOut, xsAndYs, batchLogs, outs, i, label, out, valOuts, _b, i;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    tfc.util.assert(model.optimizer != null, 'You must compile a model before training/testing. Use ' +
+                        'Model.compile(modelCompileConfig).');
+                    tfc.util.assert(config != null, "For fitDataset(), the 2nd argument (config) is required, " +
+                        "but it is not provided in this call.");
+                    tfc.util.assert(config.epochs != null && config.epochs > 0 &&
+                        Number.isInteger(config.epochs), "For fitDataset(), config.epochs is expected to be a positive " +
+                        ("integer, but got " + config.epochs));
+                    tfc.util.assert(config.batchesPerEpoch != null && config.batchesPerEpoch > 0 &&
+                        Number.isInteger(config.batchesPerEpoch), "For fitDataset(), config.batchesPerEpoch is expected to be a " +
+                        ("positive integer, but got " + config.batchesPerEpoch));
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _c.label = 1;
+                case 1:
+                    _c.trys.push([1, , 21, 22]);
+                    doValidation = config.validationData != null;
+                    validationDataIterator = void 0;
+                    valXs = void 0;
+                    valYs = void 0;
+                    if (!doValidation) return [3, 4];
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 3];
+                    tfc.util.assert(config.validationBatches > 0 &&
+                        Number.isInteger(config.validationBatches), "For fitDataset() with dataset-based validation, " +
+                        "config.validationBatches is expected to be a " +
+                        ("positive integer, but got " + config.validationBatches));
+                    return [4, config.validationData.iterator()];
+                case 2:
+                    validationDataIterator = _c.sent();
+                    return [3, 4];
+                case 3:
+                    validationData = standardizeTensorValidationData(config.validationData);
+                    valXs = validationData.xs;
+                    valYs = validationData.ys;
+                    _c.label = 4;
+                case 4:
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    _a = base_callbacks_1.configureCallbacks(callbacks, config.yieldEvery, config.verbose, config.epochs, null, null, config.batchesPerEpoch, null, doValidation, callbackMetrics), callbackList = _a.callbackList, history_1 = _a.history;
+                    model.history = history_1;
+                    return [4, callbackList.onTrainBegin()];
+                case 5:
+                    _c.sent();
+                    epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
+                    epochLogs = {};
+                    return [4, dataset.iterator()];
+                case 6:
+                    dataIterator = _c.sent();
+                    _c.label = 7;
+                case 7:
+                    if (!(epoch < config.epochs)) return [3, 18];
+                    return [4, callbackList.onEpochBegin(epoch)];
+                case 8:
+                    _c.sent();
+                    stepsDone = 0;
+                    batchIndex = 0;
+                    _c.label = 9;
+                case 9:
+                    if (!(stepsDone < config.batchesPerEpoch)) return [3, 16];
+                    return [4, dataIterator.next()];
+                case 10:
+                    iteratorOut = _c.sent();
+                    if (iteratorOut.done) {
+                        console.warn('Your dataset iterator ran out of data; ' +
+                            'interrupting training. Make sure that your ' +
+                            'dataset can generate at least `batchesPerEpoch * epochs` ' +
+                            'batches (in this case, ' +
+                            (config.batchesPerEpoch * config.epochs + " batches). ") +
+                            'You may need to use the repeat() function when building ' +
+                            'your dataset.');
+                        return [3, 16];
+                    }
+                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                    batchLogs = {};
+                    batchLogs['batch'] = batchIndex;
+                    batchLogs['size'] = xsAndYs[0].shape[0];
+                    callbackList.onBatchBegin(batchIndex, batchLogs);
+                    outs = trainFunction(xsAndYs);
+                    tfc.dispose(xsAndYs);
+                    for (i = 0; i < outLabels.length; ++i) {
+                        label = outLabels[i];
+                        out = outs[i];
+                        batchLogs[label] = out;
+                        tfc.keep(out);
+                    }
+                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                case 11:
+                    _c.sent();
+                    logs_1.disposeTensorsInLogs(batchLogs);
+                    batchIndex++;
+                    stepsDone++;
+                    if (!(stepsDone >= config.batchesPerEpoch && doValidation)) return [3, 15];
+                    valOuts = void 0;
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 13];
+                    _b = generic_utils_1.toList;
+                    return [4, model.evaluateDataset(validationDataIterator, { batches: config.validationBatches })];
+                case 12:
+                    valOuts = _b.apply(void 0, [_c.sent()]);
+                    return [3, 14];
+                case 13:
+                    valOuts = generic_utils_1.toList(model.evaluate(valXs, valYs, {
+                        batchSize: config.validationBatchSize == null ?
+                            DEFAULT_VALIDATION_BATCH_SIZE :
+                            config.validationBatchSize,
+                        verbose: 0
+                    }));
+                    _c.label = 14;
+                case 14:
+                    for (i = 0; i < model.metricsNames.length; ++i) {
+                        epochLogs["val_" + model.metricsNames[i]] = valOuts[i];
+                    }
+                    _c.label = 15;
+                case 15:
+                    if (model.stopTraining_) {
+                        return [3, 16];
+                    }
+                    return [3, 9];
+                case 16: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                case 17:
+                    _c.sent();
+                    epoch++;
+                    if (model.stopTraining_) {
+                        return [3, 18];
+                    }
+                    return [3, 7];
+                case 18: return [4, callbackList.onTrainEnd()];
+                case 19:
+                    _c.sent();
+                    return [4, model.history.syncData()];
+                case 20:
+                    _c.sent();
+                    return [2, model.history];
+                case 21:
+                    model.isTraining = false;
+                    return [7];
+                case 22: return [2];
+            }
+        });
+    });
+}
+exports.fitDataset = fitDataset;
+function evaluateDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var f, outs, dataIterator, _a, numExamples, _loop_1, batch, state_2, _loop_2, i;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    f = model.testFunction;
+                    outs = [];
+                    if (config.verbose > 0) {
+                        throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
+                    }
+                    tfc.util.assert(config.batches > 0 && Number.isInteger(config.batches), 'Test loop expects `batches` to be a positive integer, but ' +
+                        ("received " + JSON.stringify(config.batches)));
+                    if (!(dataset instanceof dataset_stub_1.LazyIterator)) return [3, 1];
+                    _a = dataset;
+                    return [3, 3];
+                case 1: return [4, dataset.iterator()];
+                case 2:
+                    _a = _b.sent();
+                    _b.label = 3;
+                case 3:
+                    dataIterator = _a;
+                    numExamples = 0;
+                    _loop_1 = function (batch) {
+                        var iteratorOut, xsAndYs, batchOuts, i, batchSize, _loop_3, i;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, dataIterator.next()];
+                                case 1:
+                                    iteratorOut = _a.sent();
+                                    if (iteratorOut.done) {
+                                        console.warn('Your dataset iterator ran out of data during evaluateDataset(). ' +
+                                            'Interrupting evalution. Make sure that your ' +
+                                            'dataset can generate at least `batches` ' +
+                                            ("batches (in this case, " + config.batches + " batches). ") +
+                                            'You may need to use the repeat() function when building ' +
+                                            'your dataset.');
+                                        return [2, "break"];
+                                    }
+                                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                                    batchOuts = tfc.tidy(function () { return f(xsAndYs); });
+                                    tfc.dispose(xsAndYs);
+                                    if (batch === 0) {
+                                        for (i = 0; i < batchOuts.length; ++i) {
+                                            outs.push(state_1.getScalar(0));
+                                        }
+                                    }
+                                    batchSize = xsAndYs[0].shape[0];
+                                    _loop_3 = function (i) {
+                                        var batchOut = batchOuts[i];
+                                        var oldScalar = outs[i];
+                                        outs[i] = tfc.tidy(function () { return tfc.add(outs[i], tfc.mul(state_1.getScalar(batchSize), batchOut)); });
+                                        if (batch > 0) {
+                                            tfc.dispose(oldScalar);
+                                        }
+                                    };
+                                    for (i = 0; i < batchOuts.length; ++i) {
+                                        _loop_3(i);
+                                    }
+                                    tfc.dispose(batchOuts);
+                                    numExamples += batchSize;
+                                    return [2];
+                            }
+                        });
+                    };
+                    batch = 0;
+                    _b.label = 4;
+                case 4:
+                    if (!(batch < config.batches)) return [3, 7];
+                    return [5, _loop_1(batch)];
+                case 5:
+                    state_2 = _b.sent();
+                    if (state_2 === "break")
+                        return [3, 7];
+                    _b.label = 6;
+                case 6:
+                    ++batch;
+                    return [3, 4];
+                case 7:
+                    _loop_2 = function (i) {
+                        var oldScalar = outs[i];
+                        outs[i] =
+                            tfc.tidy(function () { return tfc.div(outs[i], state_1.getScalar(numExamples)); });
+                        tfc.dispose(oldScalar);
+                    };
+                    for (i = 0; i < outs.length; ++i) {
+                        _loop_2(i);
+                    }
+                    return [2, generic_utils_1.singletonOrArray(outs)];
+            }
+        });
+    });
+}
+exports.evaluateDataset = evaluateDataset;
+
+},{"../backend/state":219,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/generic_utils":262,"./dataset_stub":226,"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfjs_backend_1 = require("../backend/tfjs_backend");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var math_utils_1 = require("../utils/math_utils");
+function checkBatchSize(batchSize) {
+    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
+}
+exports.checkBatchSize = checkBatchSize;
+function sliceArrays(arrays, start, stop) {
+    if (arrays == null) {
+        return [null];
+    }
+    else if (Array.isArray(arrays)) {
+        return arrays.map(function (array) { return tfjs_backend_1.sliceAlongFirstAxis(array, start, stop - start); });
+    }
+    else {
+        return tfjs_backend_1.sliceAlongFirstAxis(arrays, start, stop - start);
+    }
+}
+exports.sliceArrays = sliceArrays;
+function sliceArraysByIndices(arrays, indices) {
+    return tfc.tidy(function () {
+        if (arrays == null) {
+            return null;
+        }
+        else if (Array.isArray(arrays)) {
+            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
+        }
+        else {
+            return tfjs_backend_1.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
+        }
+    });
+}
+exports.sliceArraysByIndices = sliceArraysByIndices;
+function makeBatches(size, batchSize) {
+    var output = [];
+    var batchStart = 0;
+    var batchEnd = null;
+    while (batchStart < size) {
+        batchEnd = batchStart + batchSize;
+        if (batchEnd >= size) {
+            batchEnd = size;
+        }
+        output.push([batchStart, batchEnd]);
+        batchStart = batchEnd;
+    }
+    return output;
+}
+exports.makeBatches = makeBatches;
+function fitLoop(model, f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, numTrainSamples, indexArray, _a, callbackList, history, _loop_1, epoch, state_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (batchSize == null) {
+                        batchSize = 32;
+                    }
+                    if (epochs == null) {
+                        epochs = 1;
+                    }
+                    if (shuffle == null) {
+                        shuffle = true;
+                    }
+                    if (initialEpoch == null) {
+                        initialEpoch = 0;
+                    }
+                    doValidation = false;
+                    if (valF != null && valIns != null) {
+                        doValidation = true;
+                    }
+                    if (validationSteps != null) {
+                        doValidation = true;
+                        if (stepsPerEpoch == null) {
+                            throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
+                                'i.e., `stepsPerEpoch` must be set.');
+                        }
+                    }
+                    numTrainSamples = model.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
+                    if (numTrainSamples != null) {
+                        indexArray = math_utils_1.range(0, numTrainSamples);
+                    }
+                    if (verbose == null) {
+                        verbose = 1;
+                    }
+                    _a = base_callbacks_1.configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics), callbackList = _a.callbackList, history = _a.history;
+                    callbackList.setModel(model);
+                    model.history = history;
+                    return [4, callbackList.onTrainBegin()];
+                case 1:
+                    _b.sent();
+                    model.stopTraining_ = false;
+                    _loop_1 = function (epoch) {
+                        var epochLogs, epochIndexArray1D_1, batches_1, _loop_2, batchIndex, state_2;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, callbackList.onEpochBegin(epoch)];
+                                case 1:
+                                    _a.sent();
+                                    epochLogs = {};
+                                    if (!(stepsPerEpoch != null)) return [3, 2];
+                                    throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
+                                case 2:
+                                    if (shuffle === 'batch') {
+                                        throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
+                                    }
+                                    else if (shuffle) {
+                                        tfjs_core_1.util.shuffle(indexArray);
+                                    }
+                                    epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
+                                    batches_1 = makeBatches(numTrainSamples, batchSize);
+                                    _loop_2 = function (batchIndex) {
+                                        var batchLogs;
+                                        return __generator(this, function (_a) {
+                                            switch (_a.label) {
+                                                case 0:
+                                                    batchLogs = {};
+                                                    return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
+                                                case 1:
+                                                    _a.sent();
+                                                    tfc.tidy(function () {
+                                                        var batchStart = batches_1[batchIndex][0];
+                                                        var batchEnd = batches_1[batchIndex][1];
+                                                        var batchIds = tfjs_backend_1.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
+                                                        batchLogs['batch'] = batchIndex;
+                                                        batchLogs['size'] = batchEnd - batchStart;
+                                                        var insBatch = sliceArraysByIndices(ins, batchIds);
+                                                        var outs = f(insBatch);
+                                                        for (var i = 0; i < outLabels.length; ++i) {
+                                                            var label = outLabels[i];
+                                                            var out = outs[i];
+                                                            batchLogs[label] = out;
+                                                            tfc.keep(out);
+                                                        }
+                                                        if (batchIndex === batches_1.length - 1) {
+                                                            if (doValidation) {
+                                                                var valOuts = model.testLoop(valF, valIns, batchSize);
+                                                                for (var i = 0; i < outLabels.length; ++i) {
+                                                                    var label = outLabels[i];
+                                                                    var out = valOuts[i];
+                                                                    tfc.keep(out);
+                                                                    epochLogs['val_' + label] = out;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                                                case 2:
+                                                    _a.sent();
+                                                    logs_1.disposeTensorsInLogs(batchLogs);
+                                                    if (model.stopTraining_) {
+                                                        return [2, "break"];
+                                                    }
+                                                    return [2];
+                                            }
+                                        });
+                                    };
+                                    batchIndex = 0;
+                                    _a.label = 3;
+                                case 3:
+                                    if (!(batchIndex < batches_1.length)) return [3, 6];
+                                    return [5, _loop_2(batchIndex)];
+                                case 4:
+                                    state_2 = _a.sent();
+                                    if (state_2 === "break")
+                                        return [3, 6];
+                                    _a.label = 5;
+                                case 5:
+                                    ++batchIndex;
+                                    return [3, 3];
+                                case 6:
+                                    epochIndexArray1D_1.dispose();
+                                    _a.label = 7;
+                                case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                                case 8:
+                                    _a.sent();
+                                    if (model.stopTraining_) {
+                                        return [2, "break"];
+                                    }
+                                    return [2];
+                            }
+                        });
+                    };
+                    epoch = initialEpoch;
+                    _b.label = 2;
+                case 2:
+                    if (!(epoch < epochs)) return [3, 5];
+                    return [5, _loop_1(epoch)];
+                case 3:
+                    state_1 = _b.sent();
+                    if (state_1 === "break")
+                        return [3, 5];
+                    _b.label = 4;
+                case 4:
+                    ++epoch;
+                    return [3, 2];
+                case 5: return [4, callbackList.onTrainEnd()];
+                case 6:
+                    _b.sent();
+                    return [4, model.history.syncData()];
+                case 7:
+                    _b.sent();
+                    return [2, model.history];
+            }
+        });
+    });
+}
+function fitTensors(model, x, y, config) {
+    if (config === void 0) { config = {}; }
+    return __awaiter(this, void 0, void 0, function () {
+        var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, , 3, 4]);
+                    batchSize = config.batchSize == null ? 32 : config.batchSize;
+                    checkBatchSize(batchSize);
+                    standardizedOuts = model.standardizeUserData(x, y, false, batchSize);
+                    inputs = standardizedOuts[0];
+                    targets = standardizedOuts[1];
+                    doValidation = false;
+                    valX = void 0;
+                    valY = void 0;
+                    valIns = void 0;
+                    needValidationDisposal = false;
+                    if (config.validationData != null && config.validationData.length > 0) {
+                        doValidation = true;
+                        if (config.validationData.length === 2) {
+                            valX = config.validationData[0];
+                            valY = config.validationData[1];
+                        }
+                        else if (config.validationData.length === 3) {
+                            throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
+                        }
+                        else {
+                            throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
+                                "or 3 (valX, valY, valSampleWeight) items; " +
+                                (config.validationData + " is invalid."));
+                        }
+                        valStandardized = model.standardizeUserData(valX, valY, true, batchSize);
+                        valX = valStandardized[0];
+                        valY = valStandardized[1];
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSplit != null && config.validationSplit > 0 &&
+                        config.validationSplit < 1) {
+                        doValidation = true;
+                        splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
+                        originalBatchSize = inputs[0].shape[0];
+                        valX = sliceArrays(inputs, splitAt, originalBatchSize);
+                        inputs = sliceArrays(inputs, 0, splitAt);
+                        valY = sliceArrays(targets, splitAt, originalBatchSize);
+                        targets = sliceArrays(targets, 0, splitAt);
+                        needValidationDisposal = true;
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSteps != null) {
+                        doValidation = true;
+                    }
+                    ins = inputs.concat(targets);
+                    model.checkTrainableWeightsConsistency();
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    valFunction = void 0;
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        model.makeTestFunction();
+                        valFunction = model.testFunction;
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        valFunction = null;
+                        valIns = [];
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    return [4, fitLoop(model, trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
+                case 2:
+                    out = _a.sent();
+                    if (needValidationDisposal) {
+                        valIns.forEach(function (tensor) { return tensor.dispose(); });
+                        inputs.forEach(function (tensor) { return tensor.dispose(); });
+                        targets.forEach(function (tensor) { return tensor.dispose(); });
+                    }
+                    model.isTraining = false;
+                    return [2, out];
+                case 3:
+                    model.isTraining = false;
+                    return [7];
+                case 4: return [2];
+            }
+        });
+    });
+}
+exports.fitTensors = fitTensors;
+
+},{"../backend/tfjs_backend":220,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/math_utils":264,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -30880,12 +32895,13 @@ var IndexError = (function (_super) {
 }(Error));
 exports.IndexError = IndexError;
 
-},{}],211:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
 var training_1 = require("./engine/training");
 var models_1 = require("./models");
+var base_callbacks_1 = require("./base_callbacks");
 function model(config) {
     return new training_1.Model(config);
 }
@@ -30903,8 +32919,12 @@ function input(config) {
     return input_layer_1.Input(config);
 }
 exports.input = input;
+function registerCallbackConstructor(verbosityLevel, callbackConstructor) {
+    base_callbacks_1.CallbackConstructorRegistry.registerCallbackConstructor(verbosityLevel, callbackConstructor);
+}
+exports.registerCallbackConstructor = registerCallbackConstructor;
 
-},{"./engine/input_layer":207,"./engine/training":209,"./models":234}],212:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/input_layer":228,"./engine/training":230,"./models":258}],235:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints_1 = require("./constraints");
@@ -30925,7 +32945,7 @@ function minMaxNorm(config) {
 }
 exports.minMaxNorm = minMaxNorm;
 
-},{"./constraints":204}],213:[function(require,module,exports){
+},{"./constraints":224}],236:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var initializers_1 = require("./initializers");
@@ -30982,7 +33002,7 @@ function orthogonal(config) {
 }
 exports.orthogonal = orthogonal;
 
-},{"./initializers":218}],214:[function(require,module,exports){
+},{"./initializers":242}],237:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
@@ -31111,6 +33131,10 @@ function multiply(config) {
     return new merge_1.Multiply(config);
 }
 exports.multiply = multiply;
+function dot(config) {
+    return new merge_1.Dot(config);
+}
+exports.dot = dot;
 function batchNormalization(config) {
     return new normalization_1.BatchNormalization(config);
 }
@@ -31212,7 +33236,7 @@ exports.globalMaxPool2d = globalMaxPooling2d;
 exports.maxPool1d = maxPooling1d;
 exports.maxPool2d = maxPooling2d;
 
-},{"./engine/input_layer":207,"./engine/topology":208,"./exports":211,"./layers/advanced_activations":219,"./layers/convolutional":220,"./layers/convolutional_depthwise":221,"./layers/core":222,"./layers/embeddings":223,"./layers/merge":224,"./layers/normalization":225,"./layers/padding":226,"./layers/pooling":227,"./layers/recurrent":228,"./layers/wrappers":230}],215:[function(require,module,exports){
+},{"./engine/input_layer":228,"./engine/topology":229,"./exports":234,"./layers/advanced_activations":243,"./layers/convolutional":244,"./layers/convolutional_depthwise":245,"./layers/core":246,"./layers/embeddings":247,"./layers/merge":248,"./layers/normalization":249,"./layers/padding":250,"./layers/pooling":251,"./layers/recurrent":252,"./layers/wrappers":254}],238:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var losses = require("./losses");
@@ -31233,6 +33257,14 @@ function categoricalCrossentropy(yTrue, yPred) {
     return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 exports.categoricalCrossentropy = categoricalCrossentropy;
+function precision(yTrue, yPred) {
+    return metrics.precision(yTrue, yPred);
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return metrics.recall(yTrue, yPred);
+}
+exports.recall = recall;
 function cosineProximity(yTrue, yPred) {
     return losses.cosineProximity(yTrue, yPred);
 }
@@ -31266,7 +33298,13 @@ function mse(yTrue, yPred) {
 }
 exports.mse = mse;
 
-},{"./losses":232,"./metrics":233}],216:[function(require,module,exports){
+},{"./losses":256,"./metrics":257}],239:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var models_1 = require("./models");
+exports.modelFromJSON = models_1.modelFromJSON;
+
+},{"./models":258}],240:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var regularizers = require("./regularizers");
@@ -31284,7 +33322,7 @@ function l2(config) {
 }
 exports.l2 = l2;
 
-},{"./regularizers":236}],217:[function(require,module,exports){
+},{"./regularizers":260}],241:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints = require("./exports_constraints");
@@ -31293,6 +33331,8 @@ var initializers = require("./exports_initializers");
 exports.initializers = initializers;
 var layers = require("./exports_layers");
 exports.layers = layers;
+var models = require("./exports_models");
+exports.models = models;
 var metrics = require("./exports_metrics");
 exports.metrics = metrics;
 var regularizers = require("./exports_regularizers");
@@ -31304,6 +33344,7 @@ exports.History = base_callbacks_1.History;
 var callbacks_1 = require("./callbacks");
 exports.Callback = callbacks_1.Callback;
 var topology_1 = require("./engine/topology");
+exports.InputSpec = topology_1.InputSpec;
 exports.SymbolicTensor = topology_1.SymbolicTensor;
 var training_1 = require("./engine/training");
 exports.Model = training_1.Model;
@@ -31311,6 +33352,7 @@ var exports_1 = require("./exports");
 exports.input = exports_1.input;
 exports.loadModel = exports_1.loadModel;
 exports.model = exports_1.model;
+exports.registerCallbackConstructor = exports_1.registerCallbackConstructor;
 exports.sequential = exports_1.sequential;
 var recurrent_1 = require("./layers/recurrent");
 exports.RNN = recurrent_1.RNN;
@@ -31321,7 +33363,7 @@ exports.LayerVariable = variables_1.LayerVariable;
 var version_1 = require("./version");
 exports.version_layers = version_1.version;
 
-},{"./base_callbacks":201,"./callbacks":202,"./engine/topology":208,"./engine/training":209,"./exports":211,"./exports_constraints":212,"./exports_initializers":213,"./exports_layers":214,"./exports_metrics":215,"./exports_regularizers":216,"./layers/recurrent":228,"./models":234,"./variables":244,"./version":245}],218:[function(require,module,exports){
+},{"./base_callbacks":221,"./callbacks":222,"./engine/topology":229,"./engine/training":230,"./exports":234,"./exports_constraints":235,"./exports_initializers":236,"./exports_layers":237,"./exports_metrics":238,"./exports_models":239,"./exports_regularizers":240,"./layers/recurrent":252,"./models":258,"./variables":268,"./version":269}],242:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31377,7 +33419,7 @@ var Zeros = (function (_super) {
     return Zeros;
 }(Initializer));
 exports.Zeros = Zeros;
-tfjs_core_1.serialization.SerializationMap.register(Zeros);
+tfjs_core_1.serialization.registerClass(Zeros);
 var Ones = (function (_super) {
     __extends(Ones, _super);
     function Ones() {
@@ -31390,7 +33432,7 @@ var Ones = (function (_super) {
     return Ones;
 }(Initializer));
 exports.Ones = Ones;
-tfjs_core_1.serialization.SerializationMap.register(Ones);
+tfjs_core_1.serialization.registerClass(Ones);
 var Constant = (function (_super) {
     __extends(Constant, _super);
     function Constant(config) {
@@ -31417,7 +33459,7 @@ var Constant = (function (_super) {
     return Constant;
 }(Initializer));
 exports.Constant = Constant;
-tfjs_core_1.serialization.SerializationMap.register(Constant);
+tfjs_core_1.serialization.registerClass(Constant);
 var RandomUniform = (function (_super) {
     __extends(RandomUniform, _super);
     function RandomUniform(config) {
@@ -31439,7 +33481,7 @@ var RandomUniform = (function (_super) {
     return RandomUniform;
 }(Initializer));
 exports.RandomUniform = RandomUniform;
-tfjs_core_1.serialization.SerializationMap.register(RandomUniform);
+tfjs_core_1.serialization.registerClass(RandomUniform);
 var RandomNormal = (function (_super) {
     __extends(RandomNormal, _super);
     function RandomNormal(config) {
@@ -31452,8 +33494,9 @@ var RandomNormal = (function (_super) {
         return _this;
     }
     RandomNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
         }
         return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31464,7 +33507,7 @@ var RandomNormal = (function (_super) {
     return RandomNormal;
 }(Initializer));
 exports.RandomNormal = RandomNormal;
-tfjs_core_1.serialization.SerializationMap.register(RandomNormal);
+tfjs_core_1.serialization.registerClass(RandomNormal);
 var TruncatedNormal = (function (_super) {
     __extends(TruncatedNormal, _super);
     function TruncatedNormal(config) {
@@ -31477,8 +33520,9 @@ var TruncatedNormal = (function (_super) {
         return _this;
     }
     TruncatedNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("truncatedNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("truncatedNormal does not support dType " + dtype + ".");
         }
         return tfjs_core_1.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31489,7 +33533,7 @@ var TruncatedNormal = (function (_super) {
     return TruncatedNormal;
 }(Initializer));
 exports.TruncatedNormal = TruncatedNormal;
-tfjs_core_1.serialization.SerializationMap.register(TruncatedNormal);
+tfjs_core_1.serialization.registerClass(TruncatedNormal);
 var Identity = (function (_super) {
     __extends(Identity, _super);
     function Identity(config) {
@@ -31516,7 +33560,7 @@ var Identity = (function (_super) {
     return Identity;
 }(Initializer));
 exports.Identity = Identity;
-tfjs_core_1.serialization.SerializationMap.register(Identity);
+tfjs_core_1.serialization.registerClass(Identity);
 function computeFans(shape, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var fanIn;
@@ -31576,8 +33620,9 @@ var VarianceScaling = (function (_super) {
         }
         if (this.distribution === 'normal') {
             var stddev = Math.sqrt(scale);
-            if (dtype === 'bool') {
-                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType bool.");
+            dtype = dtype || 'float32';
+            if (dtype !== 'float32' && dtype !== 'int32') {
+                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType " + dtype + ".");
             }
             return tfjs_core_1.truncatedNormal(shape, 0, stddev, dtype, this.seed);
         }
@@ -31598,7 +33643,7 @@ var VarianceScaling = (function (_super) {
     return VarianceScaling;
 }(Initializer));
 exports.VarianceScaling = VarianceScaling;
-tfjs_core_1.serialization.SerializationMap.register(VarianceScaling);
+tfjs_core_1.serialization.registerClass(VarianceScaling);
 var GlorotUniform = (function (_super) {
     __extends(GlorotUniform, _super);
     function GlorotUniform(config) {
@@ -31612,9 +33657,11 @@ var GlorotUniform = (function (_super) {
     GlorotUniform.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotUniform.className = 'GlorotUniform';
     return GlorotUniform;
 }(VarianceScaling));
 exports.GlorotUniform = GlorotUniform;
+tfjs_core_1.serialization.registerClass(GlorotUniform);
 var GlorotNormal = (function (_super) {
     __extends(GlorotNormal, _super);
     function GlorotNormal(config) {
@@ -31628,9 +33675,11 @@ var GlorotNormal = (function (_super) {
     GlorotNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotNormal.className = 'GlorotNormal';
     return GlorotNormal;
 }(VarianceScaling));
 exports.GlorotNormal = GlorotNormal;
+tfjs_core_1.serialization.registerClass(GlorotNormal);
 var HeNormal = (function (_super) {
     __extends(HeNormal, _super);
     function HeNormal(config) {
@@ -31644,9 +33693,11 @@ var HeNormal = (function (_super) {
     HeNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    HeNormal.className = 'HeNormal';
     return HeNormal;
 }(VarianceScaling));
 exports.HeNormal = HeNormal;
+tfjs_core_1.serialization.registerClass(HeNormal);
 var LeCunNormal = (function (_super) {
     __extends(LeCunNormal, _super);
     function LeCunNormal(config) {
@@ -31660,9 +33711,11 @@ var LeCunNormal = (function (_super) {
     LeCunNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    LeCunNormal.className = 'LeCunNormal';
     return LeCunNormal;
 }(VarianceScaling));
 exports.LeCunNormal = LeCunNormal;
+tfjs_core_1.serialization.registerClass(LeCunNormal);
 var Orthogonal = (function (_super) {
     __extends(Orthogonal, _super);
     function Orthogonal(config) {
@@ -31705,7 +33758,7 @@ var Orthogonal = (function (_super) {
     return Orthogonal;
 }(Initializer));
 exports.Orthogonal = Orthogonal;
-tfjs_core_1.serialization.SerializationMap.register(Orthogonal);
+tfjs_core_1.serialization.registerClass(Orthogonal);
 exports.INITIALIZER_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'constant': 'Constant',
     'glorotNormal': 'GlorotNormal',
@@ -31760,7 +33813,7 @@ function getInitializer(identifier) {
 }
 exports.getInitializer = getInitializer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./common":203,"./errors":210,"./utils/generic_utils":238,"./utils/math_utils":240,"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./common":223,"./errors":233,"./utils/generic_utils":262,"./utils/math_utils":264,"@tensorflow/tfjs-core":68}],243:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31811,7 +33864,7 @@ var ReLU = (function (_super) {
     return ReLU;
 }(topology_1.Layer));
 exports.ReLU = ReLU;
-tfjs_core_1.serialization.SerializationMap.register(ReLU);
+tfjs_core_1.serialization.registerClass(ReLU);
 var LeakyReLU = (function (_super) {
     __extends(LeakyReLU, _super);
     function LeakyReLU(config) {
@@ -31840,7 +33893,7 @@ var LeakyReLU = (function (_super) {
     return LeakyReLU;
 }(topology_1.Layer));
 exports.LeakyReLU = LeakyReLU;
-tfjs_core_1.serialization.SerializationMap.register(LeakyReLU);
+tfjs_core_1.serialization.registerClass(LeakyReLU);
 var ELU = (function (_super) {
     __extends(ELU, _super);
     function ELU(config) {
@@ -31873,7 +33926,7 @@ var ELU = (function (_super) {
     return ELU;
 }(topology_1.Layer));
 exports.ELU = ELU;
-tfjs_core_1.serialization.SerializationMap.register(ELU);
+tfjs_core_1.serialization.registerClass(ELU);
 var ThresholdedReLU = (function (_super) {
     __extends(ThresholdedReLU, _super);
     function ThresholdedReLU(config) {
@@ -31903,7 +33956,7 @@ var ThresholdedReLU = (function (_super) {
     return ThresholdedReLU;
 }(topology_1.Layer));
 exports.ThresholdedReLU = ThresholdedReLU;
-tfjs_core_1.serialization.SerializationMap.register(ThresholdedReLU);
+tfjs_core_1.serialization.registerClass(ThresholdedReLU);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax(config) {
@@ -31933,9 +33986,9 @@ var Softmax = (function (_super) {
     return Softmax;
 }(topology_1.Layer));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],244:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32250,7 +34303,7 @@ var Conv2D = (function (_super) {
     return Conv2D;
 }(Conv));
 exports.Conv2D = Conv2D;
-tfjs_core_1.serialization.SerializationMap.register(Conv2D);
+tfjs_core_1.serialization.registerClass(Conv2D);
 var Conv2DTranspose = (function (_super) {
     __extends(Conv2DTranspose, _super);
     function Conv2DTranspose(config) {
@@ -32366,7 +34419,7 @@ var Conv2DTranspose = (function (_super) {
     return Conv2DTranspose;
 }(Conv2D));
 exports.Conv2DTranspose = Conv2DTranspose;
-tfjs_core_1.serialization.SerializationMap.register(Conv2DTranspose);
+tfjs_core_1.serialization.registerClass(Conv2DTranspose);
 var SeparableConv = (function (_super) {
     __extends(SeparableConv, _super);
     function SeparableConv(rank, config) {
@@ -32493,7 +34546,7 @@ var SeparableConv2D = (function (_super) {
     return SeparableConv2D;
 }(SeparableConv));
 exports.SeparableConv2D = SeparableConv2D;
-tfjs_core_1.serialization.SerializationMap.register(SeparableConv2D);
+tfjs_core_1.serialization.registerClass(SeparableConv2D);
 var Conv1D = (function (_super) {
     __extends(Conv1D, _super);
     function Conv1D(config) {
@@ -32518,7 +34571,7 @@ var Conv1D = (function (_super) {
     return Conv1D;
 }(Conv));
 exports.Conv1D = Conv1D;
-tfjs_core_1.serialization.SerializationMap.register(Conv1D);
+tfjs_core_1.serialization.registerClass(Conv1D);
 var Cropping2D = (function (_super) {
     __extends(Cropping2D, _super);
     function Cropping2D(config) {
@@ -32542,15 +34595,17 @@ var Cropping2D = (function (_super) {
     Cropping2D.prototype.computeOutputShape = function (inputShape) {
         if (this.dataFormat === 'channelsFirst')
             return [
-                inputShape[0], inputShape[1],
+                inputShape[0],
+                inputShape[1],
                 inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+                inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
             ];
         else
             return [
                 inputShape[0],
                 inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+                inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+                inputShape[3]
             ];
     };
     Cropping2D.prototype.call = function (inputs, kwargs) {
@@ -32577,7 +34632,7 @@ var Cropping2D = (function (_super) {
     return Cropping2D;
 }(topology_1.Layer));
 exports.Cropping2D = Cropping2D;
-tfjs_core_1.serialization.SerializationMap.register(Cropping2D);
+tfjs_core_1.serialization.registerClass(Cropping2D);
 var UpSampling2D = (function (_super) {
     __extends(UpSampling2D, _super);
     function UpSampling2D(config) {
@@ -32630,9 +34685,9 @@ var UpSampling2D = (function (_super) {
     return UpSampling2D;
 }(topology_1.Layer));
 exports.UpSampling2D = UpSampling2D;
-tfjs_core_1.serialization.SerializationMap.register(UpSampling2D);
+tfjs_core_1.serialization.registerClass(UpSampling2D);
 
-},{"../activations":197,"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
+},{"../activations":217,"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32763,9 +34818,9 @@ var DepthwiseConv2D = (function (_super) {
     return DepthwiseConv2D;
 }(convolutional_1.BaseConv));
 exports.DepthwiseConv2D = DepthwiseConv2D;
-tfjs_core_1.serialization.SerializationMap.register(DepthwiseConv2D);
+tfjs_core_1.serialization.registerClass(DepthwiseConv2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],246:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32848,7 +34903,7 @@ var Dropout = (function (_super) {
     return Dropout;
 }(topology_1.Layer));
 exports.Dropout = Dropout;
-tfjs_core_1.serialization.SerializationMap.register(Dropout);
+tfjs_core_1.serialization.registerClass(Dropout);
 var Dense = (function (_super) {
     __extends(Dense, _super);
     function Dense(config) {
@@ -32938,7 +34993,7 @@ var Dense = (function (_super) {
     return Dense;
 }(topology_1.Layer));
 exports.Dense = Dense;
-tfjs_core_1.serialization.SerializationMap.register(Dense);
+tfjs_core_1.serialization.registerClass(Dense);
 var Flatten = (function (_super) {
     __extends(Flatten, _super);
     function Flatten(config) {
@@ -32970,7 +35025,7 @@ var Flatten = (function (_super) {
     return Flatten;
 }(topology_1.Layer));
 exports.Flatten = Flatten;
-tfjs_core_1.serialization.SerializationMap.register(Flatten);
+tfjs_core_1.serialization.registerClass(Flatten);
 var Activation = (function (_super) {
     __extends(Activation, _super);
     function Activation(config) {
@@ -32997,7 +35052,7 @@ var Activation = (function (_super) {
     return Activation;
 }(topology_1.Layer));
 exports.Activation = Activation;
-tfjs_core_1.serialization.SerializationMap.register(Activation);
+tfjs_core_1.serialization.registerClass(Activation);
 var RepeatVector = (function (_super) {
     __extends(RepeatVector, _super);
     function RepeatVector(config) {
@@ -33028,7 +35083,7 @@ var RepeatVector = (function (_super) {
     return RepeatVector;
 }(topology_1.Layer));
 exports.RepeatVector = RepeatVector;
-tfjs_core_1.serialization.SerializationMap.register(RepeatVector);
+tfjs_core_1.serialization.registerClass(RepeatVector);
 var Reshape = (function (_super) {
     __extends(Reshape, _super);
     function Reshape(config) {
@@ -33112,7 +35167,7 @@ var Reshape = (function (_super) {
     return Reshape;
 }(topology_1.Layer));
 exports.Reshape = Reshape;
-tfjs_core_1.serialization.SerializationMap.register(Reshape);
+tfjs_core_1.serialization.registerClass(Reshape);
 var Permute = (function (_super) {
     __extends(Permute, _super);
     function Permute(config) {
@@ -33158,9 +35213,9 @@ var Permute = (function (_super) {
     return Permute;
 }(topology_1.Layer));
 exports.Permute = Permute;
-tfjs_core_1.serialization.SerializationMap.register(Permute);
+tfjs_core_1.serialization.registerClass(Permute);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],223:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],247:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33277,9 +35332,9 @@ var Embedding = (function (_super) {
     return Embedding;
 }(topology_1.Layer));
 exports.Embedding = Embedding;
-tfjs_core_1.serialization.SerializationMap.register(Embedding);
+tfjs_core_1.serialization.registerClass(Embedding);
 
-},{"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],224:[function(require,module,exports){
+},{"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],248:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33298,6 +35353,7 @@ var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
 var topology_1 = require("../engine/topology");
 var errors_1 = require("../errors");
+var losses_1 = require("../losses");
 var generic_utils = require("../utils/generic_utils");
 var mathUtils = require("../utils/math_utils");
 var types_utils_1 = require("../utils/types_utils");
@@ -33475,6 +35531,9 @@ var Merge = (function (_super) {
         }
         return outputShape;
     };
+    Merge.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Merge yet');
+    };
     return Merge;
 }(topology_1.Layer));
 exports.Merge = Merge;
@@ -33496,7 +35555,7 @@ var Add = (function (_super) {
     return Add;
 }(Merge));
 exports.Add = Add;
-tfjs_core_1.serialization.SerializationMap.register(Add);
+tfjs_core_1.serialization.registerClass(Add);
 function add(config) {
     if (Array.isArray(config)) {
         var layer = new Add({});
@@ -33525,7 +35584,7 @@ var Multiply = (function (_super) {
     return Multiply;
 }(Merge));
 exports.Multiply = Multiply;
-tfjs_core_1.serialization.SerializationMap.register(Multiply);
+tfjs_core_1.serialization.registerClass(Multiply);
 function multiply(config) {
     if (Array.isArray(config)) {
         var layer = new Multiply({});
@@ -33554,7 +35613,7 @@ var Average = (function (_super) {
     return Average;
 }(Merge));
 exports.Average = Average;
-tfjs_core_1.serialization.SerializationMap.register(Average);
+tfjs_core_1.serialization.registerClass(Average);
 function average(config) {
     if (Array.isArray(config)) {
         var layer = new Average({});
@@ -33583,7 +35642,7 @@ var Maximum = (function (_super) {
     return Maximum;
 }(Merge));
 exports.Maximum = Maximum;
-tfjs_core_1.serialization.SerializationMap.register(Maximum);
+tfjs_core_1.serialization.registerClass(Maximum);
 function maximum(config) {
     if (Array.isArray(config)) {
         var layer = new Maximum({});
@@ -33612,7 +35671,7 @@ var Minimum = (function (_super) {
     return Minimum;
 }(Merge));
 exports.Minimum = Minimum;
-tfjs_core_1.serialization.SerializationMap.register(Minimum);
+tfjs_core_1.serialization.registerClass(Minimum);
 function minimum(config) {
     if (Array.isArray(config)) {
         var layer = new Minimum({});
@@ -33699,6 +35758,9 @@ var Concatenate = (function (_super) {
         }
         return outputShape;
     };
+    Concatenate.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Concatenate yet');
+    };
     Concatenate.prototype.getConfig = function () {
         var config = {
             'axis': this.axis,
@@ -33711,7 +35773,7 @@ var Concatenate = (function (_super) {
     return Concatenate;
 }(Merge));
 exports.Concatenate = Concatenate;
-tfjs_core_1.serialization.SerializationMap.register(Concatenate);
+tfjs_core_1.serialization.registerClass(Concatenate);
 function concatenate(config) {
     if (Array.isArray(config)) {
         var layer = new Concatenate({});
@@ -33722,8 +35784,184 @@ function concatenate(config) {
     }
 }
 exports.concatenate = concatenate;
+function interpretAxis(axis, dim) {
+    while (axis < 0) {
+        axis += dim;
+    }
+    return axis;
+}
+function batchDot(x, y, axes) {
+    if (x.shape.length > 3 || y.shape.length > 3) {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for tensors of 4D or higher rank yet');
+    }
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of x to be >= 2, " +
+        ("but got " + x.shape.length));
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of y to be >= 2, " +
+        ("but got " + y.shape.length));
+    if (typeof axes === 'number') {
+        axes = [axes, axes];
+    }
+    if (x.dtype === 'complex64' || y.dtype === 'complex64') {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for complex64-type Tensors yet.');
+    }
+    var xNDim = x.shape.length;
+    var yNDim = y.shape.length;
+    if (axes == null) {
+        axes = [xNDim - 1, yNDim - 2];
+    }
+    var axesArray = axes;
+    return tfc.tidy(function () {
+        var diff;
+        if (xNDim > yNDim) {
+            diff = xNDim - yNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            y = y.reshape(y.shape.concat(diffShape));
+        }
+        else if (yNDim > xNDim) {
+            diff = yNDim - xNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            x = x.reshape(x.shape.concat(diffShape));
+        }
+        else {
+            diff = 0;
+        }
+        var out;
+        if (x.shape.length === 2 && y.shape.length === 2) {
+            if (axesArray[0] === axesArray[1]) {
+                out = x.mulStrict(y).sum(axesArray[0]);
+            }
+            else {
+                out = x.transpose([1, 0]).mulStrict(y).sum(axesArray[1]);
+            }
+        }
+        else {
+            var adjX = axesArray[0] === x.shape.length - 1 ? null : true;
+            var adjY = axesArray[1] === y.shape.length - 1 ? true : null;
+            out = x.matMul(y, adjX, adjY);
+        }
+        if (diff > 0) {
+            var idx = void 0;
+            if (xNDim > yNDim) {
+                idx = xNDim + yNDim - 3;
+            }
+            else {
+                idx = xNDim - 1;
+            }
+            var squeezeAxes = [];
+            for (var i = idx; i < idx + diff; ++i) {
+                squeezeAxes.push(i);
+            }
+            out = out.squeeze(squeezeAxes);
+        }
+        if (out.shape.length === 1) {
+            out = out.expandDims(1);
+        }
+        return out;
+    });
+}
+var Dot = (function (_super) {
+    __extends(Dot, _super);
+    function Dot(config) {
+        var _this = _super.call(this, config) || this;
+        _this.axes = config.axes;
+        _this.normalize = config.normalize == null ? false : config.normalize;
+        _this.supportsMasking = true;
+        _this.reshapeRequired = false;
+        return _this;
+    }
+    Dot.prototype.build = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0];
+        var shape2 = inputShape[1];
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        if (shape1[axes[0]] !== shape2[axes[1]]) {
+            throw new errors_1.ValueError("Dimension incompatibility: " +
+                (shape1[axes[0]] + " !== " + shape2[axes[1]]));
+        }
+    };
+    Dot.prototype.mergeFunction = function (inputs) {
+        if (inputs.length !== 2) {
+            throw new errors_1.ValueError('A `Dot` layer must be called on exactly 2 inputs, ' +
+                ("but received " + inputs.length + " input(s)."));
+        }
+        var x1 = inputs[0];
+        var x2 = inputs[1];
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, x1.shape.length),
+                interpretAxis(this.axes, x2.shape.length)
+            ];
+        }
+        else {
+            axes = this.axes.map(function (axis, i) { return interpretAxis(axis, inputs[i].shape.length); });
+        }
+        if (this.normalize) {
+            x1 = losses_1.l2Normalize(x1, axes[0]);
+            x2 = losses_1.l2Normalize(x2, axes[1]);
+        }
+        return batchDot(x1, x2, axes);
+    };
+    Dot.prototype.interpretAxes = function (shape1, shape2) {
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, shape1.length),
+                interpretAxis(this.axes, shape2.length)
+            ];
+        }
+        else {
+            axes = this.axes;
+        }
+        return axes;
+    };
+    Dot.prototype.computeOutputShape = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0].slice();
+        var shape2 = inputShape[1].slice();
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        shape1.splice(axes[0], 1);
+        shape2.splice(axes[1], 1);
+        shape2.splice(0, 1);
+        var outputShape = shape1.concat(shape2);
+        if (outputShape.length === 1) {
+            outputShape.push(1);
+        }
+        return outputShape;
+    };
+    Dot.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Dot yet');
+    };
+    Dot.prototype.getConfig = function () {
+        var config = {
+            'axes': this.axes,
+            'normalize': this.normalize
+        };
+        var baseConfig = _super.prototype.getConfig.call(this);
+        Object.assign(config, baseConfig);
+        return config;
+    };
+    Dot.className = 'Dot';
+    return Dot;
+}(Merge));
+exports.Dot = Dot;
+tfjs_core_1.serialization.registerClass(Dot);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../losses":256,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],249:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33760,7 +35998,7 @@ function batchNormalization(x, mean, variance, beta, gamma, epsilon) {
         out = tfc.batchNormalization4d(x, mean, variance, epsilon, gamma, beta);
     }
     else {
-        throw new errors_1.NotImplementedError("batchNormalization is not implememnted for array of rank " + x.rank + " " +
+        throw new errors_1.NotImplementedError("batchNormalization is not implemented for array of rank " + x.rank + " " +
             "yet");
     }
     return out;
@@ -33813,7 +36051,11 @@ exports.normalizeBatchInTraining = normalizeBatchInTraining;
 var BatchNormalization = (function (_super) {
     __extends(BatchNormalization, _super);
     function BatchNormalization(config) {
-        var _this = _super.call(this, config) || this;
+        var _this = this;
+        if (config == null) {
+            config = {};
+        }
+        _this = _super.call(this, config) || this;
         _this.supportsMasking = true;
         _this.axis = config.axis == null ? -1 : config.axis;
         _this.momentum = config.momentum == null ? 0.99 : config.momentum;
@@ -33924,9 +36166,9 @@ var BatchNormalization = (function (_super) {
     return BatchNormalization;
 }(topology_1.Layer));
 exports.BatchNormalization = BatchNormalization;
-tfjs_core_1.serialization.SerializationMap.register(BatchNormalization);
+tfjs_core_1.serialization.registerClass(BatchNormalization);
 
-},{"../backend/state":199,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+},{"../backend/state":219,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],250:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34096,9 +36338,9 @@ var ZeroPadding2D = (function (_super) {
     return ZeroPadding2D;
 }(topology_1.Layer));
 exports.ZeroPadding2D = ZeroPadding2D;
-tfjs_core_1.serialization.SerializationMap.register(ZeroPadding2D);
+tfjs_core_1.serialization.registerClass(ZeroPadding2D);
 
-},{"../backend/common":198,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],227:[function(require,module,exports){
+},{"../backend/common":218,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],251:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34240,7 +36482,7 @@ var MaxPooling1D = (function (_super) {
     return MaxPooling1D;
 }(Pooling1D));
 exports.MaxPooling1D = MaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling1D);
+tfjs_core_1.serialization.registerClass(MaxPooling1D);
 var AveragePooling1D = (function (_super) {
     __extends(AveragePooling1D, _super);
     function AveragePooling1D(config) {
@@ -34255,7 +36497,7 @@ var AveragePooling1D = (function (_super) {
     return AveragePooling1D;
 }(Pooling1D));
 exports.AveragePooling1D = AveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling1D);
+tfjs_core_1.serialization.registerClass(AveragePooling1D);
 var Pooling2D = (function (_super) {
     __extends(Pooling2D, _super);
     function Pooling2D(config) {
@@ -34339,7 +36581,7 @@ var MaxPooling2D = (function (_super) {
     return MaxPooling2D;
 }(Pooling2D));
 exports.MaxPooling2D = MaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling2D);
+tfjs_core_1.serialization.registerClass(MaxPooling2D);
 var AveragePooling2D = (function (_super) {
     __extends(AveragePooling2D, _super);
     function AveragePooling2D(config) {
@@ -34354,7 +36596,7 @@ var AveragePooling2D = (function (_super) {
     return AveragePooling2D;
 }(Pooling2D));
 exports.AveragePooling2D = AveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling2D);
+tfjs_core_1.serialization.registerClass(AveragePooling2D);
 var GlobalPooling1D = (function (_super) {
     __extends(GlobalPooling1D, _super);
     function GlobalPooling1D(config) {
@@ -34386,7 +36628,7 @@ var GlobalAveragePooling1D = (function (_super) {
     return GlobalAveragePooling1D;
 }(GlobalPooling1D));
 exports.GlobalAveragePooling1D = GlobalAveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling1D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling1D);
 var GlobalMaxPooling1D = (function (_super) {
     __extends(GlobalMaxPooling1D, _super);
     function GlobalMaxPooling1D(config) {
@@ -34402,7 +36644,7 @@ var GlobalMaxPooling1D = (function (_super) {
     return GlobalMaxPooling1D;
 }(GlobalPooling1D));
 exports.GlobalMaxPooling1D = GlobalMaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling1D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling1D);
 var GlobalPooling2D = (function (_super) {
     __extends(GlobalPooling2D, _super);
     function GlobalPooling2D(config) {
@@ -34455,7 +36697,7 @@ var GlobalAveragePooling2D = (function (_super) {
     return GlobalAveragePooling2D;
 }(GlobalPooling2D));
 exports.GlobalAveragePooling2D = GlobalAveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling2D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling2D);
 var GlobalMaxPooling2D = (function (_super) {
     __extends(GlobalMaxPooling2D, _super);
     function GlobalMaxPooling2D() {
@@ -34477,9 +36719,9 @@ var GlobalMaxPooling2D = (function (_super) {
     return GlobalMaxPooling2D;
 }(GlobalPooling2D));
 exports.GlobalMaxPooling2D = GlobalMaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling2D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],252:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34535,9 +36777,10 @@ function standardizeArgs(inputs, initialState, constants, numConstants) {
     return { inputs: inputs, initialState: initialState, constants: constants };
 }
 exports.standardizeArgs = standardizeArgs;
-function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, inputLength) {
+function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, needPerStepOutputs) {
     if (goBackwards === void 0) { goBackwards = false; }
     if (unroll === void 0) { unroll = false; }
+    if (needPerStepOutputs === void 0) { needPerStepOutputs = false; }
     var ndim = inputs.shape.length;
     if (ndim < 3) {
         throw new errors_1.ValueError("Input should be at least 3D, but is " + ndim + "D.");
@@ -34563,24 +36806,27 @@ function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, 
     var lastOutput;
     var states = initialStates;
     var timeSteps = inputs.shape[0];
-    for (var t = 0; t < timeSteps; ++t) {
+    var _loop_1 = function (t) {
         var currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
         currentInput = currentInput.reshape(currentInput.shape.slice(1));
-        var stepOutputs = stepFunction(currentInput, states);
+        var stepOutputs = tfc.tidy(function () { return stepFunction(currentInput, states); });
         lastOutput = stepOutputs[0];
-        if (t === 0) {
-            outputs = lastOutput.reshape([1].concat(lastOutput.shape));
-        }
-        else {
-            outputs = K.concatAlongFirstAxis(outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        if (needPerStepOutputs) {
+            if (t === 0) {
+                outputs = lastOutput.expandDims(1);
+            }
+            else {
+                var newOutputs = tfc.concat([outputs, lastOutput.expandDims(1)], 1);
+                outputs.dispose();
+                outputs = newOutputs;
+            }
         }
         states = stepOutputs[1];
+    };
+    for (var t = 0; t < timeSteps; ++t) {
+        _loop_1(t);
     }
-    return [
-        lastOutput,
-        tfc.transpose(outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
-        states
-    ];
+    return [lastOutput, outputs, states];
 }
 exports.rnn = rnn;
 var RNN = (function (_super) {
@@ -34829,8 +37075,6 @@ var RNN = (function (_super) {
                 throw new errors_1.ValueError("RNN Layer has " + numStates + " state(s) but was passed " +
                     (initialState.length + " initial state(s)."));
             }
-            var inputShape = inputs.shape;
-            var timesteps = inputShape[1];
             if (_this.unroll) {
                 console.warn('Ignoring unroll = true for RNN layer, due to imperative backend.');
             }
@@ -34839,7 +37083,7 @@ var RNN = (function (_super) {
                 var outputs = _this.cell.call([inputs].concat(states), cellCallKwargs);
                 return [outputs[0], outputs.slice(1)];
             };
-            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, timesteps);
+            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, _this.returnSequences);
             var lastOutput = rnnOutputs[0];
             var outputs = rnnOutputs[1];
             var states = rnnOutputs[2];
@@ -34915,7 +37159,7 @@ var RNN = (function (_super) {
     return RNN;
 }(topology_2.Layer));
 exports.RNN = RNN;
-tfjs_core_1.serialization.SerializationMap.register(RNN);
+tfjs_core_1.serialization.registerClass(RNN);
 var RNNCell = (function (_super) {
     __extends(RNNCell, _super);
     function RNNCell() {
@@ -35034,7 +37278,7 @@ var SimpleRNNCell = (function (_super) {
     return SimpleRNNCell;
 }(RNNCell));
 exports.SimpleRNNCell = SimpleRNNCell;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNNCell);
+tfjs_core_1.serialization.registerClass(SimpleRNNCell);
 var SimpleRNN = (function (_super) {
     __extends(SimpleRNN, _super);
     function SimpleRNN(config) {
@@ -35185,7 +37429,7 @@ var SimpleRNN = (function (_super) {
     return SimpleRNN;
 }(RNN));
 exports.SimpleRNN = SimpleRNN;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNN);
+tfjs_core_1.serialization.registerClass(SimpleRNN);
 var GRUCell = (function (_super) {
     __extends(GRUCell, _super);
     function GRUCell(config) {
@@ -35360,7 +37604,7 @@ var GRUCell = (function (_super) {
     return GRUCell;
 }(RNNCell));
 exports.GRUCell = GRUCell;
-tfjs_core_1.serialization.SerializationMap.register(GRUCell);
+tfjs_core_1.serialization.registerClass(GRUCell);
 var GRU = (function (_super) {
     __extends(GRU, _super);
     function GRU(config) {
@@ -35537,7 +37781,7 @@ var GRU = (function (_super) {
     return GRU;
 }(RNN));
 exports.GRU = GRU;
-tfjs_core_1.serialization.SerializationMap.register(GRU);
+tfjs_core_1.serialization.registerClass(GRU);
 var LSTMCell = (function (_super) {
     __extends(LSTMCell, _super);
     function LSTMCell(config) {
@@ -35747,7 +37991,7 @@ var LSTMCell = (function (_super) {
     return LSTMCell;
 }(RNNCell));
 exports.LSTMCell = LSTMCell;
-tfjs_core_1.serialization.SerializationMap.register(LSTMCell);
+tfjs_core_1.serialization.registerClass(LSTMCell);
 var LSTM = (function (_super) {
     __extends(LSTM, _super);
     function LSTM(config) {
@@ -35932,7 +38176,7 @@ var LSTM = (function (_super) {
     return LSTM;
 }(RNN));
 exports.LSTM = LSTM;
-tfjs_core_1.serialization.SerializationMap.register(LSTM);
+tfjs_core_1.serialization.registerClass(LSTM);
 var StackedRNNCells = (function (_super) {
     __extends(StackedRNNCells, _super);
     function StackedRNNCells(config) {
@@ -36096,7 +38340,7 @@ var StackedRNNCells = (function (_super) {
     return StackedRNNCells;
 }(RNNCell));
 exports.StackedRNNCells = StackedRNNCells;
-tfjs_core_1.serialization.SerializationMap.register(StackedRNNCells);
+tfjs_core_1.serialization.registerClass(StackedRNNCells);
 function generateDropoutMask(ones, rate, training, count) {
     if (training === void 0) { training = null; }
     if (count === void 0) { count = 1; }
@@ -36116,7 +38360,7 @@ function generateDropoutMask(ones, rate, training, count) {
     }
 }
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"../variables":244,"./serialization":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"../variables":268,"./serialization":253,"@tensorflow/tfjs-core":68}],253:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -36127,7 +38371,7 @@ function deserialize(config, customObjects) {
 }
 exports.deserialize = deserialize;
 
-},{"../utils/generic_utils":238,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
+},{"../utils/generic_utils":262,"@tensorflow/tfjs-core":68}],254:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36268,10 +38512,10 @@ var TimeDistributed = (function (_super) {
         return tfjs_core_1.tidy(function () {
             inputs = types_utils_1.getExactlyOneTensor(inputs);
             var step = function (inputs, states) {
-                var output = _this.layer.call(inputs, kwargs);
+                var output = types_utils_1.getExactlyOneTensor(_this.layer.call(inputs, kwargs));
                 return [output, []];
             };
-            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, true);
             var y = rnnOutputs[1];
             return y;
         });
@@ -36280,7 +38524,7 @@ var TimeDistributed = (function (_super) {
     return TimeDistributed;
 }(Wrapper));
 exports.TimeDistributed = TimeDistributed;
-tfjs_core_1.serialization.SerializationMap.register(TimeDistributed);
+tfjs_core_1.serialization.registerClass(TimeDistributed);
 exports.VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
 function checkBidirectionalMergeMode(value) {
     generic_utils.checkStringTypeUnionValue(exports.VALID_BIDIRECTIONAL_MERGE_MODES, 'BidirectionalMergeMode', value);
@@ -36451,7 +38695,7 @@ var Bidirectional = (function (_super) {
                 var forwardState = initialState.slice(0, initialState.length / 2);
                 var backwardState = initialState.slice(initialState.length / 2);
                 y = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: forwardState }));
-                yRev = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
+                yRev = _this.backwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
             }
             var states;
             if (_this.returnState) {
@@ -36542,9 +38786,9 @@ var Bidirectional = (function (_super) {
     return Bidirectional;
 }(Wrapper));
 exports.Bidirectional = Bidirectional;
-tfjs_core_1.serialization.SerializationMap.register(Bidirectional);
+tfjs_core_1.serialization.registerClass(Bidirectional);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"./recurrent":228,"./serialization":229,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"./recurrent":252,"./serialization":253,"@tensorflow/tfjs-core":68}],255:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36630,14 +38874,14 @@ function disposeTensorsInLogs(logs) {
 }
 exports.disposeTensorsInLogs = disposeTensorsInLogs;
 
-},{"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],256:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var common_1 = require("./backend/common");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 function l2Normalize(x, axis) {
     return tfjs_core_1.tidy(function () {
@@ -36814,7 +39058,13 @@ function get(identifierOrFn) {
         if (identifierOrFn in lossesMap) {
             return lossesMap[identifierOrFn];
         }
-        throw new errors_1.ValueError("Unknown loss " + identifierOrFn);
+        var errMsg = "Unknown loss " + identifierOrFn;
+        if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+            errMsg = "Unknown loss " + identifierOrFn + ". " +
+                'Use "categoricalCrossentropy" as the string name for ' +
+                'tf.losses.softmaxCrossEntropy';
+        }
+        throw new errors_1.ValueError(errMsg);
     }
     else {
         return identifierOrFn;
@@ -36822,13 +39072,13 @@ function get(identifierOrFn) {
 }
 exports.get = get;
 
-},{"./backend/common":198,"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"@tensorflow/tfjs-core":68}],257:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 var losses_1 = require("./losses");
 var losses_2 = require("./losses");
@@ -36844,6 +39094,54 @@ function categoricalAccuracy(yTrue, yPred) {
     return tfjs_core_1.tidy(function () { return K.cast(tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'); });
 }
 exports.categoricalAccuracy = categoricalAccuracy;
+function truePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function falseNegatives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(zero))
+            .sum()
+            .cast('float32');
+    });
+}
+function falsePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function precision(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fp = falsePositives(yTrue, yPred);
+        var denominator = tp.add(fp);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fn = falseNegatives(yTrue, yPred);
+        var denominator = tp.add(fn);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.recall = recall;
 function binaryCrossentropy(yTrue, yPred) {
     return losses_2.binaryCrossentropy(yTrue, yPred);
 }
@@ -36873,6 +39171,7 @@ function get(identifier) {
     var metricsMap = {
         binaryAccuracy: binaryAccuracy,
         categoricalAccuracy: categoricalAccuracy,
+        precision: precision,
         categoricalCrossentropy: exports.categoricalCrossentropy,
         sparseCategoricalCrossentropy: exports.sparseCategoricalCrossentropy,
         mse: exports.mse,
@@ -36895,7 +39194,7 @@ function get(identifier) {
 }
 exports.get = get;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"./losses":232,"@tensorflow/tfjs-core":68}],234:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"./losses":256,"@tensorflow/tfjs-core":68}],258:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36959,6 +39258,10 @@ function modelFromJSON(modelAndWeightsConfig, customObjects) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
+                    if (!('modelTopology' in modelAndWeightsConfig)) {
+                        modelAndWeightsConfig = { modelTopology: modelAndWeightsConfig };
+                    }
+                    modelAndWeightsConfig = modelAndWeightsConfig;
                     modelTopology = modelAndWeightsConfig.modelTopology;
                     if (modelTopology['model_config'] != null) {
                         modelTopology = modelTopology['model_config'];
@@ -37057,6 +39360,14 @@ var Sequential = (function (_super) {
         }
         return _this;
     }
+    Sequential.prototype.checkShape = function (layer) {
+        var shape = layer.inboundNodes[0].outputTensors[0].shape;
+        if (shape.some(function (x) { return x < 0; })) {
+            throw new errors_1.ValueError('Negative dimension size caused by adding layer ' +
+                (layer.name + " with input shape [") +
+                (layer.inboundNodes[0].inputTensors[0].shape + "]"));
+        }
+    };
     Sequential.prototype.add = function (layer) {
         var isLayerModelInstance = layer instanceof Sequential || layer instanceof training_1.Model;
         var modelLayer;
@@ -37105,6 +39416,7 @@ var Sequential = (function (_super) {
                         'For multi-output layers, ' +
                         'use the functional API.');
                 }
+                this.checkShape(layer);
                 this.outputs = [layer.inboundNodes[0].outputTensors[0]];
                 this.inputs = topology_1.getSourceInputs(this.outputs[0]);
             }
@@ -37130,6 +39442,7 @@ var Sequential = (function (_super) {
                     'For multi-output layers, ' +
                     'use the functional API.');
             }
+            this.checkShape(layer);
             this.outputs = [outputTensor];
             this.inboundNodes[0].outputTensors = this.outputs;
             this.inboundNodes[0].outputShapes = [this.outputs[0].shape];
@@ -37226,6 +39539,16 @@ var Sequential = (function (_super) {
         }
         return this.model.evaluate(x, y, config);
     };
+    Sequential.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before being used.');
+                }
+                return [2, this.model.evaluateDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.prototype.predict = function (x, config) {
         if (config === void 0) { config = {}; }
         if (this.model == null) {
@@ -37260,19 +39583,40 @@ var Sequential = (function (_super) {
             });
         });
     };
+    Sequential.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before ' +
+                        'being used.');
+                }
+                return [2, this.model.fitDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.fromConfig = function (cls, config) {
-        var model = new cls({});
+        var configArray;
+        var extraModelConfig = {};
+        if (config instanceof Array) {
+            if (!(config[0].className != null) ||
+                config[0]['className'] === 'Merge') {
+                throw new errors_1.ValueError('Legacy serialization format not supported yet.');
+            }
+            configArray = config;
+        }
+        else {
+            tfjs_core_1.util.assert(config['layers'] != null, "When the config data for a Sequential model is not an Array, " +
+                "it must be an Object that contains the 'layers' field.");
+            configArray = config['layers'];
+            delete config['layers'];
+            extraModelConfig = config;
+        }
+        var model = new cls(extraModelConfig);
         if (!(model instanceof Sequential)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called on non-Sequential input: " + model);
+            throw new errors_1.NotImplementedError("Sequential.fromConfig called on non-Sequential input: " + model);
         }
-        if (!(config instanceof Array)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called without an array of configs");
-        }
-        if (!(config[0].className != null) || config[0]['className'] === 'Merge') {
-            throw new errors_1.ValueError('Legacy serialization format not supported yet.');
-        }
-        for (var _i = 0, _a = config; _i < _a.length; _i++) {
-            var conf = _a[_i];
+        for (var _i = 0, configArray_1 = configArray; _i < configArray_1.length; _i++) {
+            var conf = configArray_1[_i];
             var layer = serialization_1.deserialize(conf);
             model.add(layer);
         }
@@ -37300,9 +39644,9 @@ var Sequential = (function (_super) {
     return Sequential;
 }(training_1.Model));
 exports.Sequential = Sequential;
-tfjs_core_1.serialization.SerializationMap.register(Sequential);
+tfjs_core_1.serialization.registerClass(Sequential);
 
-},{"./backend/state":199,"./engine/input_layer":207,"./engine/topology":208,"./engine/training":209,"./errors":210,"./layers/serialization":229,"./utils/generic_utils":238,"./utils/serialization_utils":241,"./utils/types_utils":242,"@tensorflow/tfjs-core":68}],235:[function(require,module,exports){
+},{"./backend/state":219,"./engine/input_layer":228,"./engine/topology":229,"./engine/training":230,"./errors":233,"./layers/serialization":253,"./utils/generic_utils":262,"./utils/serialization_utils":265,"./utils/types_utils":266,"@tensorflow/tfjs-core":68}],259:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -37330,7 +39674,7 @@ function getOptimizer(identifier) {
 }
 exports.getOptimizer = getOptimizer;
 
-},{"./backend/common":198,"./errors":210,"@tensorflow/tfjs-core":68}],236:[function(require,module,exports){
+},{"./backend/common":218,"./errors":233,"@tensorflow/tfjs-core":68}],260:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37392,7 +39736,7 @@ var L1L2 = (function (_super) {
     return L1L2;
 }(Regularizer));
 exports.L1L2 = L1L2;
-tfjs_core_1.serialization.SerializationMap.register(L1L2);
+tfjs_core_1.serialization.registerClass(L1L2);
 function l1(config) {
     return new L1L2({ l1: config != null ? config.l1 : null, l2: 0 });
 }
@@ -37433,7 +39777,7 @@ function getRegularizer(identifier) {
 }
 exports.getRegularizer = getRegularizer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],237:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],261:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37493,7 +39837,7 @@ function deconvLength(dimSize, strideSize, kernelSize, padding) {
 }
 exports.deconvLength = deconvLength;
 
-},{"../errors":210,"./generic_utils":238,"./math_utils":240}],238:[function(require,module,exports){
+},{"../errors":233,"./generic_utils":262,"./math_utils":264}],262:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -37762,7 +40106,7 @@ function checkArrayTypeAndLength(x, expectedType, minLength, maxLength) {
 }
 exports.checkArrayTypeAndLength = checkArrayTypeAndLength;
 
-},{"../errors":210}],239:[function(require,module,exports){
+},{"../errors":233}],263:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var variable_utils_1 = require("./variable_utils");
@@ -37922,7 +40266,7 @@ function printLayerSummaryWithConnections(layer, positions, relevantNodes, print
     }
 }
 
-},{"./variable_utils":243}],240:[function(require,module,exports){
+},{"./variable_utils":267}],264:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -37994,7 +40338,7 @@ function range(begin, end) {
 }
 exports.range = range;
 
-},{"../errors":210,"@tensorflow/tfjs-core":68}],241:[function(require,module,exports){
+},{"../errors":233,"@tensorflow/tfjs-core":68}],265:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils = require("../utils/generic_utils");
@@ -38088,7 +40432,7 @@ function convertTsToPythonic(tsConfig, key) {
 }
 exports.convertTsToPythonic = convertTsToPythonic;
 
-},{"../utils/generic_utils":238}],242:[function(require,module,exports){
+},{"../utils/generic_utils":262}],266:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -38136,7 +40480,7 @@ function getExactlyOneShape(shapes) {
 }
 exports.getExactlyOneShape = getExactlyOneShape;
 
-},{"../errors":210}],243:[function(require,module,exports){
+},{"../errors":233}],267:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function countParamsInWeights(weights) {
@@ -38154,7 +40498,7 @@ function countParamsInWeights(weights) {
 }
 exports.countParamsInWeights = countParamsInWeights;
 
-},{}],244:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38247,8 +40591,9 @@ function truncatedNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'truncatedNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38257,8 +40602,9 @@ function randomNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'randomNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38293,13 +40639,13 @@ function gradients(lossFn, variables) {
 }
 exports.gradients = gradients;
 
-},{"./backend/state":199,"./common":203,"./errors":210,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
+},{"./backend/state":219,"./common":223,"./errors":233,"@tensorflow/tfjs-core":68}],269:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.7.5';
+var version = '0.8.3';
 exports.version = version;
 
-},{}],246:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -38319,13 +40665,13 @@ exports.version = {
     'tfjs': version_1.version
 };
 
-},{"./version":247,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":217}],247:[function(require,module,exports){
+},{"./version":271,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":241}],271:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.7';
+var version = '0.13.3';
 exports.version = version;
 
-},{}],248:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 var AudioContext = window.AudioContext || window.webkitAudioContext
 
 function createWorker (fn) {
@@ -38578,7 +40924,7 @@ MediaRecorder.encoder = require('./wave-encoder')
 
 module.exports = MediaRecorder
 
-},{"./wave-encoder":249}],249:[function(require,module,exports){
+},{"./wave-encoder":273}],273:[function(require,module,exports){
 // Copied from https://github.com/chris-rudmin/Recorderjs
 
 module.exports = function () {
@@ -38654,7 +41000,7 @@ module.exports = function () {
   }
 }
 
-},{}],250:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -38772,7 +41118,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],251:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 /**
  * Bit twiddling hacks for JavaScript.
  *
@@ -38978,9 +41324,9 @@ exports.nextCombination = function(v) {
 }
 
 
-},{}],252:[function(require,module,exports){
+},{}],276:[function(require,module,exports){
 
-},{}],253:[function(require,module,exports){
+},{}],277:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -40718,7 +43064,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":250,"ieee754":261}],254:[function(require,module,exports){
+},{"base64-js":274,"ieee754":285}],278:[function(require,module,exports){
 "use strict"
 
 var createThunk = require("./lib/thunk.js")
@@ -40829,7 +43175,7 @@ function compileCwise(user_args) {
 
 module.exports = compileCwise
 
-},{"./lib/thunk.js":256}],255:[function(require,module,exports){
+},{"./lib/thunk.js":280}],279:[function(require,module,exports){
 "use strict"
 
 var uniq = require("uniq")
@@ -41189,7 +43535,7 @@ function generateCWiseOp(proc, typesig) {
 }
 module.exports = generateCWiseOp
 
-},{"uniq":302}],256:[function(require,module,exports){
+},{"uniq":326}],280:[function(require,module,exports){
 "use strict"
 
 // The function below is called when constructing a cwise function object, and does the following:
@@ -41277,9 +43623,9 @@ function createThunk(proc) {
 
 module.exports = createThunk
 
-},{"./compile.js":255}],257:[function(require,module,exports){
+},{"./compile.js":279}],281:[function(require,module,exports){
 module.exports = require("cwise-compiler")
-},{"cwise-compiler":254}],258:[function(require,module,exports){
+},{"cwise-compiler":278}],282:[function(require,module,exports){
 "use strict"
 
 function dupe_array(count, value, i) {
@@ -41329,7 +43675,7 @@ function dupe(count, value) {
 }
 
 module.exports = dupe
-},{}],259:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 'use strict';
 
 function FFT(size) {
@@ -41838,7 +44184,7 @@ FFT.prototype._singleRealTransform4 = function _singleRealTransform4(outOff,
   out[outOff + 7] = FDi;
 };
 
-},{}],260:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 1.3.2
@@ -42028,7 +44374,7 @@ if (typeof module !== "undefined" && module.exports) {
   });
 }
 
-},{}],261:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -42114,7 +44460,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],262:[function(require,module,exports){
+},{}],286:[function(require,module,exports){
 "use strict"
 
 function iota(n) {
@@ -42126,7 +44472,7 @@ function iota(n) {
 }
 
 module.exports = iota
-},{}],263:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -42149,10 +44495,10 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],264:[function(require,module,exports){
+},{}],288:[function(require,module,exports){
 !function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.MidiConvert=e():t.MidiConvert=e()}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="",e(e.s=7)}([function(t,e,n){"use strict";n.d(e,"a",function(){return r}),n.d(e,"b",function(){return i}),n.d(e,"c",function(){return a});var r=["acoustic grand piano","bright acoustic piano","electric grand piano","honky-tonk piano","electric piano 1","electric piano 2","harpsichord","clavi","celesta","glockenspiel","music box","vibraphone","marimba","xylophone","tubular bells","dulcimer","drawbar organ","percussive organ","rock organ","church organ","reed organ","accordion","harmonica","tango accordion","acoustic guitar (nylon)","acoustic guitar (steel)","electric guitar (jazz)","electric guitar (clean)","electric guitar (muted)","overdriven guitar","distortion guitar","guitar harmonics","acoustic bass","electric bass (finger)","electric bass (pick)","fretless bass","slap bass 1","slap bass 2","synth bass 1","synth bass 2","violin","viola","cello","contrabass","tremolo strings","pizzicato strings","orchestral harp","timpani","string ensemble 1","string ensemble 2","synthstrings 1","synthstrings 2","choir aahs","voice oohs","synth voice","orchestra hit","trumpet","trombone","tuba","muted trumpet","french horn","brass section","synthbrass 1","synthbrass 2","soprano sax","alto sax","tenor sax","baritone sax","oboe","english horn","bassoon","clarinet","piccolo","flute","recorder","pan flute","blown bottle","shakuhachi","whistle","ocarina","lead 1 (square)","lead 2 (sawtooth)","lead 3 (calliope)","lead 4 (chiff)","lead 5 (charang)","lead 6 (voice)","lead 7 (fifths)","lead 8 (bass + lead)","pad 1 (new age)","pad 2 (warm)","pad 3 (polysynth)","pad 4 (choir)","pad 5 (bowed)","pad 6 (metallic)","pad 7 (halo)","pad 8 (sweep)","fx 1 (rain)","fx 2 (soundtrack)","fx 3 (crystal)","fx 4 (atmosphere)","fx 5 (brightness)","fx 6 (goblins)","fx 7 (echoes)","fx 8 (sci-fi)","sitar","banjo","shamisen","koto","kalimba","bag pipe","fiddle","shanai","tinkle bell","agogo","steel drums","woodblock","taiko drum","melodic tom","synth drum","reverse cymbal","guitar fret noise","breath noise","seashore","bird tweet","telephone ring","helicopter","applause","gunshot"],i=["piano","chromatic percussion","organ","guitar","bass","strings","ensemble","brass","reed","pipe","synth lead","synth pad","synth effects","ethnic","percussive","sound effects"],a={0:"standard kit",8:"room kit",16:"power kit",24:"electronic kit",25:"tr-808 kit",32:"jazz kit",40:"brush kit",48:"orchestra kit",56:"sound fx kit"}},function(t,e,n){"use strict";function r(t){return t.replace(/\u0000/g,"")}function i(t,e){return 60/e.bpm*(t/e.PPQ)}function a(t){return"number"==typeof t}function o(t){return"string"==typeof t}function s(t){return["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"][t%12]+(Math.floor(t/12)-1)}e.b=r,e.a=i,e.c=a,n.d(e,"d",function(){return u}),e.e=s,n.d(e,"f",function(){return c});var u=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i;return function(e){return o(e)&&t.test(e)}}(),c=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,e={cbb:-2,cb:-1,c:0,"c#":1,cx:2,dbb:0,db:1,d:2,"d#":3,dx:4,ebb:2,eb:3,e:4,"e#":5,ex:6,fbb:3,fb:4,f:5,"f#":6,fx:7,gbb:5,gb:6,g:7,"g#":8,gx:9,abb:7,ab:8,a:9,"a#":10,ax:11,bbb:9,bb:10,b:11,"b#":12,bx:13};return function(n){var r=t.exec(n),i=r[1],a=r[2];return e[i.toLowerCase()]+12*(parseInt(a)+1)}}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(11),a=(n.n(i),n(10)),o=(n.n(a),n(1)),s=n(9),u=n(5),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(){r(this,t),this.header={bpm:120,timeSignature:[4,4],PPQ:480},this.tracks=[]}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t;return n.header=e.header,e.tracks.forEach(function(t){var e=s.a.fromJSON(t);n.tracks.push(e)}),n}}]),c(t,[{key:"load",value:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:null,r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"GET";return new Promise(function(i,a){var o=new XMLHttpRequest;o.open(r,t),o.responseType="arraybuffer",o.addEventListener("load",function(){4===o.readyState&&200===o.status?i(e.decode(o.response)):a(o.status)}),o.addEventListener("error",a),o.send(n)}).catch(function(t){console.log(t)})}},{key:"decode",value:function(t){var e=this;if(t instanceof ArrayBuffer){var r=new Uint8Array(t);t=String.fromCharCode.apply(null,r)}var a=i(t);return this.header=n.i(u.a)(a),this.tracks=[],a.tracks.forEach(function(t,n){var r=new s.a;r.id=n,e.tracks.push(r);var i=0;t.forEach(function(t){i+=o.a(t.deltaTime,e.header),"meta"===t.type&&"trackName"===t.subtype?r.name=o.b(t.text):"noteOn"===t.subtype?(r.noteOn(t.noteNumber,i,t.velocity/127),-1===r.channelNumber&&(r.channelNumber=t.channel)):"noteOff"===t.subtype?r.noteOff(t.noteNumber,i):"controller"===t.subtype&&t.controllerType?r.cc(t.controllerType,i,t.value/127):"meta"===t.type&&"instrumentName"===t.subtype?r.instrument=t.text:"channel"===t.type&&"programChange"===t.subtype&&(r.patch(t.programNumber),r.channelNumber=t.channel)}),e.header.name||r.length||!r.name||(e.header.name=r.name)}),this}},{key:"encode",value:function(){var t=this,e=new a.File({ticks:this.header.PPQ}),n=this.tracks.filter(function(t){return!t.length})[0];if(this.header.name&&(!n||n.name!==this.header.name)){e.addTrack().addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:this.header.name}))}return this.tracks.forEach(function(n){var r=e.addTrack();r.setTempo(t.bpm),n.name&&r.addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:n.name})),n.encode(r,t.header)}),e.toBytes()}},{key:"toArray",value:function(){for(var t=this.encode(),e=new Array(t.length),n=0;n<t.length;n++)e[n]=t.charCodeAt(n);return e}},{key:"toJSON",value:function(){var t={header:this.header,startTime:this.startTime,duration:this.duration,tracks:(this.tracks||[]).map(function(t){return t.toJSON()})};return t.header.name||(t.header.name=""),t}},{key:"track",value:function(t){var e=new s.a(t);return this.tracks.push(e),e}},{key:"get",value:function(t){return o.c(t)?this.tracks[t]:this.tracks.find(function(e){return e.name===t})}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=new t;return r.header=this.header,r.tracks=this.tracks.map(function(t){return t.slice(e,n)}),r}},{key:"startTime",get:function(){var t=this.tracks.map(function(t){return t.startTime});return t.length?Math.min.apply(Math,t)||0:0}},{key:"bpm",get:function(){return this.header.bpm},set:function(t){var e=this.header.bpm;this.header.bpm=t;var n=e/t;this.tracks.forEach(function(t){return t.scale(n)})}},{key:"timeSignature",get:function(){return this.header.timeSignature},set:function(t){this.header.timeSignature=t}},{key:"duration",get:function(){var t=this.tracks.map(function(t){return t.duration});return t.length?Math.max.apply(Math,t)||0:0}}]),t}()},function(t,e,n){"use strict";function r(t,e){var n=0,r=t.length,i=r;if(r>0&&t[r-1].time<=e)return r-1;for(;n<i;){var a=Math.floor(n+(i-n)/2),o=t[a],s=t[a+1];if(o.time===e){for(var u=a;u<t.length;u++){t[u].time===e&&(a=u)}return a}if(o.time<e&&s.time>e)return a;o.time>e?i=a:o.time<e&&(n=a+1)}return-1}function i(t,e){if(t.length){var n=r(t,e.time);t.splice(n+1,0,e)}else t.push(e)}n.d(e,"a",function(){return i})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),a={1:"modulationWheel",2:"breath",4:"footController",5:"portamentoTime",7:"volume",8:"balance",10:"pan",64:"sustain",65:"portamentoTime",66:"sostenuto",67:"softPedal",68:"legatoFootswitch",84:"portamentoContro"},o=function(){function t(e,n,i){r(this,t),this.number=e,this.time=n,this.value=i}return i(t,[{key:"name",get:function(){if(a.hasOwnProperty(this.number))return a[this.number]}}]),t}()},function(t,e,n){"use strict";function r(t){for(var e={PPQ:t.header.ticksPerBeat},n=0;n<t.tracks.length;n++)for(var r=t.tracks[n],i=0;i<r.length;i++){var a=r[i];"meta"===a.type&&("timeSignature"===a.subtype?e.timeSignature=[a.numerator,a.denominator]:"setTempo"===a.subtype&&(e.bpm||(e.bpm=6e7/a.microsecondsPerBeat)))}return e.bpm=e.bpm||120,e}n.d(e,"a",function(){return r})},function(t,e,n){"use strict";function r(t,e){for(var n=0;n<t.length;n++){var r=t[n],i=e[n];if(r.length>i)return!0}return!1}function i(t,e,n){for(var r=0,i=1/0,a=0;a<t.length;a++){var o=t[a],s=e[a];o[s]&&o[s].time<i&&(r=a,i=o[s].time)}n[r](t[r][e[r]]),e[r]+=1}function a(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];for(var a=e.filter(function(t,e){return e%2==0}),o=new Uint32Array(a.length),s=e.filter(function(t,e){return e%2==1});r(a,o);)i(a,o,s)}n.d(e,"a",function(){return a})},function(t,e,n){"use strict";function r(t){return(new s.a).decode(t)}function i(t,e){var n=(new s.a).load(t);return e&&n.then(e),n}function a(){return new s.a}function o(t){return s.a.fromJSON(t)}Object.defineProperty(e,"__esModule",{value:!0}),e.parse=r,e.load=i,e.create=a,e.fromJSON=o;var s=n(2),u=n(0);n.d(e,"instrumentByPatchID",function(){return u.a}),n.d(e,"instrumentFamilyByID",function(){return u.b}),n.d(e,"drumKitByPatchID",function(){return u.c})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=n(1),a=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),o=function(){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1;if(r(this,t),i.c(e))this.midi=e;else{if(!i.d(e))throw new Error("the midi value must either be in Pitch Notation (e.g. C#4) or a midi value");this.name=e}this.time=n,this.duration=a,this.velocity=o}return a(t,null,[{key:"fromJSON",value:function(e){return new t(e.midi,e.time,e.duration,e.velocity)}}]),a(t,[{key:"match",value:function(t){return i.c(t)?this.midi===t:i.d(t)?this.name.toLowerCase()===t.toLowerCase():void 0}},{key:"toJSON",value:function(){return{name:this.name,midi:this.midi,time:this.time,velocity:this.velocity,duration:this.duration}}},{key:"name",get:function(){return i.e(this.midi)},set:function(t){this.midi=i.f(t)}},{key:"noteOn",get:function(){return this.time},set:function(t){this.time=t}},{key:"noteOff",get:function(){return this.time+this.duration},set:function(t){this.duration=t-this.time}}]),t}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(3),a=n(4),o=n(6),s=n(8),u=n(0),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:-1,i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:-1;r(this,t),this.name=e,this.channelNumber=i,this.notes=[],this.controlChanges={},this.instrumentNumber=n}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t(e.name,e.instrumentNumber,e.channelNumber);return n.id=e.id,e.notes&&e.notes.forEach(function(t){var e=s.a.fromJSON(t);n.notes.push(e)}),e.controlChanges&&(n.controlChanges=e.controlChanges),n}}]),c(t,[{key:"note",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,a=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1,o=new s.a(t,e,r,a);return n.i(i.a)(this.notes,o),this}},{key:"noteOn",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:1,a=new s.a(t,e,0,r);return n.i(i.a)(this.notes,a),this}},{key:"noteOff",value:function(t,e){for(var n=0;n<this.notes.length;n++){var r=this.notes[n];if(r.match(t)&&0===r.duration){r.noteOff=e;break}}return this}},{key:"cc",value:function(t,e,r){this.controlChanges.hasOwnProperty(t)||(this.controlChanges[t]=[]);var o=new a.a(t,e,r);return n.i(i.a)(this.controlChanges[t],o),this}},{key:"patch",value:function(t){return this.instrumentNumber=t,this}},{key:"channel",value:function(t){return this.channelNumber=t,this}},{key:"scale",value:function(t){return this.notes.forEach(function(e){e.time*=t,e.duration*=t}),this}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=Math.max(this.notes.findIndex(function(t){return t.time>=e}),0),i=this.notes.findIndex(function(t){return t.noteOff>=n})+1,a=new t(this.name);return a.notes=this.notes.slice(r,i),a.notes.forEach(function(t){return t.time=t.time-e}),a}},{key:"encode",value:function(t,e){function r(t){var e=Math.floor(i*t),n=Math.max(e-a,0);return a=e,n}var i=e.PPQ/(60/e.bpm),a=0,s=Math.max(0,this.channelNumber);-1!==this.instrumentNumber&&t.instrument(s,this.instrumentNumber),n.i(o.a)(this.noteOns.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOn(s,e.name,r(e.time),Math.floor(127*e.velocity))},this.noteOffs.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOff(s,e.name,r(e.time))})}},{key:"toJSON",value:function(){var t={startTime:this.startTime,duration:this.duration,length:this.length,notes:[],controlChanges:{}};return void 0!==this.id&&(t.id=this.id),t.name=this.name,-1!==this.instrumentNumber&&(t.instrumentNumber=this.instrumentNumber,t.instrument=this.instrument,t.instrumentFamily=this.instrumentFamily),-1!==this.channelNumber&&(t.channelNumber=this.channelNumber,t.isPercussion=this.isPercussion),this.notes.length&&(t.notes=this.notes.map(function(t){return t.toJSON()})),Object.keys(this.controlChanges).length&&(t.controlChanges=this.controlChanges),t}},{key:"noteOns",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOn,midi:e.midi,name:e.name,velocity:e.velocity})}),t}},{key:"noteOffs",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOff,midi:e.midi,name:e.name})}),t}},{key:"length",get:function(){return this.notes.length}},{key:"startTime",get:function(){if(this.notes.length){return this.notes[0].noteOn}return 0}},{key:"duration",get:function(){if(this.notes.length){return this.notes[this.notes.length-1].noteOff}return 0}},{key:"instrument",get:function(){return this.isPercussion?u.c[this.instrumentNumber]:u.a[this.instrumentNumber]},set:function(t){var e=u.a.indexOf(t);-1!==e&&(this.instrumentNumber=e)}},{key:"isPercussion",get:function(){return[9,10].includes(this.channelNumber)}},{key:"instrumentFamily",get:function(){return this.isPercussion?"drums":u.b[Math.floor(this.instrumentNumber/8)]}}]),t}()},function(t,e,n){(function(t){var n={};!function(t){var e=t.DEFAULT_VOLUME=90,n=(t.DEFAULT_DURATION=128,t.DEFAULT_CHANNEL=0,{midi_letter_pitches:{a:21,b:23,c:12,d:14,e:16,f:17,g:19},midiPitchFromNote:function(t){var e=/([a-g])(#+|b+)?([0-9]+)$/i.exec(t),r=e[1].toLowerCase(),i=e[2]||"";return 12*parseInt(e[3],10)+n.midi_letter_pitches[r]+("#"==i.substr(0,1)?1:-1)*i.length},ensureMidiPitch:function(t){return"number"!=typeof t&&/[^0-9]/.test(t)?n.midiPitchFromNote(t):parseInt(t,10)},midi_pitches_letter:{12:"c",13:"c#",14:"d",15:"d#",16:"e",17:"f",18:"f#",19:"g",20:"g#",21:"a",22:"a#",23:"b"},midi_flattened_notes:{"a#":"bb","c#":"db","d#":"eb","f#":"gb","g#":"ab"},noteFromMidiPitch:function(t,e){var r,i=0,a=t,e=e||!1;return t>23&&(i=Math.floor(t/12)-1,a=t-12*i),r=n.midi_pitches_letter[a],e&&r.indexOf("#")>0&&(r=n.midi_flattened_notes[r]),r+i},mpqnFromBpm:function(t){var e=Math.floor(6e7/t),n=[];do{n.unshift(255&e),e>>=8}while(e);for(;n.length<3;)n.push(0);return n},bpmFromMpqn:function(t){var e=t;if(void 0!==t[0]){e=0;for(var n=0,r=t.length-1;r>=0;++n,--r)e|=t[n]<<r}return Math.floor(6e7/t)},codes2Str:function(t){return String.fromCharCode.apply(null,t)},str2Bytes:function(t,e){if(e)for(;t.length/2<e;)t="0"+t;for(var n=[],r=t.length-1;r>=0;r-=2){var i=0===r?t[r]:t[r-1]+t[r];n.unshift(parseInt(i,16))}return n},translateTickTime:function(t){for(var e=127&t;t>>=7;)e<<=8,e|=127&t|128;for(var n=[];;){if(n.push(255&e),!(128&e))break;e>>=8}return n}}),r=function(t){if(!this)return new r(t);!t||null===t.type&&void 0===t.type||null===t.channel&&void 0===t.channel||null===t.param1&&void 0===t.param1||(this.setTime(t.time),this.setType(t.type),this.setChannel(t.channel),this.setParam1(t.param1),this.setParam2(t.param2))};r.NOTE_OFF=128,r.NOTE_ON=144,r.AFTER_TOUCH=160,r.CONTROLLER=176,r.PROGRAM_CHANGE=192,r.CHANNEL_AFTERTOUCH=208,r.PITCH_BEND=224,r.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},r.prototype.setType=function(t){if(t<r.NOTE_OFF||t>r.PITCH_BEND)throw new Error("Trying to set an unknown event: "+t);this.type=t},r.prototype.setChannel=function(t){if(t<0||t>15)throw new Error("Channel is out of bounds.");this.channel=t},r.prototype.setParam1=function(t){this.param1=t},r.prototype.setParam2=function(t){this.param2=t},r.prototype.toBytes=function(){var t=[],e=this.type|15&this.channel;return t.push.apply(t,this.time),t.push(e),t.push(this.param1),void 0!==this.param2&&null!==this.param2&&t.push(this.param2),t};var i=function(t){if(!this)return new i(t);this.setTime(t.time),this.setType(t.type),this.setData(t.data)};i.SEQUENCE=0,i.TEXT=1,i.COPYRIGHT=2,i.TRACK_NAME=3,i.INSTRUMENT=4,i.LYRIC=5,i.MARKER=6,i.CUE_POINT=7,i.CHANNEL_PREFIX=32,i.END_OF_TRACK=47,i.TEMPO=81,i.SMPTE=84,i.TIME_SIG=88,i.KEY_SIG=89,i.SEQ_EVENT=127,i.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},i.prototype.setType=function(t){this.type=t},i.prototype.setData=function(t){this.data=t},i.prototype.toBytes=function(){if(!this.type)throw new Error("Type for meta-event not specified.");var t=[];if(t.push.apply(t,this.time),t.push(255,this.type),Array.isArray(this.data))t.push(this.data.length),t.push.apply(t,this.data);else if("number"==typeof this.data)t.push(1,this.data);else if(null!==this.data&&void 0!==this.data){t.push(this.data.length);var e=this.data.split("").map(function(t){return t.charCodeAt(0)});t.push.apply(t,e)}else t.push(0);return t};var a=function(t){if(!this)return new a(t);var e=t||{};this.events=e.events||[]};a.START_BYTES=[77,84,114,107],a.END_BYTES=[0,255,47,0],a.prototype.addEvent=function(t){return this.events.push(t),this},a.prototype.addNoteOn=a.prototype.noteOn=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_ON,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNoteOff=a.prototype.noteOff=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_OFF,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNote=a.prototype.note=function(t,e,n,r,i){return this.noteOn(t,e,r,i),n&&this.noteOff(t,e,n,i),this},a.prototype.addChord=a.prototype.chord=function(t,e,n,r){if(!Array.isArray(e)&&!e.length)throw new Error("Chord must be an array of pitches");return e.forEach(function(e){this.noteOn(t,e,0,r)},this),e.forEach(function(e,r){0===r?this.noteOff(t,e,n):this.noteOff(t,e)},this),this},a.prototype.setInstrument=a.prototype.instrument=function(t,e,n){return this.events.push(new r({type:r.PROGRAM_CHANGE,channel:t,param1:e,time:n||0})),this},a.prototype.setTempo=a.prototype.tempo=function(t,e){return this.events.push(new i({type:i.TEMPO,data:n.mpqnFromBpm(t),time:e||0})),this},a.prototype.toBytes=function(){var t=0,e=[],r=a.START_BYTES,i=a.END_BYTES,o=function(n){var r=n.toBytes();t+=r.length,e.push.apply(e,r)};this.events.forEach(o),t+=i.length;var s=n.str2Bytes(t.toString(16),4);return r.concat(s,e,i)};var o=function(t){if(!this)return new o(t);var e=t||{};if(e.ticks){if("number"!=typeof e.ticks)throw new Error("Ticks per beat must be a number!");if(e.ticks<=0||e.ticks>=32768||e.ticks%1!=0)throw new Error("Ticks per beat must be an integer between 1 and 32767!")}this.ticks=e.ticks||128,this.tracks=e.tracks||[]};o.HDR_CHUNKID="MThd",o.HDR_CHUNK_SIZE="\0\0\0",o.HDR_TYPE0="\0\0",o.HDR_TYPE1="\0",o.prototype.addTrack=function(t){return t?(this.tracks.push(t),this):(t=new a,this.tracks.push(t),t)},o.prototype.toBytes=function(){var t=this.tracks.length.toString(16),e=o.HDR_CHUNKID+o.HDR_CHUNK_SIZE;return parseInt(t,16)>1?e+=o.HDR_TYPE1:e+=o.HDR_TYPE0,e+=n.codes2Str(n.str2Bytes(t,2)),e+=String.fromCharCode(this.ticks/256,this.ticks%256),this.tracks.forEach(function(t){e+=n.codes2Str(t.toBytes())}),e},t.Util=n,t.File=o,t.Track=a,t.Event=r,t.MetaEvent=i}(n),void 0!==t&&null!==t?t.exports=n:void 0!==e&&null!==e?e=n:this.Midi=n}).call(e,n(12)(t))},function(t,e){function n(t){function e(t){var e=t.read(4),n=t.readInt32();return{id:e,length:n,data:t.read(n)}}var n;stream=r(t);var i=e(stream);if("MThd"!=i.id||6!=i.length)throw"Bad .mid file - header not found";var a=r(i.data),o=a.readInt16(),s=a.readInt16(),u=a.readInt16();if(32768&u)throw"Expressing time division in SMTPE frames is not supported yet";ticksPerBeat=u;for(var c={formatType:o,trackCount:s,ticksPerBeat:ticksPerBeat},h=[],f=0;f<c.trackCount;f++){h[f]=[];var d=e(stream);if("MTrk"!=d.id)throw"Unexpected chunk - expected MTrk, got "+d.id;for(var l=r(d.data);!l.eof();){var p=function(t){var e={};e.deltaTime=t.readVarInt();var r=t.readInt8();if(240==(240&r)){if(255==r){e.type="meta";var i=t.readInt8(),a=t.readVarInt();switch(i){case 0:if(e.subtype="sequenceNumber",2!=a)throw"Expected length for sequenceNumber event is 2, got "+a;return e.number=t.readInt16(),e;case 1:return e.subtype="text",e.text=t.read(a),e;case 2:return e.subtype="copyrightNotice",e.text=t.read(a),e;case 3:return e.subtype="trackName",e.text=t.read(a),e;case 4:return e.subtype="instrumentName",e.text=t.read(a),e;case 5:return e.subtype="lyrics",e.text=t.read(a),e;case 6:return e.subtype="marker",e.text=t.read(a),e;case 7:return e.subtype="cuePoint",e.text=t.read(a),e;case 32:if(e.subtype="midiChannelPrefix",1!=a)throw"Expected length for midiChannelPrefix event is 1, got "+a;return e.channel=t.readInt8(),e;case 47:if(e.subtype="endOfTrack",0!=a)throw"Expected length for endOfTrack event is 0, got "+a;return e;case 81:if(e.subtype="setTempo",3!=a)throw"Expected length for setTempo event is 3, got "+a;return e.microsecondsPerBeat=(t.readInt8()<<16)+(t.readInt8()<<8)+t.readInt8(),e;case 84:if(e.subtype="smpteOffset",5!=a)throw"Expected length for smpteOffset event is 5, got "+a;var o=t.readInt8();return e.frameRate={0:24,32:25,64:29,96:30}[96&o],e.hour=31&o,e.min=t.readInt8(),e.sec=t.readInt8(),e.frame=t.readInt8(),e.subframe=t.readInt8(),e;case 88:if(e.subtype="timeSignature",4!=a)throw"Expected length for timeSignature event is 4, got "+a;return e.numerator=t.readInt8(),e.denominator=Math.pow(2,t.readInt8()),e.metronome=t.readInt8(),e.thirtyseconds=t.readInt8(),e;case 89:if(e.subtype="keySignature",2!=a)throw"Expected length for keySignature event is 2, got "+a;return e.key=t.readInt8(!0),e.scale=t.readInt8(),e;case 127:return e.subtype="sequencerSpecific",e.data=t.read(a),e;default:return e.subtype="unknown",e.data=t.read(a),e}return e.data=t.read(a),e}if(240==r){e.type="sysEx";var a=t.readVarInt();return e.data=t.read(a),e}if(247==r){e.type="dividedSysEx";var a=t.readVarInt();return e.data=t.read(a),e}throw"Unrecognised MIDI event type byte: "+r}var s;0==(128&r)?(s=r,r=n):(s=t.readInt8(),n=r);var u=r>>4;switch(e.channel=15&r,e.type="channel",u){case 8:return e.subtype="noteOff",e.noteNumber=s,e.velocity=t.readInt8(),e;case 9:return e.noteNumber=s,e.velocity=t.readInt8(),0==e.velocity?e.subtype="noteOff":e.subtype="noteOn",e;case 10:return e.subtype="noteAftertouch",e.noteNumber=s,e.amount=t.readInt8(),e;case 11:return e.subtype="controller",e.controllerType=s,e.value=t.readInt8(),e;case 12:return e.subtype="programChange",e.programNumber=s,e;case 13:return e.subtype="channelAftertouch",e.amount=s,e;case 14:return e.subtype="pitchBend",e.value=s+(t.readInt8()<<7),e;default:throw"Unrecognised MIDI event type: "+u}}(l);h[f].push(p)}}return{header:c,tracks:h}}function r(t){function e(e){var n=t.substr(s,e);return s+=e,n}function n(){var e=(t.charCodeAt(s)<<24)+(t.charCodeAt(s+1)<<16)+(t.charCodeAt(s+2)<<8)+t.charCodeAt(s+3);return s+=4,e}function r(){var e=(t.charCodeAt(s)<<8)+t.charCodeAt(s+1);return s+=2,e}function i(e){var n=t.charCodeAt(s);return e&&n>127&&(n-=256),s+=1,n}function a(){return s>=t.length}function o(){for(var t=0;;){var e=i();if(!(128&e))return t+e;t+=127&e,t<<=7}}var s=0;return{eof:a,read:e,readInt32:n,readInt16:r,readInt8:i,readVarInt:o}}t.exports=function(t){return n(t)}},function(t,e){t.exports=function(t){return t.webpackPolyfill||(t.deprecate=function(){},t.paths=[],t.children||(t.children=[]),Object.defineProperty(t,"loaded",{enumerable:!0,get:function(){return t.l}}),Object.defineProperty(t,"id",{enumerable:!0,get:function(){return t.i}}),t.webpackPolyfill=1),t}}])});
 
-},{}],265:[function(require,module,exports){
+},{}],289:[function(require,module,exports){
 'use strict'
 
 var ops = require('ndarray-ops')
@@ -42235,7 +44581,7 @@ function ndfft(dir, x, y) {
 }
 
 module.exports = ndfft
-},{"./lib/fft-matrix.js":266,"ndarray":270,"ndarray-ops":267,"typedarray-pool":301}],266:[function(require,module,exports){
+},{"./lib/fft-matrix.js":290,"ndarray":294,"ndarray-ops":291,"typedarray-pool":325}],290:[function(require,module,exports){
 var bits = require('bit-twiddle')
 
 function fft(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
@@ -42454,7 +44800,7 @@ function fftBluestein(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
   }
 }
 
-},{"bit-twiddle":251}],267:[function(require,module,exports){
+},{"bit-twiddle":275}],291:[function(require,module,exports){
 "use strict"
 
 var compile = require("cwise-compiler")
@@ -42917,7 +45263,7 @@ exports.equals = compile({
 
 
 
-},{"cwise-compiler":254}],268:[function(require,module,exports){
+},{"cwise-compiler":278}],292:[function(require,module,exports){
 "use strict"
 
 var fft = require("ndarray-fft")
@@ -43021,7 +45367,7 @@ function resample(out, inp, clamp_lo, clamp_hi) {
 }
 
 module.exports = resample
-},{"cwise/lib/wrapper":257,"ndarray-fft":265,"ndarray-ops":267,"ndarray-scratch":269}],269:[function(require,module,exports){
+},{"cwise/lib/wrapper":281,"ndarray-fft":289,"ndarray-ops":291,"ndarray-scratch":293}],293:[function(require,module,exports){
 "use strict"
 
 var ndarray = require("ndarray")
@@ -43129,7 +45475,7 @@ function eye(shape, dtype) {
 }
 exports.eye = eye
 
-},{"ndarray":270,"ndarray-ops":267,"typedarray-pool":301}],270:[function(require,module,exports){
+},{"ndarray":294,"ndarray-ops":291,"typedarray-pool":325}],294:[function(require,module,exports){
 var iota = require("iota-array")
 var isBuffer = require("is-buffer")
 
@@ -43474,7 +45820,7 @@ function wrappedNDArrayCtor(data, shape, stride, offset) {
 
 module.exports = wrappedNDArrayCtor
 
-},{"iota-array":262,"is-buffer":263}],271:[function(require,module,exports){
+},{"iota-array":286,"is-buffer":287}],295:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -43660,9 +46006,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],272:[function(require,module,exports){
+},{}],296:[function(require,module,exports){
 arguments[4][50][0].apply(exports,arguments)
-},{"./src/index-minimal":273,"dup":50}],273:[function(require,module,exports){
+},{"./src/index-minimal":297,"dup":50}],297:[function(require,module,exports){
 "use strict";
 var protobuf = exports;
 
@@ -43700,7 +46046,7 @@ function configure() {
 protobuf.Writer._configure(protobuf.BufferWriter);
 configure();
 
-},{"./reader":274,"./reader_buffer":275,"./roots":276,"./rpc":277,"./util/minimal":280,"./writer":281,"./writer_buffer":282}],274:[function(require,module,exports){
+},{"./reader":298,"./reader_buffer":299,"./roots":300,"./rpc":301,"./util/minimal":304,"./writer":305,"./writer_buffer":306}],298:[function(require,module,exports){
 "use strict";
 module.exports = Reader;
 
@@ -44109,17 +46455,17 @@ Reader._configure = function(BufferReader_) {
     });
 };
 
-},{"./util/minimal":280}],275:[function(require,module,exports){
+},{"./util/minimal":304}],299:[function(require,module,exports){
 arguments[4][53][0].apply(exports,arguments)
-},{"./reader":274,"./util/minimal":280,"dup":53}],276:[function(require,module,exports){
+},{"./reader":298,"./util/minimal":304,"dup":53}],300:[function(require,module,exports){
 arguments[4][54][0].apply(exports,arguments)
-},{"dup":54}],277:[function(require,module,exports){
+},{"dup":54}],301:[function(require,module,exports){
 arguments[4][55][0].apply(exports,arguments)
-},{"./rpc/service":278,"dup":55}],278:[function(require,module,exports){
+},{"./rpc/service":302,"dup":55}],302:[function(require,module,exports){
 arguments[4][56][0].apply(exports,arguments)
-},{"../util/minimal":280,"dup":56}],279:[function(require,module,exports){
+},{"../util/minimal":304,"dup":56}],303:[function(require,module,exports){
 arguments[4][57][0].apply(exports,arguments)
-},{"../util/minimal":280,"dup":57}],280:[function(require,module,exports){
+},{"../util/minimal":304,"dup":57}],304:[function(require,module,exports){
 (function (global){
 "use strict";
 var util = exports;
@@ -44528,11 +46874,11 @@ util._configure = function() {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./longbits":279,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],281:[function(require,module,exports){
+},{"./longbits":303,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],305:[function(require,module,exports){
 arguments[4][59][0].apply(exports,arguments)
-},{"./util/minimal":280,"dup":59}],282:[function(require,module,exports){
+},{"./util/minimal":304,"dup":59}],306:[function(require,module,exports){
 arguments[4][60][0].apply(exports,arguments)
-},{"./util/minimal":280,"./writer":281,"dup":60}],283:[function(require,module,exports){
+},{"./util/minimal":304,"./writer":305,"dup":60}],307:[function(require,module,exports){
 // A library of seedable RNGs implemented in Javascript.
 //
 // Usage:
@@ -44594,7 +46940,7 @@ sr.tychei = tychei;
 
 module.exports = sr;
 
-},{"./lib/alea":284,"./lib/tychei":285,"./lib/xor128":286,"./lib/xor4096":287,"./lib/xorshift7":288,"./lib/xorwow":289,"./seedrandom":290}],284:[function(require,module,exports){
+},{"./lib/alea":308,"./lib/tychei":309,"./lib/xor128":310,"./lib/xor4096":311,"./lib/xorshift7":312,"./lib/xorwow":313,"./seedrandom":314}],308:[function(require,module,exports){
 // A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
 // http://baagoe.com/en/RandomMusings/javascript/
 // https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
@@ -44710,7 +47056,7 @@ if (module && module.exports) {
 
 
 
-},{}],285:[function(require,module,exports){
+},{}],309:[function(require,module,exports){
 // A Javascript implementaion of the "Tyche-i" prng algorithm by
 // Samuel Neves and Filipe Araujo.
 // See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
@@ -44815,7 +47161,7 @@ if (module && module.exports) {
 
 
 
-},{}],286:[function(require,module,exports){
+},{}],310:[function(require,module,exports){
 // A Javascript implementaion of the "xor128" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44898,7 +47244,7 @@ if (module && module.exports) {
 
 
 
-},{}],287:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 // A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
 //
 // This fast non-cryptographic random number generator is designed for
@@ -45046,7 +47392,7 @@ if (module && module.exports) {
   (typeof define) == 'function' && define   // present with an AMD loader
 );
 
-},{}],288:[function(require,module,exports){
+},{}],312:[function(require,module,exports){
 // A Javascript implementaion of the "xorshift7" algorithm by
 // François Panneton and Pierre L'ecuyer:
 // "On the Xorgshift Random Number Generators"
@@ -45145,7 +47491,7 @@ if (module && module.exports) {
 );
 
 
-},{}],289:[function(require,module,exports){
+},{}],313:[function(require,module,exports){
 // A Javascript implementaion of the "xorwow" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -45233,7 +47579,7 @@ if (module && module.exports) {
 
 
 
-},{}],290:[function(require,module,exports){
+},{}],314:[function(require,module,exports){
 /*
 Copyright 2014 David Bau.
 
@@ -45482,7 +47828,7 @@ if ((typeof module) == 'object' && module.exports) {
   Math    // math: package containing random, pow, and seedrandom
 );
 
-},{"crypto":252}],291:[function(require,module,exports){
+},{"crypto":276}],315:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45638,7 +47984,7 @@ exports.unique = unique;
 exports.shuffle = shuffle;
 exports.permutations = permutations;
 
-},{"tonal-note":296}],292:[function(require,module,exports){
+},{"tonal-note":320}],316:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45830,7 +48176,7 @@ exports.supersets = supersets;
 exports.subsets = subsets;
 exports.tokenize = tokenize$1;
 
-},{"tonal-dictionary":293,"tonal-distance":294,"tonal-note":296,"tonal-pcset":297}],293:[function(require,module,exports){
+},{"tonal-dictionary":317,"tonal-distance":318,"tonal-note":320,"tonal-pcset":321}],317:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46202,7 +48548,7 @@ exports.scale = scale;
 exports.chord = chord;
 exports.pcset = pcset;
 
-},{"tonal-pcset":297}],294:[function(require,module,exports){
+},{"tonal-pcset":321}],318:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46481,7 +48827,7 @@ exports.subtract = subtract;
 exports.interval = interval;
 exports.semitones = semitones;
 
-},{"tonal-interval":295,"tonal-note":296}],295:[function(require,module,exports){
+},{"tonal-interval":319,"tonal-note":320}],319:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46822,7 +49168,7 @@ exports.simplify = simplify;
 exports.invert = invert;
 exports.fromSemitones = fromSemitones;
 
-},{}],296:[function(require,module,exports){
+},{}],320:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47237,7 +49583,7 @@ exports.fromMidi = fromMidi;
 exports.simplify = simplify;
 exports.enharmonic = enharmonic;
 
-},{}],297:[function(require,module,exports){
+},{}],321:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47466,7 +49812,7 @@ exports.isSupersetOf = isSupersetOf;
 exports.includes = includes;
 exports.filter = filter;
 
-},{"tonal-array":291,"tonal-interval":295,"tonal-note":296}],298:[function(require,module,exports){
+},{"tonal-array":315,"tonal-interval":319,"tonal-note":320}],322:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47703,7 +50049,7 @@ exports.toScale = toScale;
 exports.supersets = supersets;
 exports.subsets = subsets;
 
-},{"tonal-array":291,"tonal-dictionary":293,"tonal-distance":294,"tonal-note":296,"tonal-pcset":297}],299:[function(require,module,exports){
+},{"tonal-array":315,"tonal-dictionary":317,"tonal-distance":318,"tonal-note":320,"tonal-pcset":321}],323:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47841,7 +50187,7 @@ exports.freq = freq$1;
 exports.chord = chord$1;
 exports.scale = scale$1;
 
-},{"tonal-array":291,"tonal-chord":292,"tonal-dictionary":293,"tonal-distance":294,"tonal-interval":295,"tonal-note":296,"tonal-pcset":297,"tonal-scale":298}],300:[function(require,module,exports){
+},{"tonal-array":315,"tonal-chord":316,"tonal-dictionary":317,"tonal-distance":318,"tonal-interval":319,"tonal-note":320,"tonal-pcset":321,"tonal-scale":322}],324:[function(require,module,exports){
 (function(root, factory){
 
 	//UMD
@@ -72224,7 +74570,7 @@ exports.scale = scale$1;
 	
 	return Tone;
 }));
-},{}],301:[function(require,module,exports){
+},{}],325:[function(require,module,exports){
 (function (global,Buffer){
 'use strict'
 
@@ -72441,7 +74787,7 @@ exports.clearCache = function clearCache() {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"bit-twiddle":251,"buffer":253,"dup":258}],302:[function(require,module,exports){
+},{"bit-twiddle":275,"buffer":277,"dup":282}],326:[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -72500,7 +74846,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],303:[function(require,module,exports){
+},{}],327:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72548,7 +74894,7 @@ var BinaryCounter = (function (_super) {
 }(AuxiliaryInput));
 exports.BinaryCounter = BinaryCounter;
 
-},{"@tensorflow/tfjs-core":68}],304:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],328:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72742,7 +75088,7 @@ var PitchChordEncoder = (function (_super) {
 }(ChordEncoder));
 exports.PitchChordEncoder = PitchChordEncoder;
 
-},{"./constants":305,"@tensorflow/tfjs-core":68,"tonal":299}],305:[function(require,module,exports){
+},{"./constants":329,"@tensorflow/tfjs-core":68,"tonal":323}],329:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 null;
@@ -72770,7 +75116,7 @@ exports.HI_CLICK_PITCH = 90;
 exports.LO_CLICK_CLASS = 9;
 exports.HI_CLICK_CLASS = 10;
 
-},{}],306:[function(require,module,exports){
+},{}],330:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73342,7 +75688,7 @@ var MultitrackConverter = (function (_super) {
 }(DataConverter));
 exports.MultitrackConverter = MultitrackConverter;
 
-},{"../protobuf/index":322,"./constants":305,"./performance":310,"./sequences":313,"@tensorflow/tfjs-core":68}],307:[function(require,module,exports){
+},{"../protobuf/index":346,"./constants":329,"./performance":334,"./sequences":337,"@tensorflow/tfjs-core":68}],331:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -73367,7 +75713,7 @@ __export(require("./player"));
 __export(require("./recorder"));
 __export(require("./visualizer"));
 
-},{"./aux_inputs":303,"./chords":304,"./constants":305,"./data":306,"./logging":308,"./midi_io":309,"./performance":310,"./player":311,"./recorder":312,"./sequences":313,"./visualizer":315}],308:[function(require,module,exports){
+},{"./aux_inputs":327,"./chords":328,"./constants":329,"./data":330,"./logging":332,"./midi_io":333,"./performance":334,"./player":335,"./recorder":336,"./sequences":337,"./visualizer":339}],332:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Level;
@@ -73398,7 +75744,7 @@ function logWithDuration(msg, startTime, prefix, level) {
 }
 exports.logWithDuration = logWithDuration;
 
-},{}],309:[function(require,module,exports){
+},{}],333:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73544,7 +75890,7 @@ function sequenceProtoToMidi(ns) {
 }
 exports.sequenceProtoToMidi = sequenceProtoToMidi;
 
-},{"../protobuf":322,"./constants":305,"./sequences":313,"midiconvert":264}],310:[function(require,module,exports){
+},{"../protobuf":346,"./constants":329,"./sequences":337,"midiconvert":288}],334:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var index_1 = require("../protobuf/index");
@@ -73747,7 +76093,7 @@ var Performance = (function () {
 }());
 exports.Performance = Performance;
 
-},{"../protobuf/index":322,"./constants":305,"./sequences":313}],311:[function(require,module,exports){
+},{"../protobuf/index":346,"./constants":329,"./sequences":337}],335:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74159,7 +76505,7 @@ var PlayerWithClick = (function (_super) {
 }(Player));
 exports.PlayerWithClick = PlayerWithClick;
 
-},{".":307,"./constants":305,"./data":306,"./soundfont":314,"tone":300}],312:[function(require,module,exports){
+},{".":331,"./constants":329,"./data":330,"./soundfont":338,"tone":324}],336:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74385,7 +76731,7 @@ var Recorder = (function () {
 }());
 exports.Recorder = Recorder;
 
-},{"../protobuf":322,"./constants":305,"tone":300}],313:[function(require,module,exports){
+},{"../protobuf":346,"./constants":329,"tone":324}],337:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74656,7 +77002,7 @@ function mergeInstruments(ns) {
 }
 exports.mergeInstruments = mergeInstruments;
 
-},{"../protobuf/index":322,"./constants":305}],314:[function(require,module,exports){
+},{"../protobuf/index":346,"./constants":329}],338:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74914,7 +77260,7 @@ var SoundFont = (function () {
 }());
 exports.SoundFont = SoundFont;
 
-},{"./constants":305,"tone":300}],315:[function(require,module,exports){
+},{"./constants":329,"tone":324}],339:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require(".");
@@ -75006,7 +77352,7 @@ var Visualizer = (function () {
 }());
 exports.Visualizer = Visualizer;
 
-},{".":307,"./constants":305}],316:[function(require,module,exports){
+},{".":331,"./constants":329}],340:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -75020,7 +77366,7 @@ __export(require("./music_vae"));
 __export(require("./protobuf"));
 __export(require("./transcription"));
 
-},{"./core":307,"./music_rnn":318,"./music_vae":320,"./protobuf":322,"./transcription":326,"@tensorflow/tfjs":246}],317:[function(require,module,exports){
+},{"./core":331,"./music_rnn":342,"./music_vae":344,"./protobuf":346,"./transcription":350,"@tensorflow/tfjs":270}],341:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tf = require("@tensorflow/tfjs-core");
@@ -75084,13 +77430,13 @@ var AttentionWrapper = (function () {
 }());
 exports.AttentionWrapper = AttentionWrapper;
 
-},{"@tensorflow/tfjs-core":68}],318:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],342:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.MusicRNN = model_1.MusicRNN;
 
-},{"./model":319}],319:[function(require,module,exports){
+},{"./model":343}],343:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -75389,7 +77735,7 @@ var MusicRNN = (function () {
 }());
 exports.MusicRNN = MusicRNN;
 
-},{"../core/aux_inputs":303,"../core/chords":304,"../core/data":306,"../core/logging":308,"../core/sequences":313,"./attention":317,"@tensorflow/tfjs-core":68}],320:[function(require,module,exports){
+},{"../core/aux_inputs":327,"../core/chords":328,"../core/data":330,"../core/logging":332,"../core/sequences":337,"./attention":341,"@tensorflow/tfjs-core":68}],344:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
@@ -75397,7 +77743,7 @@ exports.Decoder = model_1.Decoder;
 exports.Encoder = model_1.Encoder;
 exports.MusicVAE = model_1.MusicVAE;
 
-},{"./model":321}],321:[function(require,module,exports){
+},{"./model":345}],345:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -76141,14 +78487,14 @@ var MusicVAE = (function () {
 }());
 exports.MusicVAE = MusicVAE;
 
-},{"../core/chords":304,"../core/constants":305,"../core/data":306,"../core/logging":308,"@tensorflow/tfjs-core":68}],322:[function(require,module,exports){
+},{"../core/chords":328,"../core/constants":329,"../core/data":330,"../core/logging":332,"@tensorflow/tfjs-core":68}],346:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var proto_1 = require("./proto");
 var NoteSequence = proto_1.tensorflow.magenta.NoteSequence;
 exports.NoteSequence = NoteSequence;
 
-},{"./proto":323}],323:[function(require,module,exports){
+},{"./proto":347}],347:[function(require,module,exports){
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
@@ -81859,7 +84205,7 @@ $root.tensorflow = (function() {
 
 module.exports = $root;
 
-},{"protobufjs/minimal":272}],324:[function(require,module,exports){
+},{"protobufjs/minimal":296}],348:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82238,7 +84584,7 @@ function max(arr) {
     return arr.reduce(function (a, b) { return Math.max(a, b); });
 }
 
-},{"../core/logging":308,"./constants":325,"fft.js":259,"ndarray":270,"ndarray-resample":268}],325:[function(require,module,exports){
+},{"../core/logging":332,"./constants":349,"fft.js":283,"ndarray":294,"ndarray-resample":292}],349:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SAMPLE_RATE = 16000;
@@ -82249,13 +84595,13 @@ exports.MIN_MIDI_PITCH = 21;
 exports.MAX_MIDI_PITCH = 108;
 exports.MIDI_PITCHES = exports.MAX_MIDI_PITCH - exports.MIN_MIDI_PITCH + 1;
 
-},{}],326:[function(require,module,exports){
+},{}],350:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.OnsetsAndFrames = model_1.OnsetsAndFrames;
 
-},{"./model":327}],327:[function(require,module,exports){
+},{"./model":351}],351:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82621,7 +84967,7 @@ var Lstm = (function () {
     return Lstm;
 }());
 
-},{"../core/logging":308,"./audio_utils":324,"./constants":325,"./transcription_utils":328,"@tensorflow/tfjs":246}],328:[function(require,module,exports){
+},{"../core/logging":332,"./audio_utils":348,"./constants":349,"./transcription_utils":352,"@tensorflow/tfjs":270}],352:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82791,4 +85137,4 @@ function pianorollToNoteSequence(frameProbs, onsetProbs, velocityValues, onsetTh
 }
 exports.pianorollToNoteSequence = pianorollToNoteSequence;
 
-},{"../protobuf":322,"./constants":325,"@tensorflow/tfjs":246}]},{},[2]);
+},{"../protobuf":346,"./constants":349,"@tensorflow/tfjs":270}]},{},[2]);

--- a/docs/music/demos/visualizer_bundle.js
+++ b/docs/music/demos/visualizer_bundle.js
@@ -418,7 +418,7 @@ function notesMatch(aNotes, bNotes) {
 }
 exports.notesMatch = notesMatch;
 
-},{"../src/index":314,"file-saver":258}],2:[function(require,module,exports){
+},{"../src/index":338,"file-saver":282}],2:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var mm = require("../src/index");
@@ -496,7 +496,7 @@ function startOrStop() {
     }
 }
 
-},{"../src/index":314,"./common":1}],3:[function(require,module,exports){
+},{"../src/index":338,"./common":1}],3:[function(require,module,exports){
 "use strict";
 module.exports = asPromise;
 
@@ -3246,7 +3246,7 @@ var FrozenModel = (function () {
         });
     };
     FrozenModel.prototype.predict = function (inputs, config) {
-        return this.execute(inputs, this.outputNodes);
+        return this.execute_(inputs, true, this.outputNodes);
     };
     FrozenModel.prototype.constructTensorMap = function (inputs) {
         var inputArray = inputs instanceof tfc.Tensor ? [inputs] : inputs;
@@ -3261,6 +3261,10 @@ var FrozenModel = (function () {
         }, {});
     };
     FrozenModel.prototype.execute = function (inputs, outputs) {
+        return this.execute_(inputs, false, outputs);
+    };
+    FrozenModel.prototype.execute_ = function (inputs, strictInputCheck, outputs) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         outputs = outputs || this.outputNodes;
         if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
             inputs = this.constructTensorMap(inputs);
@@ -3269,7 +3273,7 @@ var FrozenModel = (function () {
             throw new Error('The model contains control flow or dynamic shape ops, ' +
                 'please use executeAsync method');
         }
-        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), outputs);
+        var result = this.executor.execute(this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
         var keys = Object.keys(result);
         return (Array.isArray(outputs) && outputs.length > 1) ?
             outputs.map(function (node) { return result[node]; }) :
@@ -3383,8 +3387,9 @@ var execution_context_1 = require("./execution_context");
 var GraphExecutor = (function () {
     function GraphExecutor(graph) {
         this.graph = graph;
-        this.compiledOrder = [];
+        this.compiledMap = new Map();
         this._weightMap = {};
+        this.SEPERATOR = ',';
         this.placeholders = graph.placeholders;
         this._outputs = graph.outputs;
         this.compile();
@@ -3459,16 +3464,23 @@ var GraphExecutor = (function () {
         enumerable: true,
         configurable: true
     });
-    GraphExecutor.prototype.compile = function () {
+    GraphExecutor.prototype.compile = function (startNodes) {
         if (this.graph.withControlFlow || this.graph.withDynamicShape) {
             return;
         }
-        var stack = this.graph.inputs.slice();
+        var compiledOrder = [];
+        var inputs = startNodes || this.graph.placeholders;
+        var sortedNodeNames = inputs.map(function (node) { return node.name; }).sort();
+        var nameKey = sortedNodeNames.join(this.SEPERATOR);
+        if (this.compiledMap.get(nameKey)) {
+            return;
+        }
+        var stack = inputs.concat(this.graph.weights);
         var visited = {};
         while (stack.length > 0) {
             var node = stack.pop();
             visited[node.name] = true;
-            this.compiledOrder.push(node);
+            compiledOrder.push(node);
             node.children.forEach(function (childNode) {
                 if (!visited[childNode.name] && childNode.inputNames.every(function (name) {
                     var nodeName = utils_1.getNodeNameAndIndex(name)[0];
@@ -3478,19 +3490,33 @@ var GraphExecutor = (function () {
                 }
             });
         }
+        this.compiledMap.set(nameKey, compiledOrder);
     };
-    GraphExecutor.prototype.execute = function (inputs, outputs) {
+    GraphExecutor.prototype.execute = function (inputs, strictInputCheck, outputs) {
         var _this = this;
-        this.checkInput(inputs);
-        this.checkInputShapeAndType(inputs);
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
+        var names = Object.keys(inputs).sort();
+        this.checkInput(inputs, strictInputCheck);
+        this.checkInputShapeAndType(inputs, strictInputCheck);
+        this.compile(names.map(function (name) { return _this.graph.nodes[name]; }));
+        var outputNames = this.calculateOutputs(outputs);
+        this.checkOutput(this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
         var tensorArrayMap = {};
         var result = tfjs_core_1.tidy(function () {
             var context = new execution_context_1.ExecutionContext(_this._weightMap, tensorArrayMap);
-            var tensors = _this.compiledOrder.reduce(function (map, node) {
-                map[node.name] = operation_executor_1.executeOp(node, map, context);
-                return map;
-            }, __assign({}, _this.weightMap, inputs));
-            return _this.findOutputs(tensors, context, outputs);
+            var tensorMap = __assign({}, _this.weightMap, inputs);
+            var compiledNodes = _this.compiledMap.get(names.join(_this.SEPERATOR));
+            for (var i = 0; i < compiledNodes.length; i++) {
+                var node = compiledNodes[i];
+                if (!tensorMap[node.name]) {
+                    tensorMap[node.name] =
+                        operation_executor_1.executeOp(node, tensorMap, context);
+                }
+                if (outputNames.every(function (name) { return !!tensorMap[name]; })) {
+                    break;
+                }
+            }
+            return _this.findOutputs(tensorMap, context, outputNames);
         });
         return result;
     };
@@ -3501,8 +3527,8 @@ var GraphExecutor = (function () {
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        this.checkInput(inputs);
-                        this.checkInputShapeAndType(inputs);
+                        this.checkInput(inputs, false);
+                        this.checkInputShapeAndType(inputs, false);
                         tensorArrayMap = {};
                         context = new execution_context_1.ExecutionContext(this._weightMap, tensorArrayMap);
                         return [4, this.executeWithControlFlow(inputs, context)];
@@ -3529,11 +3555,14 @@ var GraphExecutor = (function () {
     };
     GraphExecutor.prototype.executeWithControlFlow = function (inputs, context) {
         return __awaiter(this, void 0, void 0, function () {
-            var stack, tensorMap, added, promises;
+            var _this = this;
+            var names, inputNodes, stack, tensorMap, added, promises;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        stack = this.graph.inputs.map(function (node) {
+                        names = Object.keys(inputs);
+                        inputNodes = names.map(function (name) { return _this.graph.nodes[name]; });
+                        stack = inputNodes.concat(this.graph.weights).map(function (node) {
                             return { node: node, contexts: context.currentContext };
                         });
                         tensorMap = __assign({}, this.weightMap, inputs);
@@ -3541,7 +3570,7 @@ var GraphExecutor = (function () {
                         _a.label = 1;
                     case 1:
                         if (!(stack.length > 0)) return [3, 3];
-                        promises = this.processStack(stack, context, tensorMap, added);
+                        promises = this.processStack(inputNodes, stack, context, tensorMap, added);
                         return [4, Promise.all(promises)];
                     case 2:
                         _a.sent();
@@ -3551,7 +3580,7 @@ var GraphExecutor = (function () {
             });
         });
     };
-    GraphExecutor.prototype.processStack = function (stack, context, tensorMap, added) {
+    GraphExecutor.prototype.processStack = function (inputNodes, stack, context, tensorMap, added) {
         var _this = this;
         var promises = [];
         var _loop_1 = function () {
@@ -3562,21 +3591,26 @@ var GraphExecutor = (function () {
                 utils_1.getParamValue('isConstant', item.node, tensorMap, context)) {
                 nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
             }
-            var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
-            if (!nodeName) {
-                nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
-            }
-            var currentContext = context.currentContext;
-            if (tensors instanceof Promise) {
-                promises.push(tensors.then(function (t) {
-                    tensorMap[nodeName] = t;
-                    context.currentContext = currentContext;
-                    _this.processChildNodes(item.node, stack, context, tensorMap, added);
-                    return t;
-                }));
+            if (inputNodes.indexOf(item.node) === -1) {
+                var tensors = operation_executor_1.executeOp(item.node, tensorMap, context);
+                if (!nodeName) {
+                    nodeName = utils_1.getNodeNameAndIndex(item.node.name, context)[0];
+                }
+                var currentContext_1 = context.currentContext;
+                if (tensors instanceof Promise) {
+                    promises.push(tensors.then(function (t) {
+                        tensorMap[nodeName] = t;
+                        context.currentContext = currentContext_1;
+                        _this.processChildNodes(item.node, stack, context, tensorMap, added);
+                        return t;
+                    }));
+                }
+                else {
+                    tensorMap[nodeName] = tensors;
+                    this_1.processChildNodes(item.node, stack, context, tensorMap, added);
+                }
             }
             else {
-                tensorMap[nodeName] = tensors;
                 this_1.processChildNodes(item.node, stack, context, tensorMap, added);
             }
         };
@@ -3607,11 +3641,14 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+    GraphExecutor.prototype.calculateOutputs = function (outputs) {
         if (outputs && !(outputs instanceof Array)) {
             outputs = [outputs];
         }
-        var requestedOutputs = (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+        return (outputs || this.graph.outputs.map(function (node) { return node.name; }));
+    };
+    GraphExecutor.prototype.findOutputs = function (tensorMap, context, outputs) {
+        var requestedOutputs = this.calculateOutputs(outputs);
         return requestedOutputs.reduce(function (map, name) {
             map[name] = utils_1.getTensor(name, tensorMap, context);
             return map;
@@ -3622,9 +3659,14 @@ var GraphExecutor = (function () {
         Object.keys(this.weightMap)
             .forEach(function (key) { return _this.weightMap[key].forEach(function (tensor) { return tensor.dispose(); }); });
     };
-    GraphExecutor.prototype.checkInputShapeAndType = function (inputs) {
+    GraphExecutor.prototype.checkInputShapeAndType = function (inputs, strictInputCheck) {
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         this.placeholders.forEach(function (node) {
-            var input = inputs[node.name][0];
+            var inputTensors = inputs[node.name];
+            if (!strictInputCheck && !inputTensors) {
+                return;
+            }
+            var input = inputTensors[0];
             if (node.params['shape'] && node.params['shape'].value) {
                 var shape_1 = node.params['shape'].value;
                 var match = shape_1.length === input.shape.length &&
@@ -3636,8 +3678,9 @@ var GraphExecutor = (function () {
             }
         });
     };
-    GraphExecutor.prototype.checkInput = function (inputs) {
+    GraphExecutor.prototype.checkInput = function (inputs, strictInputCheck) {
         var _this = this;
+        if (strictInputCheck === void 0) { strictInputCheck = true; }
         var inputKeys = Object.keys(inputs);
         var missing = [];
         var extra = [];
@@ -3649,14 +3692,31 @@ var GraphExecutor = (function () {
             if (_this.inputNodes.indexOf(name) === -1)
                 extra.push(name);
         });
-        if (missing.length > 0) {
+        var notInGraph = extra.filter(function (name) { return !_this.graph.nodes[name]; });
+        if (missing.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has the keys " +
                 ("[" + inputKeys + "], but is missing the required keys: [" + missing + "]."));
         }
-        if (extra.length > 0) {
+        if (extra.length > 0 && strictInputCheck) {
             throw new Error("The dict provided in model.execute(dict) has " +
                 ("unused keys: [" + extra + "]. Please provide only the following keys: ") +
                 ("[" + this.inputNodes + "]."));
+        }
+        if (notInGraph.length > 0) {
+            throw new Error("The dict provided in model.execute(dict) has " +
+                ("keys: [" + notInGraph + "] not part of model graph."));
+        }
+    };
+    GraphExecutor.prototype.checkOutput = function (compiledNodes, outputs) {
+        var compiledNodeNames = compiledNodes.map(function (node) { return node.name; });
+        var extra = [];
+        outputs.forEach(function (name) {
+            if (compiledNodeNames.indexOf(name) === -1)
+                extra.push(name);
+        });
+        if (extra.length > 0) {
+            throw new Error("The following outputs are not be generated by the execution: " +
+                ("[" + extra + "]."));
         }
     };
     return GraphExecutor;
@@ -4372,6 +4432,9 @@ exports.executeOp = function (node, tensorMap, context) {
             return [snapshot.clone()];
         case 'shape':
             return [tfc.tensor1d(utils_1.getParamValue('x', node, tensorMap, context).shape, 'int32')];
+        case 'shapeN':
+            return utils_1.getParamValue('x', node, tensorMap, context)
+                .map(function (t) { return tfc.tensor1d(t.shape); });
         case 'size':
             return [tfc.scalar(utils_1.getParamValue('x', node, tensorMap, context).size, 'int32')];
         case 'rank':
@@ -4414,6 +4477,15 @@ exports.executeOp = function (node, tensorMap, context) {
             var size = utils_1.getParamValue('size', node, tensorMap, context);
             var alignCorners = utils_1.getParamValue('alignCorners', node, tensorMap, context);
             return [tfc.image.resizeNearestNeighbor(images, [size[0], size[1]], alignCorners)];
+        }
+        case 'cropAndResize': {
+            var image = utils_1.getParamValue('image', node, tensorMap, context);
+            var boxes = utils_1.getParamValue('boxes', node, tensorMap, context);
+            var boxInd = utils_1.getParamValue('boxInd', node, tensorMap, context);
+            var cropSize = utils_1.getParamValue('cropSize', node, tensorMap, context);
+            var method = utils_1.getParamValue('method', node, tensorMap, context);
+            var extrapolationValue = utils_1.getParamValue('extrapolationValue', node, tensorMap, context);
+            return [tfc.image.cropAndResize(image, boxes, boxInd, cropSize, method, extrapolationValue)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4547,6 +4619,11 @@ exports.executeOp = function (node, tensorMap, context) {
         case 'argMin': {
             var axis = utils_1.getParamValue('axis', node, tensorMap, context);
             return [tfc.argMin(utils_1.getParamValue('x', node, tensorMap, context), axis)];
+        }
+        case 'prod': {
+            var axis = utils_1.getParamValue('axis', node, tensorMap, context);
+            var keepDims = utils_1.getParamValue('keepDims', node, tensorMap, context);
+            return [tfc.prod(utils_1.getParamValue('x', node, tensorMap, context), axis, keepDims)];
         }
         default:
             throw TypeError("Node type " + node.op + " is not implemented");
@@ -4903,6 +4980,20 @@ exports.json = [
     },
     {
         'tfOpName': 'Mod',
+        'dlOpName': 'mod',
+        'category': 'arithmetic',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'FloorMod',
         'dlOpName': 'mod',
         'category': 'arithmetic',
         'params': [
@@ -6062,6 +6153,17 @@ exports.json = [
         'params': [{ 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' }]
     },
     {
+        'tfOpName': 'ShapeN',
+        'dlOpName': 'shapeN',
+        'category': 'graph',
+        'params': [{
+                'tfInputIndex': 0,
+                'tfInputParamLength': 0,
+                'dlParamName': 'x',
+                'type': 'tensors'
+            }]
+    },
+    {
         'tfOpName': 'Print',
         'dlOpName': 'print',
         'category': 'graph',
@@ -6143,6 +6245,22 @@ exports.json = [
                 'dlParamName': 'dtype',
                 'type': 'dtype',
                 'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'CropAndResize',
+        'dlOpName': 'cropAndResize',
+        'category': 'image',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'image', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'boxes', 'type': 'tensor' },
+            { 'tfInputIndex': 2, 'dlParamName': 'boxInd', 'type': 'tensor' },
+            { 'tfInputIndex': 3, 'dlParamName': 'cropSize', 'type': 'number[]' },
+            { 'tfParamName': 'method', 'dlParamName': 'method', 'type': 'string' }, {
+                'tfParamName': 'extrapolation_value',
+                'dlParamName': 'extrapolationValue',
+                'type': 'number'
             }
         ]
     }
@@ -6312,6 +6430,32 @@ exports.json = [
             },
             {
                 'tfParamName': 'transpose_b',
+                'dlParamName': 'transposeB',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'T',
+                'dlParamName': 'dtype',
+                'type': 'dtype',
+                'notSupported': true
+            }
+        ]
+    },
+    {
+        'tfOpName': 'BatchMatMul',
+        'dlOpName': 'matMul',
+        'category': 'matrices',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor' }, {
+                'tfParamName': 'adj_x',
+                'dlParamName': 'transposeA',
+                'type': 'bool',
+                'defaultValue': false
+            },
+            {
+                'tfParamName': 'adj_y',
                 'dlParamName': 'transposeB',
                 'type': 'bool',
                 'defaultValue': false
@@ -6509,6 +6653,19 @@ exports.json = [
         'params': [
             { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
             { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number' }
+        ]
+    },
+    {
+        'tfOpName': 'Prod',
+        'dlOpName': 'prod',
+        'category': 'reduction',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'axis', 'type': 'number[]' }, {
+                'tfParamName': 'keep_dims',
+                'dlParamName': 'keepDims',
+                'type': 'bool'
+            }
         ]
     }
 ];
@@ -6717,6 +6874,21 @@ exports.json = [
                 'dlParamName': 'numOrSizeSplits',
                 'type': 'number',
                 'defaultValue': 1
+            }
+        ]
+    },
+    {
+        'tfOpName': 'SplitV',
+        'dlOpName': 'split',
+        'category': 'slice_join',
+        'params': [
+            { 'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor' },
+            { 'tfInputIndex': 1, 'dlParamName': 'numOrSizeSplits', 'type': 'number[]' },
+            {
+                'tfInputIndex': 2,
+                'dlParamName': 'axis',
+                'type': 'number',
+                'defaultValue': 0
             }
         ]
     }
@@ -6935,6 +7107,7 @@ var OperationMapper = (function () {
         var withControlFlow = false;
         var withDynamicShape = false;
         var placeholders = [];
+        var weights = [];
         var nodes = tfNodes.reduce(function (map, node) {
             map[node.name] = _this.mapNode(node);
             if (_this.isControlFlow(node))
@@ -6943,6 +7116,8 @@ var OperationMapper = (function () {
                 withDynamicShape = true;
             if (node.op === 'Placeholder')
                 placeholders.push(map[node.name]);
+            if (node.op === 'Const')
+                weights.push(map[node.name]);
             return map;
         }, {});
         var inputs = [];
@@ -6966,6 +7141,7 @@ var OperationMapper = (function () {
             nodes: nodes,
             inputs: inputs,
             outputs: outputs,
+            weights: weights,
             placeholders: placeholders,
             withControlFlow: withControlFlow,
             withDynamicShape: withDynamicShape
@@ -7103,7 +7279,7 @@ exports.OperationMapper = OperationMapper;
 },{"../data/compiled_api":10,"./executors/utils":31,"./op_list/arithmetic":32,"./op_list/basic_math":33,"./op_list/control":34,"./op_list/convolution":35,"./op_list/creation":36,"./op_list/dynamic":37,"./op_list/evaluation":38,"./op_list/graph":39,"./op_list/image":40,"./op_list/logical":41,"./op_list/matrices":42,"./op_list/normalization":43,"./op_list/reduction":44,"./op_list/slice_join":45,"./op_list/transformation":46}],49:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.5.9';
+var version = '0.6.5';
 exports.version = version;
 
 },{}],50:[function(require,module,exports){
@@ -9042,18 +9218,24 @@ var Engine = (function () {
         this.safeMode = safeMode;
         this.debugMode = debugMode;
         this.registeredVariables = {};
-        this.refCounter = new WeakMap();
         this.nextTapeNodeId = 0;
         this.numBytes = 0;
         this.numTensors = 0;
         this.numDataBuffers = 0;
+        this.profiling = false;
         this.gradientScopeCount = 0;
         this.customGradientDepth = 0;
         this.keepTensors = new Set();
+        this.tensorInfo = new WeakMap();
         this.activeScope = { track: [], name: 'default scope' };
         this.scopeStack = [this.activeScope];
         this.profiler = new profiler_1.Profiler(backend);
+        this.activeProfile =
+            { newBytes: 0, newTensors: 0, peakBytes: 0, kernels: [], result: null };
     }
+    Engine.prototype.moveData = function (dataId) {
+        this.write(dataId, this.readSync(dataId));
+    };
     Engine.prototype.tidy = function (nameOrFn, fn, gradMode) {
         var _this = this;
         if (gradMode === void 0) { gradMode = false; }
@@ -9105,6 +9287,8 @@ var Engine = (function () {
             return x;
         };
         var scopeName = this.activeScope.name;
+        var startingBytecount = this.numBytes;
+        var startingNumTensors = this.numTensors;
         this.scopedRun(function () { return _this.customGradientDepth++; }, function () { return _this.customGradientDepth--; }, function () {
             if (!_this.debugMode()) {
                 result = forwardFunc(_this.backend, saveFunc);
@@ -9126,10 +9310,25 @@ var Engine = (function () {
             }
             this.activeTape.push(tapeNode);
         }
+        if (this.profiling) {
+            this.activeProfile.kernels.push({
+                name: scopeName,
+                bytesAdded: this.numBytes - startingBytecount,
+                totalBytesSnapshot: this.numBytes,
+                tensorsAdded: this.numTensors - startingNumTensors,
+                totalTensorsSnapshot: this.numTensors,
+                inputShapes: Object.keys(inputs).map(function (key) { return inputs[key].shape; }),
+                outputShape: Array.isArray(result) ?
+                    result.map(function (item) { return item.shape; }) :
+                    result.shape
+            });
+        }
         return result;
     };
     Engine.prototype.registerTensor = function (a) {
-        var refCount = this.refCounter.has(a.dataId) ? this.refCounter.get(a.dataId) : 0;
+        var refCount = this.tensorInfo.has(a.dataId) ?
+            this.tensorInfo.get(a.dataId).refCount :
+            0;
         this.numTensors++;
         if (refCount === 0) {
             this.numDataBuffers++;
@@ -9137,9 +9336,10 @@ var Engine = (function () {
                 this.numBytes +=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.set(a.dataId, { backend: this.backend, dtype: a.dtype, shape: a.shape, refCount: 0 });
             this.backend.register(a.dataId, a.shape, a.dtype);
         }
-        this.refCounter.set(a.dataId, refCount + 1);
+        this.tensorInfo.get(a.dataId).refCount++;
         if (!(a instanceof tensor_1.Variable)) {
             this.track(a);
         }
@@ -9151,25 +9351,26 @@ var Engine = (function () {
         this.registeredVariables[v.name] = v;
     };
     Engine.prototype.disposeTensor = function (a) {
-        if (!this.refCounter.has(a.dataId)) {
+        if (!this.tensorInfo.has(a.dataId)) {
             return;
         }
         if (this.keepTensors.has(a.id)) {
             this.keepTensors.delete(a.id);
         }
         this.numTensors--;
-        var refCount = this.refCounter.get(a.dataId);
+        var refCount = this.tensorInfo.get(a.dataId).refCount;
         if (refCount <= 1) {
-            this.refCounter.delete(a.dataId);
-            this.backend.disposeData(a.dataId);
+            var info = this.tensorInfo.get(a.dataId);
+            info.backend.disposeData(a.dataId);
             this.numDataBuffers--;
             if (a.dtype !== 'complex64') {
                 this.numBytes -=
                     util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
             }
+            this.tensorInfo.delete(a.dataId);
         }
         else {
-            this.refCounter.set(a.dataId, refCount - 1);
+            this.tensorInfo.get(a.dataId).refCount--;
         }
     };
     Engine.prototype.disposeVariables = function () {
@@ -9185,6 +9386,23 @@ var Engine = (function () {
         info.numDataBuffers = this.numDataBuffers;
         info.numBytes = this.numBytes;
         return info;
+    };
+    Engine.prototype.profile = function (query) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startBytes, startNumTensors;
+            return __generator(this, function (_a) {
+                this.profiling = true;
+                startBytes = this.numBytes;
+                startNumTensors = this.numTensors;
+                this.activeProfile.kernels = [];
+                this.activeProfile.result = query();
+                this.profiling = false;
+                this.activeProfile.peakBytes = Math.max.apply(Math, this.activeProfile.kernels.map(function (d) { return d.totalBytesSnapshot; }));
+                this.activeProfile.newBytes = this.numBytes - startBytes;
+                this.activeProfile.newTensors = this.numTensors - startNumTensors;
+                return [2, this.activeProfile];
+            });
+        });
     };
     Engine.prototype.shouldRecord = function () {
         return this.activeTape != null && this.customGradientDepth === 0;
@@ -9330,13 +9548,21 @@ var Engine = (function () {
         };
     };
     Engine.prototype.write = function (dataId, values) {
+        var info = this.tensorInfo.get(dataId);
+        if (this.backend !== info.backend) {
+            info.backend.disposeData(dataId);
+            info.backend = this.backend;
+            this.backend.register(dataId, info.shape, info.dtype);
+        }
         this.backend.write(dataId, values);
     };
     Engine.prototype.readSync = function (dataId) {
-        return this.backend.readSync(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.readSync(dataId);
     };
     Engine.prototype.read = function (dataId) {
-        return this.backend.read(dataId);
+        var info = this.tensorInfo.get(dataId);
+        return info.backend.read(dataId);
     };
     Engine.prototype.fromPixels = function (pixels, numChannels) {
         return this.backend.fromPixels(pixels, numChannels);
@@ -9373,7 +9599,7 @@ function ones(shape) {
     return tensor_1.Tensor.make(shape, { values: values });
 }
 
-},{"./profiler":184,"./tape":186,"./tensor":187,"./tensor_util":189,"./util":194}],64:[function(require,module,exports){
+},{"./profiler":204,"./tape":206,"./tensor":207,"./tensor_util":209,"./util":214}],64:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -9389,7 +9615,6 @@ var TEST_EPSILON_FLOAT32 = 1e-3;
 var Environment = (function () {
     function Environment(features) {
         this.features = {};
-        this.engines = {};
         this.registry = {};
         if (features != null) {
             this.features = features;
@@ -9405,10 +9630,11 @@ var Environment = (function () {
         if (!(backendName in exports.ENV.registry)) {
             throw new Error("Backend name '" + backendName + "' not found in registry");
         }
-        exports.ENV.initBackend(backendName, safeMode);
+        exports.ENV.engine.backend = exports.ENV.findBackend(backendName);
+        exports.ENV.backendName = backendName;
     };
     Environment.getBackend = function () {
-        exports.ENV.initDefaultBackend();
+        exports.ENV.initEngine();
         return exports.ENV.backendName;
     };
     Environment.disposeVariables = function () {
@@ -9416,6 +9642,9 @@ var Environment = (function () {
     };
     Environment.memory = function () {
         return exports.ENV.engine.memory();
+    };
+    Environment.profile = function (f) {
+        return exports.ENV.engine.profile(f);
     };
     Environment.tidy = function (nameOrFn, fn, gradMode) {
         if (gradMode === void 0) { gradMode = false; }
@@ -9472,6 +9701,18 @@ var Environment = (function () {
         else if (feature === 'IS_CHROME') {
             return environment_util_1.isChrome();
         }
+        else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+            return false;
+        }
+        else if (feature === 'WEBGL_CONV_IM2COL') {
+            return false;
+        }
+        else if (feature === 'WEBGL_PAGING_ENABLED') {
+            return this.get('IS_BROWSER') && !this.get('PROD');
+        }
+        else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
+            return environment_util_1.getWebGLMaxTextureSize(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+        }
         else if (feature === 'IS_TEST') {
             return false;
         }
@@ -9481,9 +9722,6 @@ var Environment = (function () {
         else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
             var webGLVersion = this.get('WEBGL_VERSION');
             if (webGLVersion === 0) {
-                return 0;
-            }
-            if (webGLVersion > 0) {
                 return 0;
             }
             return environment_util_1.getWebGLDisjointQueryTimerVersion(webGLVersion, this.get('IS_BROWSER'));
@@ -9513,6 +9751,10 @@ var Environment = (function () {
         else if (feature === 'WEBGL_FENCE_API_ENABLED') {
             return environment_util_1.isWebGLFenceEnabled(this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
         }
+        else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
+            var useUniforms = this.get('WEBGL_RENDER_FLOAT32_ENABLED');
+            return useUniforms ? 4 : 0;
+        }
         else if (feature === 'TEST_EPSILON') {
             return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
                 TEST_EPSILON_FLOAT16;
@@ -9520,6 +9762,12 @@ var Environment = (function () {
         else if (feature === 'EPSILON') {
             return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
                 EPSILON_FLOAT16;
+        }
+        else if (feature === 'PROD') {
+            return false;
+        }
+        else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
+            return !this.get('PROD');
         }
         throw new Error("Unknown feature " + feature + ".");
     };
@@ -9530,20 +9778,6 @@ var Environment = (function () {
         this.features = environment_util_1.getFeaturesFromURL();
         if (this.globalEngine != null) {
             this.globalEngine = null;
-        }
-    };
-    Environment.prototype.initBackend = function (backendName, safeMode) {
-        var _this = this;
-        if (safeMode === void 0) { safeMode = false; }
-        this.backendName = backendName;
-        if (this.engines[backendName]) {
-            this.globalEngine = this.engines[backendName];
-        }
-        else {
-            var backend = this.findBackend(backendName);
-            this.globalEngine =
-                new engine_1.Engine(backend, safeMode, function () { return _this.get('DEBUG'); });
-            this.engines[backendName] = this.globalEngine;
         }
     };
     Object.defineProperty(Environment.prototype, "backend", {
@@ -9571,6 +9805,7 @@ var Environment = (function () {
         }
         try {
             var backend = factory();
+            backend.setDataMover({ moveData: function (dataId) { return _this.engine.moveData(dataId); } });
             this.registry[name] = { backend: backend, priority: priority };
             return true;
         }
@@ -9586,21 +9821,22 @@ var Environment = (function () {
         }
         this.registry[name].backend.dispose();
         delete this.registry[name];
-        if (name in this.engines) {
-            delete this.engines[name];
-        }
     };
     Object.defineProperty(Environment.prototype, "engine", {
         get: function () {
-            this.initDefaultBackend();
+            this.initEngine();
             return this.globalEngine;
         },
         enumerable: true,
         configurable: true
     });
-    Environment.prototype.initDefaultBackend = function () {
+    Environment.prototype.initEngine = function () {
+        var _this = this;
         if (this.globalEngine == null) {
-            this.initBackend(this.get('BACKEND'), false);
+            this.backendName = this.get('BACKEND');
+            var backend = this.findBackend(this.backendName);
+            this.globalEngine =
+                new engine_1.Engine(backend, false, function () { return _this.get('DEBUG'); });
         }
     };
     return Environment;
@@ -9630,7 +9866,7 @@ function getOrMakeEnvironment() {
 exports.ENV = getOrMakeEnvironment();
 
 }).call(this,require('_process'))
-},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":187,"./tensor_util":189,"_process":269}],65:[function(require,module,exports){
+},{"./device_util":62,"./engine":63,"./environment_util":65,"./tensor":207,"./tensor_util":209,"_process":293}],65:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Type;
@@ -9640,14 +9876,23 @@ var Type;
     Type[Type["STRING"] = 2] = "STRING";
 })(Type = exports.Type || (exports.Type = {}));
 exports.URL_PROPERTIES = [
-    { name: 'DEBUG', type: Type.BOOLEAN }, { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'DEBUG', type: Type.BOOLEAN },
+    { name: 'IS_BROWSER', type: Type.BOOLEAN },
+    { name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN },
+    { name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN },
+    { name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER },
+    { name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN },
     { name: 'WEBGL_VERSION', type: Type.NUMBER },
     { name: 'WEBGL_RENDER_FLOAT32_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_DOWNLOAD_FLOAT_ENABLED', type: Type.BOOLEAN },
     { name: 'WEBGL_FENCE_API_ENABLED', type: Type.BOOLEAN },
-    { name: 'BACKEND', type: Type.STRING }, { name: 'EPSILON', type: Type.NUMBER }
+    { name: 'WEBGL_SIZE_UPLOAD_UNIFORM', type: Type.NUMBER },
+    { name: 'BACKEND', type: Type.STRING },
+    { name: 'EPSILON', type: Type.NUMBER },
+    { name: 'PROD', type: Type.BOOLEAN },
+    { name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN },
 ];
 function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     var gl;
@@ -9664,6 +9909,15 @@ function isWebGLVersionEnabled(webGLVersion, isBrowser) {
     return false;
 }
 exports.isWebGLVersionEnabled = isWebGLVersionEnabled;
+var MAX_TEXTURE_SIZE;
+function getWebGLMaxTextureSize(webGLVersion, isBrowser) {
+    if (MAX_TEXTURE_SIZE == null) {
+        var gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+        MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    }
+    return MAX_TEXTURE_SIZE;
+}
+exports.getWebGLMaxTextureSize = getWebGLMaxTextureSize;
 function getWebGLDisjointQueryTimerVersion(webGLVersion, isBrowser) {
     if (webGLVersion === 0) {
         return 0;
@@ -9852,6 +10106,7 @@ exports.tidy = environment_1.Environment.tidy;
 exports.keep = environment_1.Environment.keep;
 exports.dispose = environment_1.Environment.dispose;
 exports.time = environment_1.Environment.time;
+exports.profile = environment_1.Environment.profile;
 
 },{"./environment":64,"./gradients":67}],67:[function(require,module,exports){
 "use strict";
@@ -9966,7 +10221,7 @@ function checkGrads(grads) {
     }
 }
 
-},{"./environment":64,"./tensor":187,"./util":194}],68:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],68:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -9981,6 +10236,8 @@ exports.environment = environment;
 var environment_1 = require("./environment");
 var io = require("./io/io");
 exports.io = io;
+var math = require("./math");
+exports.math = math;
 var serialization = require("./serialization");
 exports.serialization = serialization;
 var tensor_1 = require("./tensor");
@@ -10027,10 +10284,12 @@ exports.setBackend = environment_1.Environment.setBackend;
 exports.getBackend = environment_1.Environment.getBackend;
 exports.disposeVariables = environment_1.Environment.disposeVariables;
 exports.memory = environment_1.Environment.memory;
+var backend_1 = require("./kernels/backend");
+exports.DataStorage = backend_1.DataStorage;
 var ops = require("./ops/ops");
 tensor_1.setOpHandler(ops);
 
-},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend_cpu":80,"./kernels/backend_webgl":82,"./ops/loss_ops":150,"./ops/ops":157,"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer":180,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183,"./serialization":185,"./tensor":187,"./test_util":191,"./train":192,"./types":193,"./util":194,"./version":195,"./webgl":196}],69:[function(require,module,exports){
+},{"./browser_util":61,"./environment":64,"./globals":66,"./io/io":72,"./kernels/backend":80,"./kernels/backend_cpu":81,"./kernels/backend_webgl":83,"./math":145,"./ops/loss_ops":165,"./ops/ops":172,"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer":200,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203,"./serialization":205,"./tensor":207,"./test_util":211,"./train":212,"./types":213,"./util":214,"./version":215,"./webgl":216}],69:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10522,7 +10781,7 @@ function browserHTTPRequest(path, requestInit) {
 }
 exports.browserHTTPRequest = browserHTTPRequest;
 
-},{"../util":194,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./router_registry":77,"./weights_loader":79}],71:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11103,7 +11362,7 @@ function getModelArtifactsInfoForJSON(modelArtifacts) {
 exports.getModelArtifactsInfoForJSON = getModelArtifactsInfoForJSON;
 
 }).call(this,require("buffer").Buffer)
-},{"../ops/tensor_ops":171,"../util":194,"./types":78,"buffer":251}],74:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214,"./types":78,"buffer":275}],74:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11351,7 +11610,7 @@ if (environment_1.ENV.get('IS_BROWSER')) {
     }
 }
 
-},{"../environment":64,"../util":194,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
+},{"../environment":64,"../util":214,"./io_utils":73,"./model_management":75,"./router_registry":77}],75:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11555,7 +11814,7 @@ function moveModel(sourceURL, destURL) {
 }
 exports.moveModel = moveModel;
 
-},{"../util":194,"./router_registry":77}],76:[function(require,module,exports){
+},{"../util":214,"./router_registry":77}],76:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -11864,7 +12123,34 @@ function loadWeights(manifest, filePathPrefix, weightNames, requestOptions) {
 }
 exports.loadWeights = loadWeights;
 
-},{"../util":194,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+},{"../util":214,"./io_utils":73,"./types":78}],80:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var DataStorage = (function () {
+    function DataStorage(dataMover) {
+        this.dataMover = dataMover;
+        this.data = new WeakMap();
+    }
+    DataStorage.prototype.get = function (dataId) {
+        if (!this.data.has(dataId)) {
+            this.dataMover.moveData(dataId);
+        }
+        return this.data.get(dataId);
+    };
+    DataStorage.prototype.set = function (dataId, value) {
+        this.data.set(dataId, value);
+    };
+    DataStorage.prototype.has = function (dataId) {
+        return this.data.has(dataId);
+    };
+    DataStorage.prototype.delete = function (dataId) {
+        return this.data.delete(dataId);
+    };
+    return DataStorage;
+}());
+exports.DataStorage = DataStorage;
+
+},{}],81:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11910,14 +12196,17 @@ var axis_util = require("../ops/axis_util");
 var broadcast_util = require("../ops/broadcast_util");
 var concat_util = require("../ops/concat_util");
 var erf_util = require("../ops/erf_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var ops = require("../ops/ops");
 var ops_1 = require("../ops/ops");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var selu_util = require("../ops/selu_util");
 var slice_util_1 = require("../ops/slice_util");
 var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -11927,12 +12216,14 @@ var where_impl_1 = require("./where_impl");
 var MathBackendCPU = (function () {
     function MathBackendCPU() {
         this.blockSize = 48;
-        this.data = new WeakMap();
         this.firstUse = true;
         if (environment_1.ENV.get('IS_BROWSER')) {
             this.canvas = document.createElement('canvas');
         }
     }
+    MathBackendCPU.prototype.setDataMover = function (dataMover) {
+        this.data = new backend_1.DataStorage(dataMover);
+    };
     MathBackendCPU.prototype.register = function (dataId, shape, dtype) {
         if (this.firstUse) {
             this.firstUse = false;
@@ -11958,7 +12249,6 @@ var MathBackendCPU = (function () {
         if (values == null) {
             throw new Error('MathBackendCPU.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         this.data.get(dataId).values = values;
     };
     MathBackendCPU.prototype.fromPixels = function (pixels, numChannels) {
@@ -12021,7 +12311,6 @@ var MathBackendCPU = (function () {
         });
     };
     MathBackendCPU.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var _a = this.data.get(dataId), dtype = _a.dtype, complexTensors = _a.complexTensors;
         if (dtype === 'complex64') {
             var realValues = complexTensors.real.dataSync();
@@ -12055,13 +12344,6 @@ var MathBackendCPU = (function () {
         return {
             unreliable: true
         };
-    };
-    MathBackendCPU.prototype.throwIfNoData = function (dataId) {
-        if (!this.data.has(dataId)) {
-            throw new Error("CPU backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
     };
     MathBackendCPU.prototype.complex = function (real, imag) {
         var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
@@ -12282,6 +12564,24 @@ var MathBackendCPU = (function () {
                 sum += aVals[offset + j];
             }
             vals[i] = sum;
+        }
+        return result;
+    };
+    MathBackendCPU.prototype.prod = function (x, axes) {
+        this.assertNotComplex(x, 'sum');
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var resultDtype = types_1.upcastType(x.dtype, 'int32');
+        var result = ops.zeros(outShape, resultDtype);
+        var reduceSize = util.sizeFromShape(reduceShape);
+        var vals = result.dataSync();
+        var aVals = x.dataSync();
+        for (var i = 0; i < vals.length; ++i) {
+            var offset = i * reduceSize;
+            var prod = 1;
+            for (var j = 0; j < reduceSize; ++j) {
+                prod *= aVals[offset + j];
+            }
+            vals[i] = prod;
         }
         return result;
     };
@@ -12778,11 +13078,19 @@ var MathBackendCPU = (function () {
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
     MathBackendCPU.prototype.abs = function (x) {
-        this.assertNotComplex(x, 'abs');
         var resultValues = new Float32Array(x.size);
         var values = x.dataSync();
-        for (var i = 0; i < values.length; ++i) {
-            resultValues[i] = Math.abs(values[i]);
+        if (x.dtype === 'complex64') {
+            for (var i = 0; i < x.size; ++i) {
+                var real = values[i * 2];
+                var imag = values[i * 2 + 1];
+                resultValues[i] = Math.sqrt(real * real + imag * imag);
+            }
+        }
+        else {
+            for (var i = 0; i < values.length; ++i) {
+                resultValues[i] = Math.abs(values[i]);
+            }
         }
         return tensor_1.Tensor.make(x.shape, { values: resultValues });
     };
@@ -13341,8 +13649,10 @@ var MathBackendCPU = (function () {
         this.assertNotComplex(x, 'pool');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var y = ops.buffer(convInfo.outShape, 'float32');
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
@@ -13353,16 +13663,16 @@ var MathBackendCPU = (function () {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
                     var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
                         var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var minMaxValue = initialValue;
                         var avgValue = 0;
                         var count = 0;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var pixel = x.get(b, xR, xC, d);
                                 if ((poolType === 'max' && pixel > minMaxValue)) {
                                     minMaxValue = pixel;
@@ -13390,30 +13700,38 @@ var MathBackendCPU = (function () {
         var maxPositions = ops.buffer(convInfo.outShape, 'int32');
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
                 for (var yR = 0; yR < convInfo.outHeight; ++yR) {
                     var xRCorner = yR * strideHeight - padTop;
-                    var xRMin = Math.max(0, xRCorner);
-                    var xRMax = Math.min(convInfo.inHeight, filterHeight + xRCorner);
+                    var xRMin = xRCorner;
+                    while (xRMin < 0) {
+                        xRMin += dilationHeight;
+                    }
+                    var xRMax = Math.min(convInfo.inHeight, effectiveFilterHeight + xRCorner);
                     for (var yC = 0; yC < convInfo.outWidth; ++yC) {
                         var xCCorner = yC * strideWidth - padLeft;
-                        var xCMin = Math.max(0, xCCorner);
-                        var xCMax = Math.min(convInfo.inWidth, filterWidth + xCCorner);
+                        var xCMin = xCCorner;
+                        while (xCMin < 0) {
+                            xCMin += dilationWidth;
+                        }
+                        var xCMax = Math.min(convInfo.inWidth, effectiveFilterWidth + xCCorner);
                         var maxValue = Number.NEGATIVE_INFINITY;
                         var maxPosition = -1;
-                        for (var xR = xRMin; xR < xRMax; ++xR) {
+                        for (var xR = xRMin; xR < xRMax; xR += dilationHeight) {
                             var wR = xR - xRCorner;
-                            for (var xC = xCMin; xC < xCMax; ++xC) {
+                            for (var xC = xCMin; xC < xCMax; xC += dilationWidth) {
                                 var wC = xC - xCCorner;
                                 var pixel = x.get(b, xR, xC, d);
                                 if (pixel > maxValue) {
                                     maxValue = pixel;
-                                    maxPosition = wR * filterWidth + wC;
+                                    maxPosition = wR * effectiveFilterWidth + wC;
                                 }
                             }
                         }
@@ -13429,10 +13747,12 @@ var MathBackendCPU = (function () {
         var maxPositions = this.maxPoolPositions(x, convInfo);
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         for (var b = 0; b < convInfo.batchSize; ++b) {
             for (var d = 0; d < convInfo.inChannels; ++d) {
@@ -13441,21 +13761,21 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
                                     continue;
                                 }
-                                var maxPos = filterHeight * filterWidth - 1 -
-                                    maxPositions.get(b, dyR, dyC, d);
-                                var curPos = wR * filterWidth + wC;
+                                var maxPos = effectiveFilterHeight * effectiveFilterWidth -
+                                    1 - maxPositions.get(b, dyR, dyC, d);
+                                var curPos = wR * effectiveFilterWidth + wC;
                                 var mask = maxPos === curPos ? 1 : 0;
                                 if (mask === 0) {
                                     continue;
@@ -13477,8 +13797,12 @@ var MathBackendCPU = (function () {
         var strideWidth = convInfo.strideWidth;
         var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
         var dx = ops.buffer(x.shape, 'float32');
         var avgMultiplier = 1 / (filterHeight * filterWidth);
         for (var b = 0; b < convInfo.batchSize; ++b) {
@@ -13488,13 +13812,13 @@ var MathBackendCPU = (function () {
                         var dyRCorner = dxR - padTop;
                         var dyCCorner = dxC - padLeft;
                         var dotProd = 0;
-                        for (var wR = 0; wR < filterHeight; ++wR) {
+                        for (var wR = 0; wR < effectiveFilterHeight; wR += dilationHeight) {
                             var dyR = (dyRCorner + wR) / strideHeight;
                             if (dyR < 0 || dyR >= convInfo.outHeight ||
                                 Math.floor(dyR) !== dyR) {
                                 continue;
                             }
-                            for (var wC = 0; wC < filterWidth; ++wC) {
+                            for (var wC = 0; wC < effectiveFilterWidth; wC += dilationWidth) {
                                 var dyC = (dyCCorner + wC) / strideWidth;
                                 if (dyC < 0 || dyC >= convInfo.outWidth ||
                                     Math.floor(dyC) !== dyC) {
@@ -13524,7 +13848,8 @@ var MathBackendCPU = (function () {
     MathBackendCPU.prototype.resizeBilinear = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeBilinear');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var result = new Float32Array(util.sizeFromShape([batch, newHeight, newWidth, numChannels]));
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13533,37 +13858,46 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var outputIdx = 0;
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
         for (var b = 0; b < batch; b++) {
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceRowFloor = Math.floor(sourceFracRow);
+                var rowFrac = sourceFracRow - sourceRowFloor;
+                var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
+                var topRowOffset = b * x.strides[0] + sourceRowFloor * x.strides[1];
+                var botRowOffset = b * x.strides[0] + sourceRowCeil * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceColFloor = Math.floor(sourceFracCol);
+                    var colFrac = sourceFracCol - sourceColFloor;
+                    var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
+                    var topLeftOffest = topRowOffset + sourceColFloor * x.strides[2];
+                    var botLeftOffset = botRowOffset + sourceColFloor * x.strides[2];
+                    var topRightOffset = topRowOffset + +sourceColCeil * x.strides[2];
+                    var botRightOffest = botRowOffset + sourceColCeil * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceRowFloor = Math.floor(sourceFracRow);
-                        var sourceRowCeil = Math.min(oldHeight - 1, Math.ceil(sourceFracRow));
-                        var sourceColFloor = Math.floor(sourceFracCol);
-                        var sourceColCeil = Math.min(oldWidth - 1, Math.ceil(sourceFracCol));
-                        var topLeft = x.get(b, sourceRowFloor, sourceColFloor, d);
-                        var bottomLeft = x.get(b, sourceRowCeil, sourceColFloor, d);
-                        var topRight = x.get(b, sourceRowFloor, sourceColCeil, d);
-                        var bottomRight = x.get(b, sourceRowCeil, sourceColCeil, d);
-                        var rowFrac = sourceFracRow - sourceRowFloor;
-                        var colFrac = sourceFracCol - sourceColFloor;
+                        var topLeft = xValues[topLeftOffest + d];
+                        var bottomLeft = xValues[botLeftOffset + d];
+                        var topRight = xValues[topRightOffset + d];
+                        var bottomRight = xValues[botRightOffest + d];
                         var top_1 = topLeft + (topRight - topLeft) * colFrac;
                         var bottom = bottomLeft + (bottomRight - bottomLeft) * colFrac;
                         var newValue = top_1 + (bottom - top_1) * rowFrac;
-                        output.set(newValue, b, r, c, d);
+                        result[outputIdx++] = newValue;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(result, [batch, newHeight, newWidth, numChannels]);
     };
     MathBackendCPU.prototype.resizeBilinearBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeBilinearBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13574,11 +13908,16 @@ var MathBackendCPU = (function () {
         ];
         var heightScale = effectiveXSize[0] / effectiveYSize[0];
         var widthScale = effectiveXSize[1] / effectiveYSize[1];
+        var dyValues = dy.dataSync();
+        var offset = 0;
         for (var b = 0; b < batch; b++) {
+            var bOffset = b * x.strides[0];
             for (var r = 0; r < yHeight; r++) {
                 var dxR = r * heightScale;
                 var topDxRIndex = Math.floor(dxR);
                 var bottomDxRIndex = Math.min(Math.ceil(dxR), xHeight - 1);
+                var topDxROffset = bOffset + topDxRIndex * x.strides[1];
+                var bottomDxROffset = bOffset + bottomDxRIndex * x.strides[1];
                 var dxRLerp = dxR - topDxRIndex;
                 var inverseDxRLerp = 1.0 - dxRLerp;
                 for (var c = 0; c < yWidth; c++) {
@@ -13587,30 +13926,33 @@ var MathBackendCPU = (function () {
                     var rightDxCIndex = Math.min(Math.ceil(dxC), xWidth - 1);
                     var dxCLerp = dxC - leftDxCIndex;
                     var inverseDxCLerp = 1.0 - dxCLerp;
+                    var topLeftRCOffset = topDxROffset + leftDxCIndex * x.strides[2];
+                    var topRightRCOffset = topDxROffset + rightDxCIndex * x.strides[2];
+                    var bottomLeftRCOffset = bottomDxROffset + leftDxCIndex * x.strides[2];
+                    var bottomRightRCOffset = bottomDxROffset + rightDxCIndex * x.strides[2];
+                    var inverseDxRLerpTimesInverseDxCLerp = inverseDxRLerp * inverseDxCLerp;
+                    var inverseDxRLerpTimesDxCLerp = inverseDxRLerp * dxCLerp;
+                    var dxRLerpTimesInverseDxCLerp = dxRLerp * inverseDxCLerp;
+                    var dxRLerpTimesDxCLerp = dxRLerp * dxCLerp;
                     for (var d = 0; d < depth; d++) {
-                        var dyVal = dy.get(b, r, c, d);
-                        var topLeft = output.get(b, topDxRIndex, leftDxCIndex, d);
-                        topLeft += dyVal * inverseDxRLerp * inverseDxCLerp;
-                        output.set(topLeft, b, topDxRIndex, leftDxCIndex, d);
-                        var topRight = output.get(b, topDxRIndex, rightDxCIndex, d);
-                        topRight += dyVal * inverseDxRLerp * dxCLerp;
-                        output.set(topRight, b, topDxRIndex, rightDxCIndex, d);
-                        var bottomLeft = output.get(b, bottomDxRIndex, leftDxCIndex, d);
-                        bottomLeft += dyVal * dxRLerp * inverseDxCLerp;
-                        output.set(bottomLeft, b, bottomDxRIndex, leftDxCIndex, d);
-                        var bottomRight = output.get(b, bottomDxRIndex, rightDxCIndex, d);
-                        bottomRight += dyVal * dxRLerp * dxCLerp;
-                        output.set(bottomRight, b, bottomDxRIndex, rightDxCIndex, d);
+                        var dyVal = dyValues[offset++];
+                        output[topLeftRCOffset + d] +=
+                            dyVal * inverseDxRLerpTimesInverseDxCLerp;
+                        output[topRightRCOffset + d] += dyVal * inverseDxRLerpTimesDxCLerp;
+                        output[bottomLeftRCOffset + d] +=
+                            dyVal * dxRLerpTimesInverseDxCLerp;
+                        output[bottomRightRCOffset + d] += dyVal * dxRLerpTimesDxCLerp;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, [batch, xWidth, xHeight, depth], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighbor = function (x, newHeight, newWidth, alignCorners) {
         this.assertNotComplex(x, 'resizeNearestNeighbor');
         var _a = x.shape, batch = _a[0], oldHeight = _a[1], oldWidth = _a[2], numChannels = _a[3];
-        var output = ops.buffer([batch, newHeight, newWidth, numChannels], x.dtype);
+        var xValues = x.dataSync();
+        var output = new Float32Array(batch * newHeight * newWidth * numChannels);
         var effectiveInputSize = [
             (alignCorners && newHeight > 1) ? oldHeight - 1 : oldHeight,
             (alignCorners && newWidth > 1) ? oldWidth - 1 : oldWidth
@@ -13619,29 +13961,36 @@ var MathBackendCPU = (function () {
             (alignCorners && newHeight > 1) ? newHeight - 1 : newHeight,
             (alignCorners && newWidth > 1) ? newWidth - 1 : newWidth
         ];
+        var effectiveRowSizeRatio = effectiveInputSize[0] / effectiveOutputSize[0];
+        var effectiveColSizeRatio = effectiveInputSize[1] / effectiveOutputSize[1];
+        var outputOffset = 0;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < newHeight; r++) {
+                var sourceFracRow = effectiveRowSizeRatio * r;
+                var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                    Math.floor(sourceFracRow));
+                var rowOffset = batchOffset + sourceNearestRow * x.strides[1];
                 for (var c = 0; c < newWidth; c++) {
+                    var sourceFracCol = effectiveColSizeRatio * c;
+                    var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
+                        Math.floor(sourceFracCol));
+                    var colOffset = rowOffset + sourceNearestCol * x.strides[2];
                     for (var d = 0; d < numChannels; d++) {
-                        var sourceFracRow = (effectiveInputSize[0]) * r / (effectiveOutputSize[0]);
-                        var sourceFracCol = (effectiveInputSize[1]) * c / (effectiveOutputSize[1]);
-                        var sourceNearestRow = Math.min(oldHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                            Math.floor(sourceFracRow));
-                        var sourceNearestCol = Math.min(oldWidth - 1, alignCorners ? Math.round(sourceFracCol) :
-                            Math.floor(sourceFracCol));
-                        var newValue = x.get(b, sourceNearestRow, sourceNearestCol, d);
-                        output.set(newValue, b, r, c, d);
+                        var newVal = xValues[colOffset + d];
+                        output[outputOffset++] = newVal;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor(output, [batch, newHeight, newWidth, numChannels], x.dtype);
     };
     MathBackendCPU.prototype.resizeNearestNeighborBackprop = function (dy, x, alignCorners) {
         this.assertNotComplex([dy, x], 'resizeNearestNeighborBackprop');
         var _a = x.shape, batch = _a[0], xHeight = _a[1], xWidth = _a[2], depth = _a[3];
         var _b = dy.shape, yHeight = _b[1], yWidth = _b[2];
-        var output = ops.buffer([batch, xHeight, xWidth, depth], x.dtype);
+        var output = new Float32Array(batch * xHeight * xWidth * depth);
+        var dyValues = dy.dataSync();
         var effectiveXSize = [
             (alignCorners && yHeight > 1) ? xHeight - 1 : xHeight,
             (alignCorners && yWidth > 1) ? xWidth - 1 : xWidth
@@ -13657,41 +14006,49 @@ var MathBackendCPU = (function () {
         var winHeight = (Math.ceil(invHeightScale) * 2) + 2;
         var winWidth = (Math.ceil(invWidthScale) * 2) + 2;
         for (var b = 0; b < batch; b++) {
+            var batchOffset = b * x.strides[0];
             for (var r = 0; r < xHeight; r++) {
+                var rowOffset = batchOffset + r * x.strides[1];
+                var startRLerp = Math.floor(r * invHeightScale);
+                var startDyR = Math.floor(startRLerp - (winHeight / 2));
                 for (var c = 0; c < xWidth; c++) {
-                    var startRLerp = Math.floor(r * invHeightScale);
-                    var startDyR = Math.floor(startRLerp - (winHeight / 2));
+                    var colOffset = rowOffset + c * x.strides[2];
                     var startCLerp = Math.floor(c * invWidthScale);
                     var startDyC = Math.floor(startCLerp - (winWidth / 2));
                     for (var d = 0; d < depth; d++) {
                         var accum = 0;
-                        for (var dyROffset = 0; dyROffset < winHeight; dyROffset++) {
-                            var dyR = dyROffset + startDyR;
+                        for (var dyRIndex = 0; dyRIndex < winHeight; dyRIndex++) {
+                            var dyR = dyRIndex + startDyR;
                             if (dyR < 0 || dyR >= yHeight) {
                                 continue;
                             }
-                            for (var dyCOffSet = 0; dyCOffSet < winWidth; dyCOffSet++) {
-                                var dyC = dyCOffSet + startDyC;
+                            var dyROffset = batchOffset + dyR * dy.strides[1];
+                            var sourceFracRow = dyR * heightScale;
+                            var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
+                                Math.floor(sourceFracRow));
+                            if (r !== sourceNearestRow) {
+                                continue;
+                            }
+                            for (var dyCIndex = 0; dyCIndex < winWidth; dyCIndex++) {
+                                var dyC = dyCIndex + startDyC;
                                 if (dyC < 0 || dyC >= yWidth) {
                                     continue;
                                 }
-                                var sourceFracRow = effectiveXSize[0] * (dyR / effectiveYSize[0]);
-                                var sourceFracCol = effectiveXSize[1] * (dyC / effectiveYSize[1]);
-                                var sourceNearestRow = Math.min(xHeight - 1, alignCorners ? Math.round(sourceFracRow) :
-                                    Math.floor(sourceFracRow));
+                                var dyCOffset = dyROffset + dyC * dy.strides[2];
+                                var sourceFracCol = dyC * widthScale;
                                 var sourceNearestCol = Math.min(xWidth - 1, alignCorners ? Math.round(sourceFracCol) :
                                     Math.floor(sourceFracCol));
-                                if (r === sourceNearestRow && c === sourceNearestCol) {
-                                    accum += dy.get(b, dyR, dyC, d);
+                                if (c === sourceNearestCol) {
+                                    accum += dyValues[dyCOffset + d];
                                 }
                             }
                         }
-                        output.set(accum, b, r, c, d);
+                        output[colOffset + d] = accum;
                     }
                 }
             }
         }
-        return output.toTensor();
+        return ops.tensor4d(output, x.shape, x.dtype);
     };
     MathBackendCPU.prototype.batchNormalization = function (x, mean, variance, varianceEpsilon, scale, offset) {
         this.assertNotComplex([x, mean, variance, scale, offset], 'batchNormalization');
@@ -13831,6 +14188,61 @@ var MathBackendCPU = (function () {
         var scoresVals = scores.dataSync();
         return non_max_suppression_impl_1.nonMaxSuppressionImpl(boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
     };
+    MathBackendCPU.prototype.fft = function (input) {
+        if (input.shape[0] !== 1) {
+            throw new Error("tf.fft() on CPU only supports vectors.");
+        }
+        var input1D = input.as1D();
+        var n = input1D.size;
+        if (this.isExponentOf2(n)) {
+            return this.fftRadix2(input1D, n).as2D(input.shape[0], input.shape[1]);
+        }
+        else {
+            var data = input.dataSync();
+            var rawOutput = this.fourierTransformByMatmul(data, n);
+            var output = complex_util.splitRealAndImagArrays(rawOutput);
+            return ops.complex(output.real, output.imag)
+                .as2D(input.shape[0], input.shape[1]);
+        }
+    };
+    MathBackendCPU.prototype.isExponentOf2 = function (size) {
+        return (size & size - 1) === 0;
+    };
+    MathBackendCPU.prototype.fftRadix2 = function (input, size) {
+        if (size === 1) {
+            return input;
+        }
+        var data = input.dataSync();
+        var half = size / 2;
+        var evenComplex = complex_util.complexWithEvenIndex(data);
+        var evenTensor = ops.complex(evenComplex.real, evenComplex.imag).as1D();
+        var oddComplex = complex_util.complexWithOddIndex(data);
+        var oddTensor = ops.complex(oddComplex.real, oddComplex.imag).as1D();
+        evenTensor = this.fftRadix2(evenTensor, half);
+        oddTensor = this.fftRadix2(oddTensor, half);
+        var e = complex_util.exponents(size);
+        var exponent = ops.complex(e.real, e.imag).mul(oddTensor);
+        var addPart = evenTensor.add(exponent);
+        var subPart = evenTensor.sub(exponent);
+        var realTensor = ops.real(addPart).concat(ops.real(subPart));
+        var imagTensor = ops.imag(addPart).concat(ops.imag(subPart));
+        return ops.complex(realTensor, imagTensor).as1D();
+    };
+    MathBackendCPU.prototype.fourierTransformByMatmul = function (data, size) {
+        var ret = new Float32Array(size * 2);
+        for (var r = 0; r < size; r++) {
+            var real = 0.0;
+            var imag = 0.0;
+            for (var c = 0; c < size; c++) {
+                var e = complex_util.exponent(r * c, size);
+                var term = complex_util.getComplexWithIndex(data, c);
+                real += term.real * e.real - term.imag * e.imag;
+                imag += term.real * e.imag + term.imag * e.real;
+            }
+            complex_util.assignToTypedArray(ret, real, imag, r);
+        }
+        return ret;
+    };
     MathBackendCPU.prototype.depthToSpace = function (x, blockSize, dataFormat) {
         util.assert(dataFormat === 'NHWC', "Only NHWC dataFormat supported on CPU for depthToSpace. Got " + dataFormat);
         util.assert(blockSize > 1, "blockSize should be > 1 for depthToSpace, but was: " + blockSize);
@@ -13964,9 +14376,7 @@ var MathBackendCPU = (function () {
             var heightScale = (cropHeight > 1) ?
                 (y2 - y1) * (imageHeight - 1) / (cropHeight - 1) :
                 0;
-            var widthScale = (cropWidth > 1) ?
-                (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) :
-                0;
+            var widthScale = (cropWidth > 1) ? (x2 - x1) * (imageWidth - 1) / (cropWidth - 1) : 0;
             for (var y = 0; y < cropHeight; y++) {
                 var yInd = (cropHeight > 1) ?
                     y1 * (imageHeight - 1) + y * (heightScale) :
@@ -13974,8 +14384,7 @@ var MathBackendCPU = (function () {
                 if (yInd < 0 || yInd > imageHeight - 1) {
                     for (var x = 0; x < cropWidth; x++) {
                         for (var c = 0; c < numChannels; c++) {
-                            var ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = extrapolationValue;
                         }
                     }
@@ -13991,8 +14400,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14015,8 +14423,7 @@ var MathBackendCPU = (function () {
                             var bottomRight = imageVals[ind];
                             var top_2 = topLeft + (topRight - topLeft) * xLerp;
                             var bottom = bottomLeft + (bottomRight - bottomLeft) * xLerp;
-                            ind = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[ind] = top_2 + ((bottom - top_2) * yLerp);
                         }
                     }
@@ -14028,8 +14435,7 @@ var MathBackendCPU = (function () {
                             0.5 * (x1 + x2) * (imageWidth - 1);
                         if (xInd < 0 || xInd > imageWidth - 1) {
                             for (var c = 0; c < numChannels; c++) {
-                                var ind = c + x * outStride[2] + y * outStride[1] +
-                                    b * outStride[0];
+                                var ind = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                                 output.values[ind] = extrapolationValue;
                             }
                             continue;
@@ -14037,10 +14443,9 @@ var MathBackendCPU = (function () {
                         var closestX = Math.round(xInd);
                         var closestY = Math.round(yInd);
                         for (var c = 0; c < numChannels; c++) {
-                            var inInd = c + closestX * inStride[2]
-                                + closestY * inStride[1] + bInd * inStride[0];
-                            var outInd = c + x * outStride[2] + y * outStride[1] +
-                                b * outStride[0];
+                            var inInd = c + closestX * inStride[2] +
+                                closestY * inStride[1] + bInd * inStride[0];
+                            var outInd = c + x * outStride[2] + y * outStride[1] + b * outStride[0];
                             output.values[outInd] = imageVals[inInd];
                         }
                     }
@@ -14049,12 +14454,84 @@ var MathBackendCPU = (function () {
         }
         return output.toTensor();
     };
+    MathBackendCPU.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        return this.scatter(sparseIndices, sparseValues, outputShape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        if (numSlices === 0) {
+            return ops_1.tensor([], resultShape, x.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer([numSlices, sliceSize], x.dtype);
+        var indicesData = indices.dataSync();
+        var xData = x.dataSync();
+        for (var i = 0; i < numSlices; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                flattenIndex += dim * strides[j];
+                index.push(dim);
+            }
+            if (flattenIndex < 0 || flattenIndex >= x.size / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + x.shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                buffer.values[i * sliceSize + k] = xData[flattenIndex * sliceSize + k];
+            }
+        }
+        return buffer.toTensor().reshape(resultShape);
+    };
+    MathBackendCPU.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var defaultValue = ops_1.scalar(0);
+        var sumDupeIndices = true;
+        return this.scatter(indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices);
+    };
+    MathBackendCPU.prototype.scatter = function (indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank, strides, defaultValue, sumDupeIndices) {
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var indicesData = indices.dataSync();
+        var updatesData = updates.dataSync();
+        if (outputSize === 0) {
+            return ops_1.tensor([], shape, updates.dtype);
+        }
+        var buffer = new tensor_1.TensorBuffer(flattenShape, updates.dtype);
+        buffer.values.fill(defaultValue.dataSync()[0]);
+        for (var i = 0; i < numUpdates; i++) {
+            var index = [];
+            var flattenIndex = 0;
+            for (var j = 0; j < sliceRank; j++) {
+                var dim = indicesData[i * sliceRank + j];
+                index.push(dim);
+                flattenIndex += dim * strides[j];
+            }
+            if (flattenIndex < 0 || flattenIndex >= outputSize / sliceSize) {
+                throw new Error("Invalid indices: " + index + " does not index into " + shape);
+            }
+            for (var k = 0; k < sliceSize; k++) {
+                if (sumDupeIndices) {
+                    buffer.values[flattenIndex * sliceSize + k] +=
+                        updatesData[i * sliceSize + k];
+                }
+                else {
+                    buffer.values[flattenIndex * sliceSize + k] = updates.rank === 0 ?
+                        updatesData[0] :
+                        updatesData[i * sliceSize + k];
+                }
+            }
+        }
+        return buffer.toTensor().reshape(shape);
+    };
     return MathBackendCPU;
 }());
 exports.MathBackendCPU = MathBackendCPU;
 environment_1.ENV.registerBackend('cpu', function () { return new MathBackendCPU(); }, 1, tensor_1.setTensorTracker);
 
-},{"../environment":64,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/broadcast_util":139,"../ops/concat_util":143,"../ops/erf_util":146,"../ops/ops":157,"../ops/selu_util":166,"../ops/slice_util":168,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./where_impl":132,"seedrandom":281}],81:[function(require,module,exports){
+},{"../environment":64,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/broadcast_util":151,"../ops/concat_util":155,"../ops/erf_util":159,"../ops/gather_nd_util":161,"../ops/ops":172,"../ops/scatter_nd_util":180,"../ops/selu_util":183,"../ops/slice_util":185,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./where_impl":143,"seedrandom":305}],82:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -14100,7 +14577,7 @@ function reshapeTensor(x, shape) {
 }
 exports.reshapeTensor = reshapeTensor;
 
-},{"../ops/tensor_ops":171,"../tensor":187,"../util":194}],82:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../tensor":207,"../util":214}],83:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14144,7 +14621,9 @@ var log_1 = require("../log");
 var array_ops_util = require("../ops/array_ops_util");
 var axis_util = require("../ops/axis_util");
 var concat_util_1 = require("../ops/concat_util");
+var gather_nd_util = require("../ops/gather_nd_util");
 var reduce_util = require("../ops/reduce_util");
+var scatter_nd_util = require("../ops/scatter_nd_util");
 var segment_util = require("../ops/segment_util");
 var slice_util_1 = require("../ops/slice_util");
 var softmax_1 = require("../ops/softmax");
@@ -14153,6 +14632,7 @@ var tensor_1 = require("../tensor");
 var types_1 = require("../types");
 var util = require("../util");
 var util_1 = require("../util");
+var backend_1 = require("./backend");
 var backend_util = require("./backend_util");
 var complex_util_1 = require("./complex_util");
 var non_max_suppression_impl_1 = require("./non_max_suppression_impl");
@@ -14161,31 +14641,39 @@ var topk_impl_1 = require("./topk_impl");
 var argminmax_gpu_1 = require("./webgl/argminmax_gpu");
 var avg_pool_backprop_gpu_1 = require("./webgl/avg_pool_backprop_gpu");
 var batchnorm_gpu_1 = require("./webgl/batchnorm_gpu");
+var batchnorm_packed_gpu_1 = require("./webgl/batchnorm_packed_gpu");
 var binaryop_complex_gpu = require("./webgl/binaryop_complex_gpu");
 var binaryop_complex_gpu_1 = require("./webgl/binaryop_complex_gpu");
 var binaryop_gpu = require("./webgl/binaryop_gpu");
 var binaryop_gpu_1 = require("./webgl/binaryop_gpu");
 var clip_gpu_1 = require("./webgl/clip_gpu");
+var complex_abs_gpu_1 = require("./webgl/complex_abs_gpu");
 var concat_gpu_1 = require("./webgl/concat_gpu");
 var conv_backprop_gpu_1 = require("./webgl/conv_backprop_gpu");
 var conv_backprop_gpu_depthwise_1 = require("./webgl/conv_backprop_gpu_depthwise");
 var conv_gpu_1 = require("./webgl/conv_gpu");
-var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var conv_gpu_depthwise_1 = require("./webgl/conv_gpu_depthwise");
+var crop_and_resize_gpu_1 = require("./webgl/crop_and_resize_gpu");
 var cumsum_gpu_1 = require("./webgl/cumsum_gpu");
 var depth_to_space_gpu_1 = require("./webgl/depth_to_space_gpu");
 var encode_float_gpu_1 = require("./webgl/encode_float_gpu");
+var fft_gpu = require("./webgl/fft_gpu");
+var fft_gpu_1 = require("./webgl/fft_gpu");
 var from_pixels_gpu_1 = require("./webgl/from_pixels_gpu");
 var gather_gpu_1 = require("./webgl/gather_gpu");
+var gather_nd_gpu_1 = require("./webgl/gather_nd_gpu");
 var gpgpu_context_1 = require("./webgl/gpgpu_context");
 var gpgpu_math = require("./webgl/gpgpu_math");
 var gpgpu_util = require("./webgl/gpgpu_util");
+var im2col_gpu_1 = require("./webgl/im2col_gpu");
 var lrn_gpu_1 = require("./webgl/lrn_gpu");
 var lrn_grad_gpu_1 = require("./webgl/lrn_grad_gpu");
 var max_pool_backprop_gpu_1 = require("./webgl/max_pool_backprop_gpu");
 var mulmat_gpu_1 = require("./webgl/mulmat_gpu");
+var mulmat_packed_gpu_1 = require("./webgl/mulmat_packed_gpu");
 var multinomial_gpu_1 = require("./webgl/multinomial_gpu");
 var onehot_gpu_1 = require("./webgl/onehot_gpu");
+var pack_gpu_1 = require("./webgl/pack_gpu");
 var pad_gpu_1 = require("./webgl/pad_gpu");
 var pool_gpu_1 = require("./webgl/pool_gpu");
 var reduce_gpu_1 = require("./webgl/reduce_gpu");
@@ -14194,6 +14682,7 @@ var resize_bilinear_gpu_1 = require("./webgl/resize_bilinear_gpu");
 var resize_nearest_neighbor_backprop_gpu_1 = require("./webgl/resize_nearest_neighbor_backprop_gpu");
 var resize_nearest_neighbor_gpu_1 = require("./webgl/resize_nearest_neighbor_gpu");
 var reverse_gpu_1 = require("./webgl/reverse_gpu");
+var scatter_gpu_1 = require("./webgl/scatter_gpu");
 var segment_gpu_1 = require("./webgl/segment_gpu");
 var select_gpu_1 = require("./webgl/select_gpu");
 var slice_gpu_1 = require("./webgl/slice_gpu");
@@ -14204,16 +14693,16 @@ var tile_gpu_1 = require("./webgl/tile_gpu");
 var transpose_gpu_1 = require("./webgl/transpose_gpu");
 var unary_op = require("./webgl/unaryop_gpu");
 var unaryop_gpu_1 = require("./webgl/unaryop_gpu");
+var unpack_gpu_1 = require("./webgl/unpack_gpu");
 var webgl_util = require("./webgl/webgl_util");
 var where_impl_1 = require("./where_impl");
 var BEFORE_PAGING_CONSTANT = 300;
-exports.SIZE_UPLOAD_UNIFORM = 32;
+exports.SIZE_UPLOAD_UNIFORM = 4;
 var MathBackendWebGL = (function () {
     function MathBackendWebGL(gpgpu, delayedStorage) {
         if (delayedStorage === void 0) { delayedStorage = true; }
         this.gpgpu = gpgpu;
         this.delayedStorage = delayedStorage;
-        this.texData = new WeakMap();
         this.pendingRead = new WeakMap();
         this.pendingDisposal = new WeakSet();
         this.lruDataGPU = [];
@@ -14235,9 +14724,12 @@ var MathBackendWebGL = (function () {
         else {
             this.gpgpuCreatedLocally = false;
         }
-        this.NUM_BYTES_BEFORE_PAGING =
-            (window.screen.height * window.screen.width * window.devicePixelRatio) *
-                BEFORE_PAGING_CONSTANT;
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.NUM_BYTES_BEFORE_PAGING =
+                (window.screen.height * window.screen.width *
+                    window.devicePixelRatio) *
+                    BEFORE_PAGING_CONSTANT;
+        }
         this.textureManager = new texture_manager_1.TextureManager(this.gpgpu);
     }
     MathBackendWebGL.prototype.register = function (dataId, shape, dtype) {
@@ -14251,8 +14743,12 @@ var MathBackendWebGL = (function () {
             texture: null,
             complexTensors: null,
             texShape: null,
-            usage: tex_util_1.TextureUsage.RENDER
+            usage: tex_util_1.TextureUsage.RENDER,
+            isPacked: false
         });
+    };
+    MathBackendWebGL.prototype.setDataMover = function (dataMover) {
+        this.texData = new backend_1.DataStorage(dataMover);
     };
     MathBackendWebGL.prototype.fromPixels = function (pixels, numChannels) {
         if (pixels == null) {
@@ -14285,27 +14781,31 @@ var MathBackendWebGL = (function () {
             this.fromPixelsCanvas.getContext('2d').drawImage(pixels, 0, 0, pixels.width, pixels.height);
             pixels = this.fromPixelsCanvas;
         }
-        var tempPixelArray = tensor_1.Tensor.make(texShape, {}, 'int32');
-        this.texData.get(tempPixelArray.dataId).usage = tex_util_1.TextureUsage.PIXELS;
-        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelArray.dataId), pixels);
+        var tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
+        this.texData.get(tempPixelHandle.dataId).usage = tex_util_1.TextureUsage.PIXELS;
+        this.gpgpu.uploadPixelDataToTexture(this.getTexture(tempPixelHandle.dataId), pixels);
         var program = new from_pixels_gpu_1.FromPixelsProgram(outShape);
-        var res = this.compileAndRun(program, [tempPixelArray]);
-        tempPixelArray.dispose();
+        var res = this.compileAndRun(program, [tempPixelHandle]);
+        this.disposeData(tempPixelHandle.dataId);
         return res;
+    };
+    MathBackendWebGL.prototype.makeTensorHandle = function (shape, dtype) {
+        var dataId = {};
+        this.register(dataId, shape, dtype);
+        return { dataId: dataId, shape: shape, dtype: dtype };
     };
     MathBackendWebGL.prototype.write = function (dataId, values) {
         if (values == null) {
             throw new Error('MathBackendWebGL.write(): values can not be null');
         }
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype;
+        var texture = texData.texture, texShape = texData.texShape, usage = texData.usage, dtype = texData.dtype, isPacked = texData.isPacked;
         if (dtype === 'complex64') {
             throw new Error("Cannot write to a complex64 dtype. " +
                 "Please use tf.complex(real, imag).");
         }
         if (texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -14316,9 +14816,8 @@ var MathBackendWebGL = (function () {
         }
     };
     MathBackendWebGL.prototype.readSync = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype, complexTensors = texData.complexTensors;
+        var values = texData.values, dtype = texData.dtype, complexTensors = texData.complexTensors;
         if (values != null) {
             this.cacheOnCPU(dataId);
             return values;
@@ -14335,8 +14834,7 @@ var MathBackendWebGL = (function () {
             result = complex_util_1.mergeRealAndImagArrays(realValues, imagValues);
         }
         else {
-            result =
-                this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+            result = this.getValuesFromTexture(dataId);
         }
         if (shouldTimeProgram) {
             this.downloadWaitMs += performance.now() - start;
@@ -14346,7 +14844,7 @@ var MathBackendWebGL = (function () {
     };
     MathBackendWebGL.prototype.read = function (dataId) {
         return __awaiter(this, void 0, void 0, function () {
-            var subscribers_1, texData, shape, texture, values, texShape, dtype, bufferOrTexture, vals, subscribers;
+            var subscribers_1, texData, texture, values, texShape, bufferOrTexture, vals, subscribers;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14354,9 +14852,8 @@ var MathBackendWebGL = (function () {
                             subscribers_1 = this.pendingRead.get(dataId);
                             return [2, new Promise(function (resolve) { return subscribers_1.push(resolve); })];
                         }
-                        this.throwIfNoData(dataId);
                         texData = this.texData.get(dataId);
-                        shape = texData.shape, texture = texData.texture, values = texData.values, texShape = texData.texShape, dtype = texData.dtype;
+                        texture = texData.texture, values = texData.values, texShape = texData.texShape;
                         if (values != null) {
                             this.cacheOnCPU(dataId);
                             return [2, values];
@@ -14372,7 +14869,7 @@ var MathBackendWebGL = (function () {
                     case 1:
                         _a.sent();
                         if (bufferOrTexture instanceof WebGLTexture) {
-                            vals = this.getValuesFromTexture(texture, dataId, dtype, texShape, shape);
+                            vals = this.getValuesFromTexture(dataId);
                         }
                         else {
                             vals = this.gpgpu.downloadFloat32MatrixFromBuffer(bufferOrTexture, texShape[0], texShape[1]);
@@ -14390,25 +14887,33 @@ var MathBackendWebGL = (function () {
             });
         });
     };
-    MathBackendWebGL.prototype.getValuesFromTexture = function (texture, dataId, dtype, texShape, shape) {
+    MathBackendWebGL.prototype.getValuesFromTexture = function (dataId) {
+        var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype, texture = _a.texture, texShape = _a.texShape;
         if (environment_1.ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
-            return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            if (this.texData.get(dataId).isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                return this.gpgpu.downloadMatrixFromPackedTexture(texture, batch, rows, cols, texShape[0], texShape[1]);
+            }
+            else {
+                return this.gpgpu.downloadFloat32MatrixFromOutputTexture(texture, texShape[0], texShape[1]);
+            }
         }
-        var tmpTarget = tensor_1.Tensor.make(shape, {});
+        var tmpTarget = this.makeTensorHandle(shape, 'float32');
+        tmpTarget.size = util_1.sizeFromShape(shape);
         this.texData.get(tmpTarget.dataId).usage = tex_util_1.TextureUsage.DOWNLOAD;
-        var tmpInput = tensor_1.Tensor.make(shape, { dataId: dataId }, dtype);
         var program = new encode_float_gpu_1.EncodeFloatProgram(shape);
         var pageToCpu = false;
-        this.compileAndRun(program, [tmpInput], tmpTarget, null, pageToCpu);
+        this.compileAndRun(program, [{ shape: shape, dtype: dtype, dataId: dataId }], tmpTarget, null, pageToCpu);
         var tmpData = this.texData.get(tmpTarget.dataId);
         var vals = this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
-        tmpInput.dispose();
-        tmpTarget.dispose();
+        this.disposeData(tmpTarget.dataId);
         return vals;
     };
     MathBackendWebGL.prototype.time = function (f) {
         return __awaiter(this, void 0, void 0, function () {
-            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimers, kernelMs, res;
+            var oldActiveTimers, newActiveTimers, outerMostTime, flattenedActiveTimerQueries, flattenedActiveTimerNames, kernelMs, res;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -14424,22 +14929,26 @@ var MathBackendWebGL = (function () {
                         }
                         this.activeTimers = newActiveTimers;
                         f();
-                        flattenedActiveTimers = util.flatten(this.activeTimers);
+                        flattenedActiveTimerQueries = util.flatten(this.activeTimers.map(function (d) { return d.query; }))
+                            .filter(function (d) { return d != null; });
+                        flattenedActiveTimerNames = util.flatten(this.activeTimers.map(function (d) { return d.name; }))
+                            .filter(function (d) { return d != null; });
                         this.activeTimers = oldActiveTimers;
                         if (outerMostTime) {
                             this.programTimersStack = null;
                         }
-                        return [4, Promise.all(flattenedActiveTimers).then(function (results) {
-                                var sum = 0;
-                                results.forEach(function (result) { return sum += result; });
-                                return sum;
-                            })];
+                        return [4, Promise.all(flattenedActiveTimerQueries)];
                     case 1:
                         kernelMs = _a.sent();
                         res = {
                             uploadWaitMs: this.uploadWaitMs,
                             downloadWaitMs: this.downloadWaitMs,
-                            kernelMs: kernelMs,
+                            kernelMs: util.sum(kernelMs),
+                            getExtraProfileInfo: function () {
+                                return kernelMs.map(function (d, i) { return ({ name: flattenedActiveTimerNames[i], ms: d }); })
+                                    .map(function (d) { return d.name + ": " + d.ms; })
+                                    .join(', ');
+                            },
                             wallMs: null
                         };
                         this.uploadWaitMs = 0;
@@ -14487,9 +14996,9 @@ var MathBackendWebGL = (function () {
             return;
         }
         if (this.texData.has(dataId)) {
-            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors;
+            var _a = this.texData.get(dataId), texture = _a.texture, texShape = _a.texShape, usage = _a.usage, complexTensors = _a.complexTensors, isPacked = _a.isPacked;
             if (texture != null) {
-                this.releaseTexture(dataId, texture, texShape, usage);
+                this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             }
             if (complexTensors != null) {
                 complexTensors.real.dispose();
@@ -14509,7 +15018,7 @@ var MathBackendWebGL = (function () {
         return this.canvas;
     };
     MathBackendWebGL.prototype.complex = function (real, imag) {
-        var result = tensor_1.Tensor.make(real.shape, {}, 'complex64');
+        var result = this.makeOutputArray(real.shape, 'complex64');
         var resultData = this.texData.get(result.dataId);
         resultData.complexTensors = {
             real: environment_1.ENV.engine.keep(real.clone()),
@@ -14566,8 +15075,18 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.batchMatMul = function (a, b, transposeA, transposeB) {
-        var program = new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-        return this.compileAndRun(program, [a, b]);
+        var outerShapeA = transposeA ? a.shape[2] : a.shape[1];
+        var outerShapeB = transposeB ? b.shape[1] : b.shape[2];
+        if (a.shape[0] === 1 && b.shape[0] === 1) {
+            var aSqueezed = a.as2D(a.shape[1], a.shape[2]);
+            var bSqueezed = b.as2D(b.shape[1], b.shape[2]);
+            var program = new mulmat_packed_gpu_1.MatMulPackedProgram(aSqueezed.shape, bSqueezed.shape, [outerShapeA, outerShapeB], transposeA, transposeB);
+            var result = this.unpackTensor(this.compileAndRun(program, [aSqueezed, bSqueezed], this.makePackedTensor(program.outputShape)));
+            return result.reshape([1, result.shape[0], result.shape[1]]);
+        }
+        else {
+            return this.compileAndRun(new mulmat_gpu_1.MatMulProgram(a.shape, b.shape, transposeA, transposeB), [a, b]);
+        }
     };
     MathBackendWebGL.prototype.multiply = function (a, b) {
         if (a.dtype === 'complex64') {
@@ -14604,8 +15123,14 @@ var MathBackendWebGL = (function () {
             scaleShape = scale.shape;
             inputs.push(scale);
         }
-        var program = new batchnorm_gpu_1.BatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
-        return this.compileAndRun(program, inputs);
+        var output = null;
+        var envSpecificBatchNormProgram = batchnorm_gpu_1.BatchNormProgram;
+        if (environment_1.ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
+            output = this.makePackedTensor(x.shape);
+            envSpecificBatchNormProgram = batchnorm_packed_gpu_1.BatchNormPackedProgram;
+        }
+        var program = new envSpecificBatchNormProgram(x.shape, mean.shape, variance.shape, offsetShape, scaleShape, varianceEpsilon);
+        return this.compileAndRun(program, inputs, output);
     };
     MathBackendWebGL.prototype.localResponseNormalization4D = function (x, radius, bias, alpha, beta) {
         var program = new lrn_gpu_1.LRNProgram(x.shape, radius, bias, alpha, beta);
@@ -14704,6 +15229,13 @@ var MathBackendWebGL = (function () {
         var a2D = x.as2D(-1, inSize);
         var outputDType = types_1.sumOutType(x.dtype);
         return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+    };
+    MathBackendWebGL.prototype.prod = function (x, axes) {
+        var _a = axis_util.computeOutAndReduceShapes(x.shape, axes), outShape = _a[0], reduceShape = _a[1];
+        var inSize = util.sizeFromShape(reduceShape);
+        var a2D = x.as2D(-1, inSize);
+        var outputDType = types_1.sumOutType(x.dtype);
+        return this.reduce(a2D, 'prod', outputDType).reshape(outShape);
     };
     MathBackendWebGL.prototype.unsortedSegmentSum = function (x, segmentIds, numSegments) {
         var axis = 0;
@@ -15012,6 +15544,15 @@ var MathBackendWebGL = (function () {
         return this.compileAndRun(program, [x]);
     };
     MathBackendWebGL.prototype.abs = function (x) {
+        if (x.dtype === 'complex64') {
+            var xData = this.texData.get(x.dataId);
+            var program_1 = new complex_abs_gpu_1.ComplexAbsProgram(x.shape);
+            var inputs = [
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+                this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+            ];
+            return this.compileAndRun(program_1, inputs);
+        }
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.ABS);
         return this.compileAndRun(program, [x]);
     };
@@ -15085,7 +15626,23 @@ var MathBackendWebGL = (function () {
         var program = new unaryop_gpu_1.UnaryOpProgram(x.shape, unary_op.STEP(alpha));
         return this.compileAndRun(program, [x]);
     };
+    MathBackendWebGL.prototype.conv2dWithIm2Row = function (x, filter, convInfo) {
+        var filterWidth = convInfo.filterWidth, filterHeight = convInfo.filterHeight, inChannels = convInfo.inChannels, outWidth = convInfo.outWidth, outHeight = convInfo.outHeight;
+        var sharedDim = filterWidth * filterHeight * inChannels;
+        var numCols = outHeight * outWidth;
+        var x2ColShape = [sharedDim, numCols];
+        var xSqueezed = x.squeeze([0]);
+        var w2Row = filter.reshape([sharedDim, -1]);
+        var im2ColProgram = new im2col_gpu_1.Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
+        var im2Col = this.compileAndRun(im2ColProgram, [xSqueezed], this.makePackedTensor(x2ColShape));
+        var matmulProgram = new mulmat_packed_gpu_1.MatMulPackedProgram(im2Col.shape, w2Row.shape, [numCols, convInfo.outChannels], true, false);
+        var product = this.unpackTensor(this.compileAndRun(matmulProgram, [im2Col, w2Row], this.makePackedTensor(matmulProgram.outputShape)));
+        return product.reshape([1, outHeight, outWidth, convInfo.outChannels]);
+    };
     MathBackendWebGL.prototype.conv2d = function (x, filter, convInfo) {
+        if (environment_1.ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
+            return this.conv2dWithIm2Row(x, filter, convInfo);
+        }
         var program = new conv_gpu_1.Conv2DProgram(convInfo);
         return this.compileAndRun(program, [x, filter]);
     };
@@ -15198,14 +15755,69 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.split = function (x, sizeSplits, axis) {
         return split_shared_1.split(x, sizeSplits, axis);
     };
+    MathBackendWebGL.prototype.scatterND = function (indices, updates, shape) {
+        var _a = scatter_nd_util.calculateShapes(updates, indices, shape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, sliceSize = _a.sliceSize, strides = _a.strides, outputSize = _a.outputSize;
+        var flattenShape = [outputSize / sliceSize, sliceSize];
+        var flattenIndices = indices.reshape([numUpdates, sliceRank]);
+        var flattenX = updates.reshape([numUpdates, sliceSize]);
+        if (outputSize === 0) {
+            return backend_util.reshapeTensor(tensor_ops_1.tensor([]), shape);
+        }
+        var defaultValue = tensor_ops_1.scalar(0);
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, flattenIndices.rank, flattenX.rank, strides, flattenShape);
+        return this.compileAndRun(program, [flattenX, flattenIndices, defaultValue])
+            .reshape(shape);
+    };
+    MathBackendWebGL.prototype.sparseToDense = function (sparseIndices, sparseValues, outputShape, defaultValue) {
+        var _a = scatter_nd_util.calculateShapes(sparseValues, sparseIndices, outputShape), sliceRank = _a.sliceRank, numUpdates = _a.numUpdates, strides = _a.strides, outputSize = _a.outputSize;
+        var sumDupeIndices = false;
+        var program = new scatter_gpu_1.ScatterProgram(numUpdates, sliceRank, sparseIndices.rank, sparseValues.rank, strides, [outputSize, 1], sumDupeIndices);
+        return this.compileAndRun(program, [sparseValues, sparseIndices, defaultValue])
+            .reshape(outputShape);
+    };
+    MathBackendWebGL.prototype.fft = function (x) {
+        var xData = this.texData.get(x.dataId);
+        var realProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
+        var imagProgram = new fft_gpu_1.FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+        var inputs = [
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+            this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+        ];
+        var real = this.compileAndRun(realProgram, inputs);
+        var imag = this.compileAndRun(imagProgram, inputs);
+        var complex = this.complex(real, imag).as2D(x.shape[0], x.shape[1]);
+        real.dispose();
+        imag.dispose();
+        return complex;
+    };
+    MathBackendWebGL.prototype.gatherND = function (x, indices) {
+        var indicesShape = indices.shape;
+        var sliceRank = indicesShape[indicesShape.length - 1];
+        var _a = gather_nd_util.prepareAndValidate(x, indices), resultShape = _a[0], numSlices = _a[1], sliceSize = _a[2], strides = _a[3];
+        var flattenIndices = indices.reshape([numSlices, sliceRank]);
+        var flattenX = x.reshape([x.size / sliceSize, sliceSize]);
+        var program = new gather_nd_gpu_1.GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+        return this.compileAndRun(program, [flattenX, flattenIndices])
+            .reshape(resultShape);
+    };
     MathBackendWebGL.prototype.makeOutputArray = function (shape, dtype) {
         return tensor_1.Tensor.make(shape, {}, dtype);
+    };
+    MathBackendWebGL.prototype.makePackedTensor = function (shape) {
+        var packedTensor = tensor_1.Tensor.make(shape, {});
+        this.texData.get(packedTensor.dataId).isPacked = true;
+        return packedTensor;
+    };
+    MathBackendWebGL.prototype.unpackTensor = function (input) {
+        var program = new unpack_gpu_1.UnpackProgram(input.shape);
+        return this.compileAndRun(program, [input]);
     };
     MathBackendWebGL.prototype.compileAndRun = function (program, inputs, output, customSetup, pageToCpu) {
         var _this = this;
         if (pageToCpu === void 0) { pageToCpu = true; }
         if (output == null) {
-            output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+            output =
+                this.makeOutputArray(program.outputShape, inputs[0].dtype);
         }
         if (output.size === 0) {
             this.texData.get(output.dataId).values =
@@ -15220,13 +15832,29 @@ var MathBackendWebGL = (function () {
             }
             var texData = _this.texData.get(input.dataId);
             if (texData.texture == null &&
-                util.sizeFromShape(input.shape) <= exports.SIZE_UPLOAD_UNIFORM) {
+                !(!texData.isPacked && program.usesPackedTextures) &&
+                util.sizeFromShape(input.shape) <=
+                    environment_1.ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
                 return {
                     shape: input.shape,
                     texData: null,
                     isUniform: true,
                     uniformValues: _this.readSync(input.dataId)
                 };
+            }
+            if (texData.isPacked !== !!program.usesPackedTextures) {
+                var preProcessProgram = void 0;
+                var processedInput = void 0;
+                if (texData.isPacked) {
+                    preProcessProgram = new unpack_gpu_1.UnpackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input]);
+                }
+                else {
+                    preProcessProgram = new pack_gpu_1.PackProgram(input.shape);
+                    processedInput = _this.compileAndRun(preProcessProgram, [input], _this.makePackedTensor(input.shape));
+                }
+                texData = _this.texData.get(processedInput.dataId);
+                input = processedInput;
             }
             _this.uploadToGPU(input.dataId);
             return { shape: input.shape, texData: texData, isUniform: false };
@@ -15247,7 +15875,8 @@ var MathBackendWebGL = (function () {
             query = this.startTimer();
         }
         gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-        if (pageToCpu && this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED') && pageToCpu &&
+            this.numBytesInGPU > this.NUM_BYTES_BEFORE_PAGING) {
             var numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
             while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
                 var dataId = this.lruDataGPU.shift();
@@ -15258,7 +15887,7 @@ var MathBackendWebGL = (function () {
         }
         if (shouldTimeProgram) {
             query = this.endTimer(query);
-            this.activeTimers.push(this.getQueryTime(query));
+            this.activeTimers.push({ name: program.constructor.name, query: this.getQueryTime(query) });
         }
         return output;
     };
@@ -15297,22 +15926,16 @@ var MathBackendWebGL = (function () {
             return 16;
         });
     };
-    MathBackendWebGL.prototype.throwIfNoData = function (dataId) {
-        if (!this.texData.has(dataId)) {
-            throw new Error("WebGL backend: No data found for this tensor. " +
-                "Did you change your backend in the middle of the program? " +
-                "New backends can't use Tensors created with previous backends");
-        }
-    };
     MathBackendWebGL.prototype.uploadToGPU = function (dataId) {
-        this.throwIfNoData(dataId);
         var texData = this.texData.get(dataId);
-        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage;
+        var shape = texData.shape, values = texData.values, texture = texData.texture, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (texture != null) {
-            var index = this.lruDataGPU.indexOf(dataId);
-            if (index >= 0) {
-                this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
-                this.lruDataGPU.push(dataId);
+            if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+                var index = this.lruDataGPU.indexOf(dataId);
+                if (index >= 0) {
+                    this.lruDataGPU.splice(this.lruDataGPU.indexOf(dataId), 1);
+                    this.lruDataGPU.push(dataId);
+                }
             }
             return;
         }
@@ -15321,12 +15944,20 @@ var MathBackendWebGL = (function () {
         if (shouldTimeProgram) {
             start = performance.now();
         }
-        var texShape = webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        var texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
         texData.texShape = texShape;
-        var newTexture = this.acquireTexture(dataId, texShape, usage);
+        var newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
         texData.texture = newTexture;
         if (values != null) {
-            this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            if (isPacked) {
+                var batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+                var rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+                var cols = shape[shape.length - 1];
+                this.gpgpu.uploadMatrixToPackedTexture(newTexture, batch, rows, cols, typedArrayToFloat32(values, dtype));
+            }
+            else {
+                this.gpgpu.uploadMatrixToTexture(newTexture, texShape[0], texShape[1], typedArrayToFloat32(values, dtype));
+            }
             texData.values = null;
             if (shouldTimeProgram) {
                 this.uploadWaitMs += performance.now() - start;
@@ -15336,9 +15967,9 @@ var MathBackendWebGL = (function () {
     MathBackendWebGL.prototype.cacheOnCPU = function (dataId, float32Values) {
         var dontKeepCopyOnGPU = this.delayedStorage;
         var texData = this.texData.get(dataId);
-        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage;
+        var texture = texData.texture, texShape = texData.texShape, dtype = texData.dtype, usage = texData.usage, isPacked = texData.isPacked;
         if (dontKeepCopyOnGPU && texture != null) {
-            this.releaseTexture(dataId, texture, texShape, usage);
+            this.releaseTexture(dataId, texture, texShape, usage, isPacked);
             texData.texture = null;
             texData.texShape = null;
         }
@@ -15347,20 +15978,24 @@ var MathBackendWebGL = (function () {
             texData.values = float32ToTypedArray(float32Values, dtype);
         }
     };
-    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType) {
+    MathBackendWebGL.prototype.releaseTexture = function (dataId, texture, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        var idx = this.lruDataGPU.indexOf(dataId);
-        if (idx >= 0) {
-            this.lruDataGPU.splice(idx, 1);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            var idx = this.lruDataGPU.indexOf(dataId);
+            if (idx >= 0) {
+                this.lruDataGPU.splice(idx, 1);
+            }
         }
         this.numBytesInGPU -= this.computeBytes(shape, dtype);
-        this.textureManager.releaseTexture(texture, texShape, texType);
+        this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
     };
-    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType) {
+    MathBackendWebGL.prototype.acquireTexture = function (dataId, texShape, texType, isPacked) {
         var _a = this.texData.get(dataId), shape = _a.shape, dtype = _a.dtype;
-        this.lruDataGPU.push(dataId);
+        if (environment_1.ENV.get('WEBGL_PAGING_ENABLED')) {
+            this.lruDataGPU.push(dataId);
+        }
         this.numBytesInGPU += this.computeBytes(shape, dtype);
-        return this.textureManager.acquireTexture(texShape, texType);
+        return this.textureManager.acquireTexture(texShape, texType, isPacked);
     };
     MathBackendWebGL.prototype.computeBytes = function (shape, dtype) {
         return util.sizeFromShape(shape) * util.bytesPerElement(dtype);
@@ -15391,7 +16026,7 @@ function typedArrayToFloat32(a, dtype) {
     return (a instanceof Float32Array) ? a : new Float32Array(a);
 }
 
-},{"../environment":64,"../globals":66,"../log":133,"../ops/array_ops_util":135,"../ops/axis_util":136,"../ops/concat_util":143,"../ops/reduce_util":160,"../ops/segment_util":165,"../ops/slice_util":168,"../ops/softmax":169,"../ops/tensor_ops":171,"../tensor":187,"../types":193,"../util":194,"./backend_util":81,"./complex_util":83,"./non_max_suppression_impl":84,"./split_shared":85,"./topk_impl":86,"./webgl/argminmax_gpu":87,"./webgl/avg_pool_backprop_gpu":88,"./webgl/batchnorm_gpu":89,"./webgl/binaryop_complex_gpu":90,"./webgl/binaryop_gpu":91,"./webgl/clip_gpu":92,"./webgl/concat_gpu":93,"./webgl/conv_backprop_gpu":94,"./webgl/conv_backprop_gpu_depthwise":95,"./webgl/conv_gpu":96,"./webgl/conv_gpu_depthwise":97,"./webgl/crop_and_resize_gpu":98,"./webgl/cumsum_gpu":99,"./webgl/depth_to_space_gpu":100,"./webgl/encode_float_gpu":101,"./webgl/from_pixels_gpu":102,"./webgl/gather_gpu":103,"./webgl/gpgpu_context":104,"./webgl/gpgpu_math":105,"./webgl/gpgpu_util":106,"./webgl/lrn_gpu":107,"./webgl/lrn_grad_gpu":108,"./webgl/max_pool_backprop_gpu":109,"./webgl/mulmat_gpu":110,"./webgl/multinomial_gpu":111,"./webgl/onehot_gpu":112,"./webgl/pad_gpu":113,"./webgl/pool_gpu":114,"./webgl/reduce_gpu":115,"./webgl/resize_bilinear_backprop_gpu":116,"./webgl/resize_bilinear_gpu":117,"./webgl/resize_nearest_neighbor_backprop_gpu":118,"./webgl/resize_nearest_neighbor_gpu":119,"./webgl/reverse_gpu":120,"./webgl/segment_gpu":121,"./webgl/select_gpu":122,"./webgl/slice_gpu":124,"./webgl/strided_slice_gpu":125,"./webgl/tex_util":126,"./webgl/texture_manager":127,"./webgl/tile_gpu":128,"./webgl/transpose_gpu":129,"./webgl/unaryop_gpu":130,"./webgl/webgl_util":131,"./where_impl":132}],83:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../log":144,"../ops/array_ops_util":147,"../ops/axis_util":148,"../ops/concat_util":155,"../ops/gather_nd_util":161,"../ops/reduce_util":175,"../ops/scatter_nd_util":180,"../ops/segment_util":182,"../ops/slice_util":185,"../ops/softmax":186,"../ops/tensor_ops":191,"../tensor":207,"../types":213,"../util":214,"./backend":80,"./backend_util":82,"./complex_util":84,"./non_max_suppression_impl":85,"./split_shared":87,"./topk_impl":88,"./webgl/argminmax_gpu":89,"./webgl/avg_pool_backprop_gpu":90,"./webgl/batchnorm_gpu":91,"./webgl/batchnorm_packed_gpu":92,"./webgl/binaryop_complex_gpu":93,"./webgl/binaryop_gpu":94,"./webgl/clip_gpu":95,"./webgl/complex_abs_gpu":96,"./webgl/concat_gpu":97,"./webgl/conv_backprop_gpu":98,"./webgl/conv_backprop_gpu_depthwise":99,"./webgl/conv_gpu":100,"./webgl/conv_gpu_depthwise":101,"./webgl/crop_and_resize_gpu":102,"./webgl/cumsum_gpu":103,"./webgl/depth_to_space_gpu":104,"./webgl/encode_float_gpu":105,"./webgl/fft_gpu":106,"./webgl/from_pixels_gpu":107,"./webgl/gather_gpu":108,"./webgl/gather_nd_gpu":109,"./webgl/gpgpu_context":110,"./webgl/gpgpu_math":111,"./webgl/gpgpu_util":112,"./webgl/im2col_gpu":113,"./webgl/lrn_gpu":114,"./webgl/lrn_grad_gpu":115,"./webgl/max_pool_backprop_gpu":116,"./webgl/mulmat_gpu":117,"./webgl/mulmat_packed_gpu":118,"./webgl/multinomial_gpu":119,"./webgl/onehot_gpu":120,"./webgl/pack_gpu":121,"./webgl/pad_gpu":122,"./webgl/pool_gpu":123,"./webgl/reduce_gpu":124,"./webgl/resize_bilinear_backprop_gpu":125,"./webgl/resize_bilinear_gpu":126,"./webgl/resize_nearest_neighbor_backprop_gpu":127,"./webgl/resize_nearest_neighbor_gpu":128,"./webgl/reverse_gpu":129,"./webgl/scatter_gpu":130,"./webgl/segment_gpu":131,"./webgl/select_gpu":132,"./webgl/slice_gpu":134,"./webgl/strided_slice_gpu":135,"./webgl/tex_util":136,"./webgl/texture_manager":137,"./webgl/tile_gpu":138,"./webgl/transpose_gpu":139,"./webgl/unaryop_gpu":140,"./webgl/unpack_gpu":141,"./webgl/webgl_util":142,"./where_impl":143}],84:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function mergeRealAndImagArrays(real, imag) {
@@ -15417,8 +16052,59 @@ function splitRealAndImagArrays(complex) {
     return { real: real, imag: imag };
 }
 exports.splitRealAndImagArrays = splitRealAndImagArrays;
+function complexWithEvenIndex(complex) {
+    var len = Math.ceil(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 0; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithEvenIndex = complexWithEvenIndex;
+function complexWithOddIndex(complex) {
+    var len = Math.floor(complex.length / 4);
+    var real = new Float32Array(len);
+    var imag = new Float32Array(len);
+    for (var i = 2; i < complex.length; i += 4) {
+        real[Math.floor(i / 4)] = complex[i];
+        imag[Math.floor(i / 4)] = complex[i + 1];
+    }
+    return { real: real, imag: imag };
+}
+exports.complexWithOddIndex = complexWithOddIndex;
+function getComplexWithIndex(complex, index) {
+    var real = complex[index * 2];
+    var imag = complex[index * 2 + 1];
+    return { real: real, imag: imag };
+}
+exports.getComplexWithIndex = getComplexWithIndex;
+function assignToTypedArray(data, real, imag, index) {
+    data[index * 2] = real;
+    data[index * 2 + 1] = imag;
+}
+exports.assignToTypedArray = assignToTypedArray;
+function exponents(n) {
+    var real = new Float32Array(n / 2);
+    var imag = new Float32Array(n / 2);
+    for (var i = 0; i < Math.ceil(n / 2); i++) {
+        var x = -2 * Math.PI * (i / n);
+        real[i] = Math.cos(x);
+        imag[i] = Math.sin(x);
+    }
+    return { real: real, imag: imag };
+}
+exports.exponents = exponents;
+function exponent(k, n) {
+    var x = -2 * Math.PI * (k / n);
+    var real = Math.cos(x);
+    var imag = Math.sin(x);
+    return { real: real, imag: imag };
+}
+exports.exponent = exponent;
 
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15476,7 +16162,33 @@ function intersectionOverUnion(boxes, i, j) {
     return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 
-},{"../ops/tensor_ops":171}],85:[function(require,module,exports){
+},{"../ops/tensor_ops":191}],86:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function getChannels(name) {
+    return ['x', 'y', 'z', 'w'].map(function (d) { return name + "." + d; });
+}
+exports.getChannels = getChannels;
+function getInnerDims(rank, dims) {
+    return dims.slice(0, rank).slice(-2);
+}
+exports.getInnerDims = getInnerDims;
+function getSourceCoords(rank, dims) {
+    if (rank === 1) {
+        return 'rc';
+    }
+    var coords = '';
+    for (var i = 0; i < rank; i++) {
+        coords += dims[i];
+        if (i < rank - 1) {
+            coords += ',';
+        }
+    }
+    return coords;
+}
+exports.getSourceCoords = getSourceCoords;
+
+},{}],87:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function split(x, sizeSplits, axis) {
@@ -15491,7 +16203,7 @@ function split(x, sizeSplits, axis) {
 }
 exports.split = split;
 
-},{}],86:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_ops_1 = require("../ops/tensor_ops");
@@ -15526,7 +16238,7 @@ function topkImpl(x, xShape, xDtype, k, sorted) {
 }
 exports.topkImpl = topkImpl;
 
-},{"../ops/tensor_ops":171,"../util":194}],87:[function(require,module,exports){
+},{"../ops/tensor_ops":191,"../util":214}],89:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ArgMinMaxProgram = (function () {
@@ -15544,13 +16256,13 @@ var ArgMinMaxProgram = (function () {
         var indexSnippet = firstPass ?
             'inOffset + i;' :
             'round(getBestIndicesA(batch, inOffset + i));';
-        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = 0;\n        float bestValue = getA(batch, inOffset);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
+        this.userCode = "\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        int bestIndex = inOffset;\n        float bestValue = getA(batch, bestIndex);\n\n        for (int i = 0; i < " + windowSize + "; i++) {\n          int inIdx = " + indexSnippet + ";\n          float candidate = getA(batch, inIdx);\n          if (candidate " + compOp + " bestValue) {\n            bestValue = candidate;\n            bestIndex = inIdx;\n          }\n        }\n        setOutput(float(bestIndex));\n      }\n    ";
     }
     return ArgMinMaxProgram;
 }());
 exports.ArgMinMaxProgram = ArgMinMaxProgram;
 
-},{}],88:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var AvgPool2DBackpropProgram = (function () {
@@ -15561,16 +16273,20 @@ var AvgPool2DBackpropProgram = (function () {
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
         var avgMultiplier = 1 / (filterHeight * filterWidth);
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float avgMultiplier = float(" + avgMultiplier + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + ";\n            wC+= " + dilationWidth + ") {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n\n            dotProd += dyValue * avgMultiplier;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return AvgPool2DBackpropProgram;
 }());
 exports.AvgPool2DBackpropProgram = AvgPool2DBackpropProgram;
 
-},{}],89:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15594,13 +16310,52 @@ var BatchNormProgram = (function () {
             scaleSnippet = 'getScaleAtOutCoords()';
         }
         this.outputShape = xShape;
-        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+        this.userCode = "\n      void main() {\n        float x = getXAtOutCoords();\n        float mean = getMeanAtOutCoords();\n        float variance = getVarianceAtOutCoords();\n        float offset = " + offsetSnippet + ";\n        float scale = " + scaleSnippet + ";\n        float inv = scale * inversesqrt(variance + float(" + varianceEpsilon + "));\n        setOutput(dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));\n      }\n    ";
     }
     return BatchNormProgram;
 }());
 exports.BatchNormProgram = BatchNormProgram;
 
-},{"../../ops/broadcast_util":139}],90:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],92:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var broadcast_util = require("../../ops/broadcast_util");
+var BatchNormPackedProgram = (function () {
+    function BatchNormPackedProgram(xShape, meanShape, varianceShape, offsetShape, scaleShape, varianceEpsilon) {
+        this.supportsBroadcasting = true;
+        this.usesPackedTextures = true;
+        this.variableNames = ['x', 'mean', 'variance'];
+        broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+        broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+        var meanSnippet = broadcastSample('mean', meanShape.length);
+        var varianceSnippet = broadcastSample('variance', varianceShape.length);
+        var offsetSnippet = 'vec4 offset = vec4(0.0)';
+        if (offsetShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+            this.variableNames.push('offset');
+            offsetSnippet = broadcastSample('offset', offsetShape.length);
+        }
+        var scaleSnippet = 'vec4 scale = vec4(1.0)';
+        if (scaleShape != null) {
+            broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+            this.variableNames.push('scale');
+            scaleSnippet = broadcastSample('scale', scaleShape.length);
+        }
+        this.outputShape = xShape;
+        this.userCode = "\n      void main() {\n        ivec4 rc = getOutputCoords();\n\n        " + offsetSnippet + ";\n        " + scaleSnippet + ";\n\n        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);\n        " + meanSnippet + ";\n        " + varianceSnippet + ";\n\n        vec4 inv = scale * inversesqrt(variance + vec4(" + varianceEpsilon + "));\n\n        setOutput((x - mean) * inv + offset);\n      }\n    ";
+    }
+    return BatchNormPackedProgram;
+}());
+exports.BatchNormPackedProgram = BatchNormPackedProgram;
+function broadcastSample(texName, rank) {
+    var texSampler = "get" + texName.charAt(0).toUpperCase() + texName.slice(1);
+    if (rank === 1) {
+        return "\n      vec4 " + texName + "Sample = " + texSampler + "(rc.w);\n      vec4 " + texName + " = vec4(" + texName + "Sample.xy, " + texName + "Sample.xy);\n    ";
+    }
+    return "vec4 " + texName + " = " + texSampler + "(rc.x, rc.y, rc.z, rc.w)";
+}
+
+},{"../../ops/broadcast_util":151}],93:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15620,7 +16375,7 @@ var BinaryOpComplexProgram = (function () {
 }());
 exports.BinaryOpComplexProgram = BinaryOpComplexProgram;
 
-},{"../../ops/broadcast_util":139}],91:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],94:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -15669,7 +16424,7 @@ var BinaryOpProgram = (function () {
 }());
 exports.BinaryOpProgram = BinaryOpProgram;
 
-},{"../../ops/broadcast_util":139}],92:[function(require,module,exports){
+},{"../../ops/broadcast_util":151}],95:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ClipProgram = (function () {
@@ -15682,7 +16437,20 @@ var ClipProgram = (function () {
 }());
 exports.ClipProgram = ClipProgram;
 
-},{}],93:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var ComplexAbsProgram = (function () {
+    function ComplexAbsProgram(shape) {
+        this.variableNames = ['real', 'imag'];
+        this.outputShape = shape;
+        this.userCode = "\n      void main() {\n        float real = getRealAtOutCoords();\n        float imag = getImagAtOutCoords();\n        vec2 v = vec2(real, imag);\n\n        setOutput(sqrt(dot(v, v)));\n      }\n    ";
+    }
+    return ComplexAbsProgram;
+}());
+exports.ComplexAbsProgram = ComplexAbsProgram;
+
+},{}],97:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var concat_util = require("../../ops/concat_util");
@@ -15698,7 +16466,7 @@ var ConcatProgram = (function () {
 }());
 exports.ConcatProgram = ConcatProgram;
 
-},{"../../ops/concat_util":143}],94:[function(require,module,exports){
+},{"../../ops/concat_util":155}],98:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DDerFilterProgram = (function () {
@@ -15730,7 +16498,7 @@ var Conv2DDerInputProgram = (function () {
 }());
 exports.Conv2DDerInputProgram = Conv2DDerInputProgram;
 
-},{}],95:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DDerFilterProgram = (function () {
@@ -15764,7 +16532,7 @@ var DepthwiseConv2DDerInputProgram = (function () {
 }());
 exports.DepthwiseConv2DDerInputProgram = DepthwiseConv2DDerInputProgram;
 
-},{}],96:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Conv2DProgram = (function () {
@@ -15787,7 +16555,7 @@ var Conv2DProgram = (function () {
 }());
 exports.Conv2DProgram = Conv2DProgram;
 
-},{}],97:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthwiseConv2DProgram = (function () {
@@ -15811,7 +16579,7 @@ var DepthwiseConv2DProgram = (function () {
 }());
 exports.DepthwiseConv2DProgram = DepthwiseConv2DProgram;
 
-},{}],98:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var CropAndResizeProgram = (function () {
@@ -15852,7 +16620,7 @@ var CropAndResizeProgram = (function () {
 }());
 exports.CropAndResizeProgram = CropAndResizeProgram;
 
-},{}],99:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -15903,7 +16671,7 @@ function getFinalCoord(rank, name) {
     }
 }
 
-},{"./shader_compiler":123}],100:[function(require,module,exports){
+},{"./shader_compiler":133}],104:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DepthToSpaceProgram = (function () {
@@ -15959,7 +16727,7 @@ var DepthToSpaceProgram = (function () {
 }());
 exports.DepthToSpaceProgram = DepthToSpaceProgram;
 
-},{}],101:[function(require,module,exports){
+},{}],105:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var EncodeFloatProgram = (function () {
@@ -15972,7 +16740,25 @@ var EncodeFloatProgram = (function () {
 }());
 exports.EncodeFloatProgram = EncodeFloatProgram;
 
-},{}],102:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COMPLEX_FFT = {
+    REAL: 'return real * expR - imag * expI;',
+    IMAG: 'return real * expI + imag * expR;'
+};
+var FFTProgram = (function () {
+    function FFTProgram(op, inputShape) {
+        this.variableNames = ['real', 'imag'];
+        var innerDim = inputShape[1];
+        this.outputShape = inputShape;
+        this.userCode = "\n      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;\n\n      float unaryOpComplex(float real, float expR, float imag, float expI) {\n        " + op + "\n      }\n\n      float mulMatDFT(int batch, int index) {\n        float indexRatio = float(index) / float(" + innerDim + ");\n        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;\n\n        float result = 0.0;\n\n        for (int i = 0; i < " + innerDim + "; i++) {\n          // x = (-2 * PI / N) * index * i;\n          float x = negativeTwoPiTimesIndexRatio * float(i);\n          float expR = cos(x);\n          float expI = sin(x);\n          float real = getReal(batch, i);\n          float imag = getImag(batch, i);\n\n          result += unaryOpComplex(real, expR, imag, expI);\n        }\n\n        return result;\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        setOutput(mulMatDFT(coords[0], coords[1]));\n      }\n    ";
+    }
+    return FFTProgram;
+}());
+exports.FFTProgram = FFTProgram;
+
+},{}],107:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var FromPixelsProgram = (function () {
@@ -15986,7 +16772,7 @@ var FromPixelsProgram = (function () {
 }());
 exports.FromPixelsProgram = FromPixelsProgram;
 
-},{}],103:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16025,7 +16811,26 @@ function getSourceCoords(aShape, axis) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],104:[function(require,module,exports){
+},{"./shader_compiler":133}],109:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var GatherNDProgram = (function () {
+    function GatherNDProgram(sliceDim, strides, shape) {
+        this.sliceDim = sliceDim;
+        this.strides = strides;
+        this.variableNames = ['x', 'indices'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + this.strides + ");\n         void main() {\n          " + dtype + " coords = getOutputCoords();\n          int flattenIndex = 0;\n          for (int j = 0; j < " + this.sliceDim + "; j++) {\n            int index = round(getIndices(coords[0], j));\n            flattenIndex += index * " + strideString + ";\n          }\n          setOutput(getX(flattenIndex, coords[1]));\n        }\n      ";
+    }
+    return GatherNDProgram;
+}());
+exports.GatherNDProgram = GatherNDProgram;
+
+},{"./shader_compiler":133}],110:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16153,6 +16958,10 @@ var GPGPUContext = (function () {
         this.throwIfDisposed();
         gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
     };
+    GPGPUContext.prototype.createFloat16PackedMatrixTexture = function (rows, columns) {
+        this.throwIfDisposed();
+        return gpgpu_util.createFloat16PackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
+    };
     GPGPUContext.prototype.createPackedMatrixTexture = function (rows, columns) {
         this.throwIfDisposed();
         return gpgpu_util.createPackedMatrixTexture(this.gl, rows, columns, this.textureConfig);
@@ -16171,9 +16980,9 @@ var GPGPUContext = (function () {
         var numChannels = webgl_util.getNumChannels();
         return gpgpu_util.uploadMatrixToTexture(this.gl, texture, rows, columns, matrix, numChannels, this.textureConfig);
     };
-    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, rows, columns, matrix) {
+    GPGPUContext.prototype.uploadMatrixToPackedTexture = function (texture, batch, rows, columns, matrix) {
         this.throwIfDisposed();
-        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, rows, columns, matrix, this.textureConfig);
+        return gpgpu_util.uploadMatrixToPackedTexture(this.gl, texture, batch, rows, columns, matrix, this.textureConfig);
     };
     GPGPUContext.prototype.downloadFloat32MatrixFromOutputTexture = function (texture, rows, columns) {
         var _this = this;
@@ -16221,9 +17030,9 @@ var GPGPUContext = (function () {
         }
         return { query: query, isFencePassed: isFencePassed };
     };
-    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, rows, columns) {
+    GPGPUContext.prototype.downloadMatrixFromPackedTexture = function (texture, batch, rows, columns, physicalRows, physicalCols) {
         var _this = this;
-        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, rows, columns, _this.textureConfig); });
+        return this.downloadMatrixDriver(texture, function () { return gpgpu_util.downloadMatrixFromPackedOutputTexture(_this.gl, batch, rows, columns, physicalRows, physicalCols, _this.textureConfig); });
     };
     GPGPUContext.prototype.createProgram = function (fragmentShaderSource) {
         this.throwIfDisposed();
@@ -16505,7 +17314,7 @@ function binSearchLastTrue(arr) {
 }
 exports.binSearchLastTrue = binSearchLastTrue;
 
-},{"../../environment":64,"../../util":194,"./gpgpu_util":106,"./tex_util":126,"./webgl_util":131}],105:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./gpgpu_util":112,"./tex_util":136,"./webgl_util":142}],111:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../../util");
@@ -16516,7 +17325,8 @@ function compileProgram(gpgpu, program, inputs, output) {
         var shapeInfo = {
             logicalShape: input.shape,
             texShape: input.isUniform ? null : input.texData.texShape,
-            isUniform: input.isUniform
+            isUniform: input.isUniform,
+            isPacked: input.isUniform ? false : input.texData.isPacked
         };
         return { name: program.variableNames[i], shapeInfo: shapeInfo };
     });
@@ -16524,7 +17334,8 @@ function compileProgram(gpgpu, program, inputs, output) {
     var outShapeInfo = {
         logicalShape: output.shape,
         texShape: output.texData.texShape,
-        isUniform: false
+        isUniform: false,
+        isPacked: output.texData.isPacked
     };
     var source = shader_compiler.makeShader(inputInfos, outShapeInfo, userCode, program.supportsBroadcasting === true);
     var webGLProgram = gpgpu.createProgram(source);
@@ -16576,7 +17387,12 @@ function runProgram(binary, inputs, output, customSetup) {
     var outTex = output.texData.texture;
     var outTexShape = output.texData.texShape;
     var gpgpu = binary.gpgpu;
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    if (output.texData.isPacked) {
+        gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
+    else {
+        gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    }
     gpgpu.setProgram(binary.webGLProgram);
     inputs.forEach(function (input, i) {
         var variableName = binary.program.variableNames[i];
@@ -16618,10 +17434,11 @@ function makeShaderKey(program, inputs, output) {
 }
 exports.makeShaderKey = makeShaderKey;
 
-},{"../../util":194,"./shader_compiler":123}],106:[function(require,module,exports){
+},{"../../util":214,"./shader_compiler":133}],112:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 var tex_util = require("./tex_util");
 var webgl_util = require("./webgl_util");
 function getWebGLContextAttributes() {
@@ -16716,7 +17533,7 @@ function getTextureConfig(gl, textureHalfFloatExtension) {
 }
 exports.getTextureConfig = getTextureConfig;
 function createAndConfigureTexture(gl, width, height, internalFormat, textureFormat, textureType) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     var texture = webgl_util.createTexture(gl);
     var tex2d = gl.TEXTURE_2D;
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(tex2d, texture); });
@@ -16748,6 +17565,11 @@ function createPackedMatrixTexture(gl, rows, columns, textureConfig) {
     return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatPackedFloat, gl.RGBA, gl.FLOAT);
 }
 exports.createPackedMatrixTexture = createPackedMatrixTexture;
+function createFloat16PackedMatrixTexture(gl, rows, columns, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), width = _a[0], height = _a[1];
+    return createAndConfigureTexture(gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA, textureConfig.textureTypeHalfFloat);
+}
+exports.createFloat16PackedMatrixTexture = createFloat16PackedMatrixTexture;
 function bindVertexProgramAttributeStreams(gl, program, vertexBuffer) {
     var posOffset = 0;
     var uvOffset = 3 * 4;
@@ -16765,7 +17587,7 @@ function uploadPixelDataToTexture(gl, texture, pixels) {
 }
 exports.uploadPixelDataToTexture = uploadPixelDataToTexture;
 function uploadDataToTexture(gl, texture, width, height, data, textureFormat) {
-    webgl_util.validateTextureSize(gl, width, height);
+    webgl_util.validateTextureSize(width, height);
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, texture); });
     webgl_util.callAndCheck(gl, function () { return gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, textureFormat, gl.FLOAT, data); });
     webgl_util.callAndCheck(gl, function () { return gl.bindTexture(gl.TEXTURE_2D, null); });
@@ -16784,10 +17606,10 @@ function uploadMatrixToTexture(gl, texture, rows, columns, matrix, numChannels, 
     uploadDataToTexture(gl, texture, w, h, unpackedArray, textureConfig.textureFormatFloat);
 }
 exports.uploadMatrixToTexture = uploadMatrixToTexture;
-function uploadMatrixToPackedTexture(gl, texture, rows, columns, matrix, textureConfig) {
+function uploadMatrixToPackedTexture(gl, texture, batch, rows, columns, matrix, textureConfig) {
     var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
     var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
-    tex_util.encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA);
+    tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
     uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }
 exports.uploadMatrixToPackedTexture = uploadMatrixToPackedTexture;
@@ -16836,16 +17658,32 @@ function downloadByteEncodedFloatMatrixFromOutputTexture(gl, rows, columns, text
     return new Float32Array(downloadTarget.buffer);
 }
 exports.downloadByteEncodedFloatMatrixFromOutputTexture = downloadByteEncodedFloatMatrixFromOutputTexture;
-function downloadMatrixFromPackedOutputTexture(gl, rows, columns, textureConfig) {
-    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns), w = _a[0], h = _a[1];
-    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+function downloadMatrixFromPackedOutputTexture(gl, batch, rows, cols, physicalRows, physicalCols, textureConfig) {
+    var _a = tex_util.getPackedMatrixTextureShapeWidthHeight(physicalRows, physicalCols), w = _a[0], h = _a[1];
+    var packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
     webgl_util.callAndCheck(gl, function () { return gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, packedRGBA); });
-    var matrix = new Float32Array(rows * columns);
-    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix);
+    var matrix = new Float32Array(util.sizeFromShape([batch, rows, cols]));
+    return tex_util.decodeMatrixFromPackedRGBA(packedRGBA, batch, rows, cols, matrix);
 }
 exports.downloadMatrixFromPackedOutputTexture = downloadMatrixFromPackedOutputTexture;
 
-},{"../../environment":64,"./tex_util":126,"./webgl_util":131}],107:[function(require,module,exports){
+},{"../../environment":64,"../../util":214,"./tex_util":136,"./webgl_util":142}],113:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Im2ColProgram = (function () {
+    function Im2ColProgram(outputShape, inputShape, convInfo) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var filterWidth = convInfo.filterWidth, inChannels = convInfo.inChannels, strideWidth = convInfo.strideWidth, strideHeight = convInfo.strideHeight, padInfo = convInfo.padInfo, outWidth = convInfo.outWidth, dilationWidth = convInfo.dilationWidth, dilationHeight = convInfo.dilationHeight;
+        var left = padInfo.left, top = padInfo.top;
+        var itemsPerBlockRow = inChannels * filterWidth;
+        this.userCode = "\n      void main() {\n        ivec2 rc = getOutputCoords();\n\n        vec4 result = vec4(0);\n\n        for(int row=0; row<=1; row++) {\n          for(int col=0; col<=1; col++) {\n            int blockIndex = rc.y + col;\n            int pos = rc.x + row;\n\n            if(blockIndex >= " + outputShape[1] + " || pos >= " + outputShape[0] + ") continue;\n\n            int offsetY = int(blockIndex / (" + outWidth + ")) * " + strideHeight + " - " + top + ";\n            int d0 = offsetY + " + dilationHeight + " * (pos / " + itemsPerBlockRow + ");\n\n            if(d0 >= " + inputShape[0] + " || d0 < 0) continue;\n\n            int offsetX = int(mod(float(blockIndex), " + outWidth + ".) * " + strideWidth + ". - " + left + ".);\n            int d1 = offsetX + " + dilationWidth + " * (int(mod(float(pos), " + itemsPerBlockRow + ".) / " + inChannels + ".));\n\n            if(d1 >= " + inputShape[1] + " || d1 < 0) continue;\n\n            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), " + inChannels + ".)));\n          }\n        }\n\n        gl_FragColor = result;\n      }\n    ";
+    }
+    return Im2ColProgram;
+}());
+exports.Im2ColProgram = Im2ColProgram;
+
+},{}],114:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNProgram = (function () {
@@ -16872,7 +17710,7 @@ var LRNProgram = (function () {
 }());
 exports.LRNProgram = LRNProgram;
 
-},{}],108:[function(require,module,exports){
+},{}],115:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var LRNGradProgram = (function () {
@@ -16891,27 +17729,28 @@ var LRNGradProgram = (function () {
 }());
 exports.LRNGradProgram = LRNGradProgram;
 
-},{}],109:[function(require,module,exports){
+},{}],116:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MaxPool2DBackpropProgram = (function () {
     function MaxPool2DBackpropProgram(convInfo) {
         this.variableNames = ['dy', 'maxPos'];
         this.outputShape = convInfo.inShape;
-        var filterHeight = convInfo.filterHeight;
-        var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
-        var padTop = filterHeight - 1 - convInfo.padInfo.top;
-        var padLeft = filterWidth - 1 - convInfo.padInfo.left;
-        var lastIndex = filterHeight * filterWidth - 1;
-        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + filterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + filterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
+        var dilationHeight = convInfo.dilationHeight;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
+        var padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
+        var padLeft = effectiveFilterWidth - 1 - convInfo.padInfo.left;
+        var lastIndex = effectiveFilterHeight * effectiveFilterWidth - 1;
+        this.userCode = "\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int b = coords[0];\n        int d = coords[3];\n\n        ivec2 dyRCCorner = coords.yz - pads;\n        int dyRCorner = dyRCCorner.x;\n        int dyCCorner = dyRCCorner.y;\n\n        // Convolve dy(?, ?, d) with pos mask(:, :, d) to get dx(xR, xC, d).\n        // ? = to be determined. : = across all values in that axis.\n        float dotProd = 0.0;\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n          wR += " + dilationHeight + ") {\n          float dyR = float(dyRCorner + wR) / " + strideHeight + ".0;\n\n          if (dyR < 0.0 || dyR >= " + convInfo.outHeight + ".0 || fract(dyR) > 0.0) {\n            continue;\n          }\n          int idyR = int(dyR);\n\n          for (int wC = 0; wC < " + effectiveFilterWidth + "; wC++) {\n            float dyC = float(dyCCorner + wC) / " + strideWidth + ".0;\n\n            if (dyC < 0.0 || dyC >= " + convInfo.outWidth + ".0 ||\n                fract(dyC) > 0.0) {\n              continue;\n            }\n            int idyC = int(dyC);\n\n            float dyValue = getDy(b, idyR, idyC, d);\n            int maxPosValue = " + lastIndex + " - int(getMaxPos(b, idyR, idyC, d));\n\n            // Get the current value, check it against the value from the\n            // position matrix.\n            int curPosValue = wR * " + effectiveFilterWidth + " + wC;\n            float mask = float(maxPosValue == curPosValue ? 1.0 : 0.0);\n\n            dotProd += dyValue * mask;\n          }\n        }\n        setOutput(dotProd);\n      }\n    ";
     }
     return MaxPool2DBackpropProgram;
 }());
 exports.MaxPool2DBackpropProgram = MaxPool2DBackpropProgram;
 
-},{}],110:[function(require,module,exports){
+},{}],117:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MatMulProgram = (function () {
@@ -16940,7 +17779,29 @@ var MatMulProgram = (function () {
 }());
 exports.MatMulProgram = MatMulProgram;
 
-},{}],111:[function(require,module,exports){
+},{}],118:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var MatMulPackedProgram = (function () {
+    function MatMulPackedProgram(aShape, bShape, outputShape, transposeA, transposeB) {
+        if (transposeA === void 0) { transposeA = false; }
+        if (transposeB === void 0) { transposeB = false; }
+        this.variableNames = ['matrixA', 'matrixB'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var sharedDim = transposeA ? aShape[0] : aShape[1];
+        var sharedDimensionPacked = Math.ceil(sharedDim / 2);
+        var aSample = transposeA ? 'i * 2, rc.x' : 'rc.x, i * 2';
+        var bSample = transposeB ? 'rc.y, i * 2' : 'i * 2, rc.y';
+        var aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
+        var bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
+        this.userCode = "\n      const float sharedDimension = " + sharedDimensionPacked + ".0;\n\n      vec4 dot2x2ARowBCol(ivec2 rc) {\n        vec4 result = vec4(0);\n        for (int i = 0; i < " + sharedDimensionPacked + "; i++) {\n          vec4 a = getMatrixA(" + aSample + ");\n          vec4 b = getMatrixB(" + bSample + ");\n\n          result += (" + aSwizzle[0] + " * " + bSwizzle[0] + ") + (" + aSwizzle[1] + " * " + bSwizzle[1] + ");\n        }\n        return result;\n      }\n\n      void main() {\n        ivec2 rc = getOutputCoords();\n        setOutput(dot2x2ARowBCol(rc));\n      }\n    ";
+    }
+    return MatMulPackedProgram;
+}());
+exports.MatMulPackedProgram = MatMulPackedProgram;
+
+},{}],119:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var MultinomialProgram = (function () {
@@ -16962,7 +17823,7 @@ var MultinomialProgram = (function () {
 }());
 exports.MultinomialProgram = MultinomialProgram;
 
-},{}],112:[function(require,module,exports){
+},{}],120:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var OneHotProgram = (function () {
@@ -16975,7 +17836,69 @@ var OneHotProgram = (function () {
 }());
 exports.OneHotProgram = OneHotProgram;
 
-},{}],113:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var PackProgram = (function () {
+    function PackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var outOfBoundsCondition = getOutOfBoundsCondition(rank, outputShape, channels);
+        var setup = getSetup(rank, outputShape[outputShape.length - 1], outputShape[outputShape.length - 2], channels);
+        var output = getOutput(outputShape, channels);
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n\n        if(" + outOfBoundsCondition + ") {\n          gl_FragColor = vec4(0);\n        } else {\n          " + setup + "\n\n          setOutput(vec4(" + output + "));\n        }\n      }\n    ";
+    }
+    return PackProgram;
+}());
+exports.PackProgram = PackProgram;
+function getSourceCoordsArr(rank, dims) {
+    var coords = [];
+    for (var row = 0; row <= 1; row++) {
+        for (var col = 0; col <= 1; col++) {
+            var coord = (row === 0 ? 'r' : 'rp1') + ", " + (col === 0 ? 'c' : 'cp1');
+            for (var d = 2; d < rank; d++) {
+                coord = dims[dims.length - 1 - d] + "," + coord;
+            }
+            coords.push(coord);
+        }
+    }
+    return coords;
+}
+function getOutOfBoundsCondition(rank, shape, dims) {
+    if (rank === 1) {
+        return "rc > " + shape[0];
+    }
+    var cond = '';
+    for (var i = 0; i < rank; i++) {
+        cond += dims[i] + " >= " + shape[i];
+        if (i < rank - 1) {
+            cond += '||';
+        }
+    }
+    return cond;
+}
+function getSetup(rank, cols, rows, dims) {
+    if (rank === 1) {
+        return '';
+    }
+    var innerDims = packing_util_1.getInnerDims(rank, dims);
+    return "\n    int r = " + innerDims[0] + ";\n    int c = " + innerDims[1] + ";\n    int rp1 = r + 1;\n    int cp1 = c + 1;\n\n    bool cEdge = cp1 >= " + cols + ";\n    bool rEdge = rp1 >= " + rows + ";\n  ";
+}
+function getOutput(shape, dims) {
+    var rank = shape.length;
+    var sourceCoords = getSourceCoordsArr(rank, dims);
+    if (rank === 1) {
+        return "getA(rc),\n            rc + 1 >= " + shape[0] + " ? 0. : getA(rc + 1),\n            0, 0";
+    }
+    return "getA(" + sourceCoords[0] + "),\n          cEdge ? 0. : getA(" + sourceCoords[1] + "),\n          rEdge ? 0. : getA(" + sourceCoords[2] + "),\n          rEdge || cEdge ? 0. : getA(" + sourceCoords[3] + ")";
+}
+
+},{"../packing_util":86,"./shader_compiler":133}],122:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -16998,7 +17921,7 @@ var PadProgram = (function () {
 }());
 exports.PadProgram = PadProgram;
 
-},{"./shader_compiler":123}],114:[function(require,module,exports){
+},{"./shader_compiler":133}],123:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Pool2DProgram = (function () {
@@ -17007,10 +17930,13 @@ var Pool2DProgram = (function () {
         if (poolType === 'avg' && computePositions) {
             throw new Error('Cannot compute positions for average pool.');
         }
-        var filterHeight = convInfo.filterHeight;
         var filterWidth = convInfo.filterWidth;
         var strideHeight = convInfo.strideHeight;
         var strideWidth = convInfo.strideWidth;
+        var dilationHeight = convInfo.dilationHeight;
+        var dilationWidth = convInfo.dilationWidth;
+        var effectiveFilterHeight = convInfo.effectiveFilterHeight;
+        var effectiveFilterWidth = convInfo.effectiveFilterWidth;
         var padTop = convInfo.padInfo.top;
         var padLeft = convInfo.padInfo.left;
         this.outputShape = convInfo.outShape;
@@ -17021,7 +17947,7 @@ var Pool2DProgram = (function () {
         }
         if (computePositions) {
             var compareOp_1 = '>=';
-            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + filterHeight + "; wR++) {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + filterWidth + "; wC++) {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + filterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
+            this.userCode = "\n        const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n        const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n\n        void main() {\n          ivec4 coords = getOutputCoords();\n          int batch = coords[0];\n          int d = coords[3];\n\n          ivec2 xRCCorner = coords.yz * strides - pads;\n          int xRCorner = xRCCorner.x;\n          int xCCorner = xRCCorner.y;\n\n          // max/min x(?, ?, d) to get y(yR, yC, d).\n          // ? = to be determined\n          float minMaxValue = 0.0;\n          float minMaxValueFound = 0.0;\n          int minMaxPosition = 0;\n          float avgValue = 0.0;\n\n          for (int wR = 0; wR < " + effectiveFilterHeight + ";\n              wR += " + dilationHeight + ") {\n            int xR = xRCorner + wR;\n\n            if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n              continue;\n            }\n\n            for (int wC = 0; wC < " + effectiveFilterWidth + ";\n                wC += " + dilationWidth + ") {\n              int xC = xCCorner + wC;\n\n              if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n                continue;\n              }\n\n              float value = getX(batch, xR, xC, d);\n\n              // If a min / max value has already been found, use it. If not,\n              // use the current value.\n              float currMinMaxValue = mix(\n                  value, minMaxValue, minMaxValueFound);\n              if (value " + compareOp_1 + " currMinMaxValue) {\n                minMaxValue = value;\n                minMaxValueFound = 1.0;\n                minMaxPosition = wR * " + effectiveFilterWidth + " + wC;\n              }\n            }\n          }\n          setOutput(float(minMaxPosition));\n        }\n      ";
             return;
         }
         var compareOp = 'max';
@@ -17033,13 +17959,13 @@ var Pool2DProgram = (function () {
         var filterWidthNearestVec4 = Math.floor(filterWidth / 4) * 4;
         var filterWidthVec4Remainder = filterWidth % 4;
         var updateSnippet = "\n      if (" + isAvgPool + ") {\n        avgValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
-        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + filterHeight + "; wR++) {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC;\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              getValue(batch, xR, xC + 3, d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + 1, d),\n              getValue(batch, xR, xC + 2, d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const ivec2 strides = ivec2(" + strideHeight + ", " + strideWidth + ");\n      const ivec2 pads = ivec2(" + padTop + ", " + padLeft + ");\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float count = 0.0;\n\n      float getValue(int batch, int xR, int xC, int d) {\n        if (xC < 0 || xC >= " + convInfo.inWidth + ") {\n          return initializationValue;\n        }\n        count += 1.0;\n        return getX(batch, xR, xC, d);\n      }\n\n      void main() {\n        ivec4 coords = getOutputCoords();\n        int batch = coords[0];\n        int d = coords[3];\n\n        ivec2 xRCCorner = coords.yz * strides - pads;\n        int xRCorner = xRCCorner.x;\n        int xCCorner = xRCCorner.y;\n\n        // max/min x(?, ?, d) to get y(yR, yC, d).\n        // ? = to be determined\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float avgValue = 0.0;\n        count = 0.0;\n\n        for (int wR = 0; wR < " + effectiveFilterHeight + ";\n            wR += " + dilationHeight + ") {\n          int xR = xRCorner + wR;\n\n          if (xR < 0 || xR >= " + convInfo.inHeight + ") {\n            continue;\n          }\n\n          for (int wC = 0; wC < " + filterWidthNearestVec4 + "; wC += 4) {\n            int xC = xCCorner + wC * " + dilationWidth + ";\n\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 3 * " + dilationWidth + ", d)\n            );\n\n            " + updateSnippet + "\n          }\n\n          int xC = xCCorner + " + filterWidthNearestVec4 + ";\n          if (" + (filterWidthVec4Remainder === 1) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              initializationValue,\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 2) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              initializationValue,\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          } else if (" + (filterWidthVec4Remainder === 3) + ") {\n            vec4 values = vec4(\n              getValue(batch, xR, xC, d),\n              getValue(batch, xR, xC + " + dilationWidth + ", d),\n              getValue(batch, xR, xC + 2 * " + dilationWidth + ", d),\n              initializationValue\n            );\n\n            " + updateSnippet + "\n          }\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return Pool2DProgram;
 }());
 exports.Pool2DProgram = Pool2DProgram;
 
-},{}],115:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ReduceProgram = (function () {
@@ -17052,7 +17978,10 @@ var ReduceProgram = (function () {
         this.outputShape = [batchSize, outSize];
         var initializationValue = '0.0';
         var compareOp = "";
-        if (reduceType === 'min') {
+        if (reduceType === 'prod') {
+            initializationValue = '1.0';
+        }
+        else if (reduceType === 'min') {
             initializationValue = '1.0 / 0.0';
             compareOp = "min";
         }
@@ -17065,6 +17994,9 @@ var ReduceProgram = (function () {
         if (reduceType === 'sum') {
             returnValue = "sumValue";
         }
+        else if (reduceType === 'prod') {
+            returnValue = "prodValue";
+        }
         else if (reduceType === 'all') {
             returnValue = "allValue";
         }
@@ -17073,7 +18005,7 @@ var ReduceProgram = (function () {
         }
         var windowSizeNearestVec4 = Math.floor(windowSize / 4) * 4;
         var windowSizeVec4Remainder = windowSize % 4;
-        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
+        var updateSnippet = "\n      if (" + (reduceType === 'sum') + ") {\n        sumValue += dot(values, ones);\n      } else if (" + (reduceType === 'prod') + ") {\n        vec2 tmp = vec2(values[0], values[1]) * vec2(values[2], values[3]);\n        prodValue *= tmp[0] * tmp[1];\n      } else {\n        minMaxValue = " + compareOp + "(values, minMaxValue);\n      }\n    ";
         var vecType = "vec4";
         if (reduceType === 'all') {
             initializationValue = '1.0';
@@ -17089,13 +18021,13 @@ var ReduceProgram = (function () {
         if (inSize % windowSize > 0) {
             checkOutOfBounds = "\n        if (inIdx < 0 || inIdx >= " + inSize + ") {\n          return initializationValue;\n        }\n      ";
         }
-        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
+        this.userCode = "\n      const float initializationValue = " + initializationValue + ";\n      const vec4 ones = vec4(1.0, 1.0, 1.0, 1.0);\n\n      float getValue(int batch, int inIdx) {\n        " + checkOutOfBounds + "\n        return getX(batch, inIdx);\n      }\n\n      void main() {\n        ivec2 coords = getOutputCoords();\n        int batch = coords[0];\n        int outIdx = coords[1];\n        int inOffset = outIdx * " + windowSize + ";\n\n        vec4 minMaxValue = vec4(" + initializationValue + ");\n        float prodValue = 1.0;\n        float sumValue = 0.0;\n        float allValue = 1.0;\n        float anyValue = 0.0;\n\n        for (int i = 0; i < " + windowSizeNearestVec4 + "; i += 4) {\n          int inIdx = inOffset + i;\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            getValue(batch, inIdx + 3)\n          );\n\n          " + updateSnippet + "\n        }\n\n        int inIdx = inOffset + " + windowSizeNearestVec4 + ";\n        if (" + (windowSizeVec4Remainder === 1) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            initializationValue,\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 2) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            initializationValue,\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        } else if (" + (windowSizeVec4Remainder === 3) + ") {\n          " + vecType + " values = " + vecType + "(\n            getValue(batch, inIdx),\n            getValue(batch, inIdx + 1),\n            getValue(batch, inIdx + 2),\n            initializationValue\n          );\n\n          " + updateSnippet + "\n        }\n        setOutput(" + returnValue + ");\n      }\n    ";
     }
     return ReduceProgram;
 }());
 exports.ReduceProgram = ReduceProgram;
 
-},{}],116:[function(require,module,exports){
+},{}],125:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearBackpropProgram = (function () {
@@ -17125,7 +18057,7 @@ var ResizeBilinearBackpropProgram = (function () {
 }());
 exports.ResizeBilinearBackpropProgram = ResizeBilinearBackpropProgram;
 
-},{}],117:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeBilinearProgram = (function () {
@@ -17148,7 +18080,7 @@ var ResizeBilinearProgram = (function () {
 }());
 exports.ResizeBilinearProgram = ResizeBilinearProgram;
 
-},{}],118:[function(require,module,exports){
+},{}],127:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeigborBackpropProgram = (function () {
@@ -17178,7 +18110,7 @@ var ResizeNearestNeigborBackpropProgram = (function () {
 }());
 exports.ResizeNearestNeigborBackpropProgram = ResizeNearestNeigborBackpropProgram;
 
-},{}],119:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var ResizeNearestNeighborProgram = (function () {
@@ -17202,7 +18134,7 @@ var ResizeNearestNeighborProgram = (function () {
 }());
 exports.ResizeNearestNeighborProgram = ResizeNearestNeighborProgram;
 
-},{}],120:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17232,7 +18164,41 @@ var ReverseProgram = (function () {
 }());
 exports.ReverseProgram = ReverseProgram;
 
-},{"./shader_compiler":123}],121:[function(require,module,exports){
+},{"./shader_compiler":133}],130:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var shader_compiler_1 = require("./shader_compiler");
+var ScatterProgram = (function () {
+    function ScatterProgram(updateSize, sliceDim, indicesRank, updatesRank, strides, shape, summingDupeIndex) {
+        if (summingDupeIndex === void 0) { summingDupeIndex = true; }
+        this.variableNames = ['updates', 'indices', 'defaultValue'];
+        this.outputShape = shape;
+        var stridesType = shader_compiler_1.getCoordsDataType(strides.length);
+        var dtype = shader_compiler_1.getCoordsDataType(shape.length);
+        var indicesString = '';
+        if (indicesRank === 1) {
+            indicesString = 'i';
+        }
+        else if (indicesRank === 2) {
+            indicesString = 'i, j';
+        }
+        var indicesSnippet = "getIndices(" + indicesString + ")";
+        var updatesString = '';
+        if (updatesRank === 1) {
+            updatesString = 'i';
+        }
+        else if (updatesRank === 2) {
+            updatesString = 'i, coords[1]';
+        }
+        var updatesSnippet = "getUpdates(" + updatesString + ")";
+        var strideString = sliceDim > 1 ? 'strides[j]' : 'strides';
+        this.userCode = "\n        " + stridesType + " strides = " + stridesType + "(" + strides + ");\n\n        void main() {\n          " + dtype + " coords = getOutputCoords();\n          float sum = 0.0;\n          bool found = false;\n          for (int i = 0; i < " + updateSize + "; i++) {\n            int flattenedIndex = 0;\n            for (int j = 0; j < " + sliceDim + "; j++) {\n              int index = round(" + indicesSnippet + ");\n              flattenedIndex += index * " + strideString + ";\n            }\n            if (flattenedIndex == coords[0]) {\n              sum += " + updatesSnippet + ";\n              found = true;\n            }\n          }\n          setOutput(mix(getDefaultValue(), sum, float(found)));\n        }\n      ";
+    }
+    return ScatterProgram;
+}());
+exports.ScatterProgram = ScatterProgram;
+
+},{"./shader_compiler":133}],131:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var SegmentOpProgram = (function () {
@@ -17263,7 +18229,7 @@ var SegmentOpProgram = (function () {
 }());
 exports.SegmentOpProgram = SegmentOpProgram;
 
-},{}],122:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17300,7 +18266,7 @@ var SelectProgram = (function () {
 }());
 exports.SelectProgram = SelectProgram;
 
-},{"./shader_compiler":123}],123:[function(require,module,exports){
+},{"./shader_compiler":133}],133:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var broadcast_util = require("../../ops/broadcast_util");
@@ -17317,11 +18283,21 @@ function makeShader(inputsInfo, outputShape, userCode, broadcast) {
     var inputSamplingSnippet = inputsInfo.map(function (x) { return getInputSamplingSnippet(x, outputShape, broadcast); })
         .join('\n');
     var outTexShape = outputShape.texShape;
-    var outputSamplingSnippet = getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    var outputSamplingSnippet;
+    var floatTextureSetOutputSnippet;
+    if (outputShape.isPacked) {
+        outputSamplingSnippet =
+            getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    }
+    else {
+        outputSamplingSnippet =
+            getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+        floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    }
     var source = [
-        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-        FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-        inputSamplingSnippet, userCode
+        SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+        inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
     ].join('\n');
     return source;
 }
@@ -17348,14 +18324,47 @@ function getSamplerFromInInfo(inInfo) {
                 " is not yet supported");
     }
 }
+function getPackedSamplerFromInInfo(inInfo) {
+    var shape = inInfo.shapeInfo.logicalShape;
+    switch (shape.length) {
+        case 1:
+            return getPackedSampler1D(inInfo);
+        case 2:
+            return getPackedSampler2D(inInfo);
+        case 4:
+            return getPackedSampler4D(inInfo);
+        default:
+            throw new Error("Packed " + shape.length + "-D input sampling" +
+                " is not yet supported");
+    }
+}
 function getInputSamplingSnippet(inInfo, outShapeInfo, broadcast) {
     var res = getSamplerFlat(inInfo);
-    res += getSamplerFromInInfo(inInfo);
+    if (inInfo.shapeInfo.isPacked) {
+        res += getPackedSamplerFromInInfo(inInfo);
+    }
+    else {
+        res += getSamplerFromInInfo(inInfo);
+    }
     if (broadcast ||
         util.arraysEqual(inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
         res += getSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     }
     return res;
+}
+function getPackedOutputSamplingSnippet(outShape, outTexShape) {
+    switch (outShape.length) {
+        case 0:
+            return getOutputScalarCoords();
+        case 1:
+            return getOutputPacked1DCoords(outShape, outTexShape);
+        case 2:
+            return getOutputPacked2DCoords(outShape, outTexShape);
+        case 4:
+            return getOutputPacked4DCoords(outShape, outTexShape);
+        default:
+            throw new Error(outShape.length + "-D output packed sampling is not yet supported");
+    }
 }
 function getOutputSamplingSnippet(outShape, outTexShape) {
     switch (outShape.length) {
@@ -17377,17 +18386,28 @@ function getOutputSamplingSnippet(outShape, outTexShape) {
             throw new Error(outShape.length + "-D output sampling is not yet supported");
     }
 }
-var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_1D_SNIPPET = "\nvec2 UVfrom1D(int texNumR, int texNumC, int index) {\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom1D(int texNumR, int texNumC, int index) {\n  int texelIndex = index / 2;\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_2D_SNIPPET = "\nvec2 UVfrom2D(int texNumR, int texNumC, int numC, int row, int col) {\n  int index = row * numC + col;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom2D(int texelsInLogicalRow, int texNumR,\n  int texNumC, int row, int col) {\n  int texelIndex = (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = texelIndex / texNumC;\n  int texC = texelIndex - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_3D_SNIPPET = "\nvec2 UVfrom3D(int texNumR, int texNumC, int stride0,\n    int stride1, int row, int col, int depth) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
-var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
+var SAMPLE_4D_SNIPPET = "\nvec2 UVfrom4D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int row, int col, int depth,\n    int depth2) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\nvec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,\n    int texelsInBatch, int texelsInLogicalRow, int b2, int b,\n    int row, int col) {\n  int index = b2 * texelsInBatch2 + b * texelsInBatch +\n    (row / 2) * texelsInLogicalRow + (col / 2);\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_5D_SNIPPET = "\nvec2 UVfrom5D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int row, int col, int depth,\n    int depth2, int depth3) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 +\n              depth * stride2 + depth2 * stride3 + depth3;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var SAMPLE_6D_SNIPPET = "\nvec2 UVfrom6D(int texNumR, int texNumC, int stride0,\n    int stride1, int stride2, int stride3, int stride4,\n    int row, int col, int depth, int depth2, int depth3, int depth4) {\n  // Explicitly use integer operations as dot() only works on floats.\n  int index = row * stride0 + col * stride1 + depth * stride2 + depth2 *\n    stride3 + depth3 * stride4 + depth4;\n  int texR = index / texNumC;\n  int texC = index - texR * texNumC;\n  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);\n}\n";
 var FLOAT_TEXTURE_SAMPLE_SNIPPET = "\n  float sampleTexture(sampler2D textureSampler, vec2 uv) {\n    return texture2D(textureSampler, uv).r;\n  }\n";
-var FLOAT_TEXTURE_SETOUTPUT_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
-var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
+var FLOAT_TEXTURE_SET_R_SNIPPET = "\n  void setOutput(float val) {\n    gl_FragColor = vec4(val, 0, 0, 0);\n  }\n";
+var FLOAT_TEXTURE_SET_RGBA_SNIPPET = "\n  void setOutput(vec4 val) {\n    gl_FragColor = val;\n  }\n";
+var SHADER_PREFIX = "\n  precision highp float;\n  precision highp int;\n  varying vec2 resultUV;\n  const vec2 halfCR = vec2(0.5, 0.5);\n\n  struct ivec5\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n  };\n\n  struct ivec6\n  {\n    int x;\n    int y;\n    int z;\n    int w;\n    int u;\n    int v;\n  };\n\n  bool isNaN(float val) {\n    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;\n  }\n\n  bool hasNaN(vec4 values) {\n    vec4 v1 = values * values;\n    vec4 v2 = values * values;\n    return any(notEqual(v1, v2));\n  }\n\n  float getNaN(vec4 values) {\n    return dot(vec4(1), values);\n  }\n\n  int round(float value) {\n    return int(floor(value + 0.5));\n  }\n\n  int imod(int x, int y) {\n    return x - y * (x / y);\n  }\n\n  //Based on the work of Dave Hoskins\n  //https://www.shadertoy.com/view/4djSRW\n  #define HASHSCALE1 443.8975\n  float random(float seed){\n    vec2 p = resultUV * seed;\n    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);\n    p3 += dot(p3, p3.yzx + 19.19);\n    return fract((p3.x + p3.y) * p3.z);\n  }\n\n  " + SAMPLE_1D_SNIPPET + "\n  " + SAMPLE_2D_SNIPPET + "\n  " + SAMPLE_3D_SNIPPET + "\n  " + SAMPLE_4D_SNIPPET + "\n  " + SAMPLE_5D_SNIPPET + "\n  " + SAMPLE_6D_SNIPPET + "\n";
 function getOutputScalarCoords() {
     return "\n    int getOutputCoords() {\n      return 0;\n    }\n  ";
+}
+function getOutputPacked1DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (texShape[0] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.x * " + packedTexShape[1] + ".0);\n      }\n    ";
+    }
+    if (texShape[1] === 1) {
+        return "\n      int getOutputCoords() {\n        return 2 * int(resultUV.y * " + packedTexShape[0] + ".0);\n      }\n    ";
+    }
+    return "\n    int getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      return resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n    }\n  ";
 }
 function getOutput1DCoords(shape, texShape) {
     if (texShape[0] === 1) {
@@ -17402,6 +18422,13 @@ function getOutput3DCoords(shape, texShape) {
     var stride0 = shape[1] * shape[2];
     var stride1 = shape[2];
     return "\n    ivec3 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n      int c = index / " + stride1 + ";\n      int d = index - c * " + stride1 + ";\n      return ivec3(r, c, d);\n    }\n  ";
+}
+function getOutputPacked4DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texelsInLogicalRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    ivec4 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n\n      int b2 = index / " + texelsInBatch2 + ";\n      index -= b2 * " + texelsInBatch2 + ";\n\n      int b = index / " + texelsInBatch + ";\n      index -= b * " + texelsInBatch + ";\n\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = int(mod(float(index), " + texelsInLogicalRow + ".)) * 2;\n\n      return ivec4(b2, b, r, c);\n    }\n  ";
 }
 function getOutput4DCoords(shape, texShape) {
     var stride2 = shape[3];
@@ -17424,6 +18451,14 @@ function getOutput6DCoords(shape, texShape) {
     var stride0 = shape[1] * stride1;
     return "\n    ivec6 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n        vec2(" + texShape[0] + ", " + texShape[1] + "));\n      int index = resTexRC.x * " + texShape[1] + " + resTexRC.y;\n\n      int r = index / " + stride0 + ";\n      index -= r * " + stride0 + ";\n\n      int c = index / " + stride1 + ";\n      index -= c * " + stride1 + ";\n\n      int d = index / " + stride2 + ";\n      index -= d * " + stride2 + ";\n\n      int d2 = index / " + stride3 + ";\n      index -= d2 * " + stride3 + ";\n\n      int d3 = index / " + stride4 + ";\n      int d4 = index - d3 * " + stride4 + ";\n\n      ivec6 result = ivec6(r, c, d, d2, d3, d4);\n      return result;\n    }\n  ";
 }
+function getOutputPacked2DCoords(shape, texShape) {
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    if (util.arraysEqual(shape, texShape)) {
+        return "\n      ivec2 getOutputCoords() {\n        return 2 * ivec2(resultUV.yx * vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n      }\n    ";
+    }
+    var texelsInLogicalRow = Math.ceil(shape[1] / 2);
+    return "\n    ivec2 getOutputCoords() {\n      ivec2 resTexRC = ivec2(resultUV.yx *\n                             vec2(" + packedTexShape[0] + ", " + packedTexShape[1] + "));\n\n      int index = resTexRC.x * " + packedTexShape[1] + " + resTexRC.y;\n      int r = 2 * (index / " + texelsInLogicalRow + ");\n      int c = imod(index, " + texelsInLogicalRow + ") * 2;\n\n      return ivec2(r, c);\n    }\n  ";
+}
 function getOutput2DCoords(shape, texShape) {
     if (util.arraysEqual(shape, texShape)) {
         return "\n      ivec2 getOutputCoords() {\n        return ivec2(resultUV.yx * vec2(" + texShape[0] + ", " + texShape[1] + "));\n      }\n    ";
@@ -17444,10 +18479,31 @@ function getSamplerScalar(inputInfo) {
     }
     return "\n    float " + funcName + "() {\n      return sampleTexture(" + texName + ", halfCR);\n    }\n  ";
 }
+function getPackedSampler1D(inputInfo) {
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    return "\n    vec4 " + funcName + "(int index) {\n      vec2 uv = packedUVfrom1D(\n        " + packedTexShape[0] + ", " + packedTexShape[1] + ", index);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
+}
 function getSampler1D(inputInfo) {
     var texName = inputInfo.name;
     var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
     return "\n    float " + funcName + "(int index) {\n      return " + funcName + "Flat(index);\n    }\n  ";
+}
+function getPackedSampler2D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var texNumR = texShape[0];
+    var texNumC = texShape[1];
+    if (texShape != null && util.arraysEqual(shape, texShape)) {
+        return "\n      vec4 " + funcName + "(int row, int col) {\n        vec2 uv = (vec2(col, row) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n\n        return texture2D(" + texName + ", uv);\n      }\n    ";
+    }
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var valuesPerRow = Math.ceil(shape[1] / 2);
+    return "\n    vec4 " + funcName + "(int row, int col) {\n      vec2 uv = packedUVfrom2D(" + valuesPerRow + ", " + packedTexShape[0] + ", " + packedTexShape[1] + ", row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler2D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17467,15 +18523,15 @@ function getSampler2D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col) {\n        int index = row * " + shape[1] + " + col;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col) {\n        float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2(0.5, (float(index) + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2(0.5, (index + 0.5) / " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     if (texNumR === 1) {
-        return "\n    float " + funcName + "(int row, int col) {\n      int index = row * " + shape[1] + " + col;\n      vec2 uv = vec2((float(index) + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col) {\n      float index = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      vec2 uv = vec2((index + 0.5) / " + texNumC + ".0, 0.5);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n  float " + funcName + "(int row, int col) {\n    vec2 uv = UVfrom2D(" + texNumR + ", " + texNumC + ", " + shape[1] + ", row, col);\n    return sampleTexture(" + texName + ", uv);\n  }\n";
 }
@@ -17493,18 +18549,31 @@ function getSampler3D(inputInfo) {
         return "\n        " + getSamplerFromInInfo(newInputInfo) + "\n        float " + funcName + "(int row, int col, int depth) {\n          return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n        }\n      ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth) {\n        int index = row * " + stride0 + " + col * " + stride1 + " + depth;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth) {\n        float index = dot(vec3(row, col, depth),\n                          vec3(" + stride0 + ", " + stride1 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n        float " + funcName + "(int row, int col, int depth) {\n          int texR = row;\n          int texC = col * " + stride1 + " + depth;\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
+        return "\n        float " + funcName + "(int row, int col, int depth) {\n          float texR = float(row);\n          float texC = dot(vec2(col, depth), vec2(" + stride1 + ", 1));\n          vec2 uv = (vec2(texC, texR) + halfCR) /\n                     vec2(" + texNumC + ".0, " + texNumR + ".0);\n          return sampleTexture(" + texName + ", uv);\n        }\n      ";
     }
     if (texNumC === stride1) {
-        return "\n    float " + funcName + "(int row, int col, int depth) {\n      int texR = row * " + shape[1] + " + col;\n      int texC = depth;\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
+        return "\n    float " + funcName + "(int row, int col, int depth) {\n      float texR = dot(vec2(row, col), vec2(" + shape[1] + ", 1));\n      float texC = float(depth);\n      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(" + texNumC + ".0, " + texNumR + ".0);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
     }
     return "\n      float " + funcName + "(int row, int col, int depth) {\n        vec2 uv = UVfrom3D(\n            " + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ", row, col, depth);\n        return sampleTexture(" + texName + ", uv);\n      }\n  ";
+}
+function getPackedSampler4D(inputInfo) {
+    var shape = inputInfo.shapeInfo.logicalShape;
+    var texName = inputInfo.name;
+    var funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+    var texShape = inputInfo.shapeInfo.texShape;
+    var packedTexShape = [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+    var texNumR = packedTexShape[0];
+    var texNumC = packedTexShape[1];
+    var valuesPerRow = Math.ceil(shape[3] / 2);
+    var texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+    var texelsInBatch2 = texelsInBatch * shape[1];
+    return "\n    vec4 " + funcName + "(int b2, int b, int row, int col) {\n      vec2 uv = packedUVfrom4D(\n        " + texNumR + ", " + texNumC + ", " + texelsInBatch2 + ",\n        " + texelsInBatch + ", " + valuesPerRow + ", b2, b, row, col);\n      return texture2D(" + texName + ", uv);\n    }\n  ";
 }
 function getSampler4D(inputInfo) {
     var shape = inputInfo.shapeInfo.logicalShape;
@@ -17520,16 +18589,16 @@ function getSampler4D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float index = dot(vec4(row, col, depth, depth2),\n                          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", 1));\n        return " + funcName + "Flat(round(index));\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = float(row);\n        float texC =\n            dot(vec3(col, depth, depth2), vec3(" + stride1 + ", " + stride2 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride2) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2) {\n        float texR = dot(vec3(row, col, depth),\n                         vec3(" + shape[1] * shape[2] + ", " + shape[2] + ", 1));\n        float texC = float(depth2);\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2) {\n      vec2 uv = UVfrom4D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", row, col, depth, depth2);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17548,16 +18617,16 @@ function getSampler5D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          depth3;\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " +\n                   depth2 * " + stride3 + " + depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", 1));\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride3) {
-        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " +\n                   depth * " + shape[3] + " + depth2;\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] + ", " + shape[2] * shape[3] + ",\n            " + shape[3] + ", 1));\n        int texC = depth3;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth, int depth2, int depth3) {\n      vec2 uv = UVfrom5D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", row, col, depth, depth2, depth3);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17577,16 +18646,16 @@ function getSampler6D(inputInfo) {
         return "\n      " + getSamplerFromInInfo(newInputInfo) + "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        return " + funcName + "(" + getSqueezedParams(params, keptDims) + ");\n      }\n    ";
     }
     if (inputInfo.shapeInfo.isUniform) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        int index = row * " + stride0 + " + col * " + stride1 + " +\n            depth * " + stride2 + " + depth2 * " + stride3 + " + depth3 * " + stride3 + "\n            + depth4\n        return " + funcName + "Flat(index);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n        float index = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + stride0 + ", " + stride1 + ", " + stride2 + ", " + stride3 + ")) +\n          dot(\n            vec2(depth3, depth4),\n            vec2(" + stride4 + ", 1));\n        return " + funcName + "Flat(index);\n      }\n    ";
     }
     var texShape = inputInfo.shapeInfo.texShape;
     var texNumR = texShape[0];
     var texNumC = texShape[1];
     if (texNumC === stride0) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        int texC = col * " + stride1 + " + depth * " + stride2 + " + depth2;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row;\n        float texC = dot(\n          vec4(col, depth, depth2, depth3),\n          vec4(" + stride1 + ", " + stride2 + ", " + stride3 + ", " + stride4 + ")) + depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                   vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     if (texNumC === stride4) {
-        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        int texR = row * " + shape[1] * shape[2] + " + col * " + shape[2] + " + depth;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
+        return "\n      float " + funcName + "(int row, int col, int depth,\n                    int depth2, int depth3, int depth4) {\n        float texR = dot(\n          vec4(row, col, depth, depth2),\n          vec4(" + shape[1] * shape[2] * shape[3] * shape[4] + ",\n               " + shape[2] * shape[3] * shape[4] + ",\n               " + shape[3] * shape[4] + ",\n               " + shape[4] + ")) + depth3;\n        int texC = depth4;\n        vec2 uv = (vec2(texC, texR) + halfCR) /\n                  vec2(" + texNumC + ".0, " + texNumR + ".0);\n        return sampleTexture(" + texName + ", uv);\n      }\n    ";
     }
     return "\n    float " + funcName + "(int row, int col, int depth,\n                  int depth2, int depth3, int depth4) {\n      vec2 uv = UVfrom6D(" + texNumR + ", " + texNumC + ", " + stride0 + ", " + stride1 + ",\n          " + stride2 + ", " + stride3 + ", " + stride4 + "\n          ,row, col, depth, depth2, depth3, depth4);\n      return sampleTexture(" + texName + ", uv);\n    }\n  ";
 }
@@ -17715,7 +18784,7 @@ function getSqueezedParams(params, keptDims) {
     return keptDims.map(function (d) { return params[d]; }).join(', ');
 }
 
-},{"../../ops/broadcast_util":139,"../../util":194}],124:[function(require,module,exports){
+},{"../../ops/broadcast_util":151,"../../util":214}],134:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17779,7 +18848,7 @@ function getCoords(rank) {
     }
 }
 
-},{"./shader_compiler":123}],125:[function(require,module,exports){
+},{"./shader_compiler":133}],135:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -17817,9 +18886,10 @@ var StridedSliceProgram = (function () {
 }());
 exports.StridedSliceProgram = StridedSliceProgram;
 
-},{"./shader_compiler":123}],126:[function(require,module,exports){
+},{"./shader_compiler":133}],136:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+var util = require("../../util");
 var TextureUsage;
 (function (TextureUsage) {
     TextureUsage[TextureUsage["RENDER"] = 0] = "RENDER";
@@ -17829,9 +18899,11 @@ var TextureUsage;
 })(TextureUsage = exports.TextureUsage || (exports.TextureUsage = {}));
 var PhysicalTextureType;
 (function (PhysicalTextureType) {
-    PhysicalTextureType[PhysicalTextureType["FLOAT16"] = 0] = "FLOAT16";
-    PhysicalTextureType[PhysicalTextureType["FLOAT32"] = 1] = "FLOAT32";
-    PhysicalTextureType[PhysicalTextureType["UNSIGNED_BYTE"] = 2] = "UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT16"] = 0] = "UNPACKED_FLOAT16";
+    PhysicalTextureType[PhysicalTextureType["UNPACKED_FLOAT32"] = 1] = "UNPACKED_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_4X1_UNSIGNED_BYTE"] = 2] = "PACKED_4X1_UNSIGNED_BYTE";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT32"] = 3] = "PACKED_2X2_FLOAT32";
+    PhysicalTextureType[PhysicalTextureType["PACKED_2X2_FLOAT16"] = 4] = "PACKED_2X2_FLOAT16";
 })(PhysicalTextureType = exports.PhysicalTextureType || (exports.PhysicalTextureType = {}));
 function getUnpackedMatrixTextureShapeWidthHeight(rows, columns) {
     return [columns, rows];
@@ -17899,118 +18971,130 @@ function getPackedRGBAArraySizeFromMatrixShape(rows, columns) {
     return w * h * 4;
 }
 exports.getPackedRGBAArraySizeFromMatrixShape = getPackedRGBAArraySizeFromMatrixShape;
-function encodeMatrixToPackedRGBA(matrix, rows, columns, packedRGBA) {
+function encodeMatrixToPackedRGBA(matrix, batches, rows, columns, packedRGBA) {
     var requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
     if (packedRGBA.length < requiredSize) {
-        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >= " + requiredSize);
+        throw new Error("packedRGBA length (" + packedRGBA.length + ") must be >=\n        " + requiredSize);
     }
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    {
-        var dstStride = (oddWidth ? 4 : 0);
-        var oneRow = columns;
-        var dst = 0;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            var matrixSrcRow = (blockY * 2 * columns);
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                var matrixSrcCol = blockX * 2;
-                var src = matrixSrcRow + matrixSrcCol;
-                packedRGBA[dst] = matrix[src];
-                packedRGBA[dst + 1] = matrix[src + 1];
-                packedRGBA[dst + 2] = matrix[src + oneRow];
-                packedRGBA[dst + 3] = matrix[src + oneRow + 1];
-                dst += 4;
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var sourceOffset = batch * rows * columns;
+        var batchOffset = batch * flattenedMatrixSize;
+        {
+            var dstStride = (oddWidth ? 4 : 0);
+            var oneRow = columns;
+            var dst = batchOffset;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                var matrixSrcRow = (blockY * 2 * columns);
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    var matrixSrcCol = blockX * 2;
+                    var src = sourceOffset + matrixSrcRow + matrixSrcCol;
+                    packedRGBA[dst] = matrix[src];
+                    packedRGBA[dst + 1] = matrix[src + 1];
+                    packedRGBA[dst + 2] = matrix[src + oneRow];
+                    packedRGBA[dst + 3] = matrix[src + oneRow + 1];
+                    dst += 4;
+                }
+                dst += dstStride;
             }
-            dst += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = columns - 1;
-        var dst = (textureWidth - 1) * 4;
-        var srcStride = 2 * columns;
-        var dstStride = textureWidth * 4;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            packedRGBA[dst] = matrix[src];
-            packedRGBA[dst + 2] = matrix[src + columns];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + columns - 1;
+            var dst = batchOffset + (texelsPerRow - 1) * 4;
+            var srcStride = 2 * columns;
+            var dstStride = texelsPerRow * 4;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                packedRGBA[dst] = matrix[src];
+                packedRGBA[dst + 2] = matrix[src + columns];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (rows - 1) * columns;
-        var dst = (textureHeight - 1) * textureWidth * 4;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            packedRGBA[dst++] = matrix[src++];
-            packedRGBA[dst++] = matrix[src++];
-            dst += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (rows - 1) * columns;
+            var dst = batchOffset + (texelsPerBatch - texelsPerRow) * 4;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                packedRGBA[dst++] = matrix[src++];
+                packedRGBA[dst++] = matrix[src++];
+                dst += 2;
+            }
+            if (oddWidth && oddHeight) {
+                packedRGBA[batchOffset + flattenedMatrixSize - 4] = matrix[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        packedRGBA[packedRGBA.length - 4] = matrix[matrix.length - 1];
     }
     return packedRGBA;
 }
 exports.encodeMatrixToPackedRGBA = encodeMatrixToPackedRGBA;
-function decodeMatrixFromPackedRGBA(packedRGBA, rows, columns, matrix) {
+function decodeMatrixFromPackedRGBA(packedRGBA, batches, rows, columns, matrix) {
     var requiredSize = rows * columns;
-    if (requiredSize < matrix.length) {
+    if (matrix.length < requiredSize) {
         throw new Error("matrix length (" + matrix.length + ") must be >= " + requiredSize);
     }
     var oddWidth = (columns % 2) === 1;
     var oddHeight = (rows % 2) === 1;
     var widthInFullBlocks = Math.floor(columns / 2);
     var heightInFullBlocks = Math.floor(rows / 2);
-    var _a = getPackedMatrixTextureShapeWidthHeight(rows, columns), textureWidth = _a[0], textureHeight = _a[1];
-    {
-        var srcStride = oddWidth ? 4 : 0;
-        var dstStride = columns + (oddWidth ? 1 : 0);
-        var src = 0;
-        var dstRow1 = 0;
-        var dstRow2 = columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow1++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
-                matrix[dstRow2++] = packedRGBA[src++];
+    var texelsPerRow = Math.ceil(columns / 2);
+    var texelsPerBatch = texelsPerRow * Math.ceil(rows / 2);
+    var flattenedMatrixSize = util.nearestLargerEven(rows) * util.nearestLargerEven(columns);
+    for (var batch = 0; batch < batches; batch++) {
+        var batchOffset = batch * rows * columns;
+        var sourceOffset = batch * flattenedMatrixSize;
+        {
+            var srcStride = oddWidth ? 4 : 0;
+            var dstStride = columns + (oddWidth ? 1 : 0);
+            var src = sourceOffset;
+            var dstRow1 = batchOffset;
+            var dstRow2 = batchOffset + columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow1++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                    matrix[dstRow2++] = packedRGBA[src++];
+                }
+                src += srcStride;
+                dstRow1 += dstStride;
+                dstRow2 += dstStride;
             }
-            src += srcStride;
-            dstRow1 += dstStride;
-            dstRow2 += dstStride;
         }
-    }
-    if (oddWidth) {
-        var src = (textureWidth - 1) * 4;
-        var dst = columns - 1;
-        var srcStride = textureWidth * 4;
-        var dstStride = 2 * columns;
-        for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
-            matrix[dst] = packedRGBA[src];
-            matrix[dst + columns] = packedRGBA[src + 2];
-            src += srcStride;
-            dst += dstStride;
+        if (oddWidth) {
+            var src = sourceOffset + (texelsPerRow - 1) * 4;
+            var dst = batchOffset + columns - 1;
+            var srcStride = texelsPerRow * 4;
+            var dstStride = 2 * columns;
+            for (var blockY = 0; blockY < heightInFullBlocks; ++blockY) {
+                matrix[dst] = packedRGBA[src];
+                matrix[dst + columns] = packedRGBA[src + 2];
+                src += srcStride;
+                dst += dstStride;
+            }
         }
-    }
-    if (oddHeight) {
-        var src = (textureHeight - 1) * textureWidth * 4;
-        var dst = (rows - 1) * columns;
-        for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
-            matrix[dst++] = packedRGBA[src++];
-            matrix[dst++] = packedRGBA[src++];
-            src += 2;
+        if (oddHeight) {
+            var src = sourceOffset + (texelsPerBatch - texelsPerRow) * 4;
+            var dst = batchOffset + (rows - 1) * columns;
+            for (var blockX = 0; blockX < widthInFullBlocks; ++blockX) {
+                matrix[dst++] = packedRGBA[src++];
+                matrix[dst++] = packedRGBA[src++];
+                src += 2;
+            }
+            if (oddWidth) {
+                matrix[batchOffset + (rows * columns) - 1] = packedRGBA[src];
+            }
         }
-    }
-    if (oddWidth && oddHeight) {
-        matrix[matrix.length - 1] = packedRGBA[packedRGBA.length - 4];
     }
     return matrix;
 }
 exports.decodeMatrixFromPackedRGBA = decodeMatrixFromPackedRGBA;
 
-},{}],127:[function(require,module,exports){
+},{"../../util":214}],137:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
@@ -18024,9 +19108,9 @@ var TextureManager = (function () {
         this.logEnabled = false;
         this.usedTextures = {};
     }
-    TextureManager.prototype.acquireTexture = function (shapeRC, usage) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(usage);
-        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType);
+    TextureManager.prototype.acquireTexture = function (shapeRC, usage, isPacked) {
+        var physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
+        var shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18044,24 +19128,34 @@ var TextureManager = (function () {
         this.numUsedTextures++;
         this.log();
         var newTexture;
-        if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT32) {
+        if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32) {
+            newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16) {
+            newTexture =
+                this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
+        }
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32) {
             newTexture =
                 this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.FLOAT16) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16) {
             newTexture =
                 this.gpgpu.createFloat16MatrixTexture(shapeRC[0], shapeRC[1]);
         }
-        else if (physicalTexType === tex_util_1.PhysicalTextureType.UNSIGNED_BYTE) {
+        else if (physicalTexType === tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE) {
             newTexture =
                 this.gpgpu.createUnsignedBytesMatrixTexture(shapeRC[0], shapeRC[1]);
         }
         this.usedTextures[shapeKey].push(newTexture);
         return newTexture;
     };
-    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType) {
-        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType);
-        var shapeKey = getKeyFromTextureShape(shape, physicalTexType);
+    TextureManager.prototype.releaseTexture = function (texture, shape, logicalTexType, isPacked) {
+        if (this.freeTextures == null) {
+            return;
+        }
+        var physicalTexType = getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+        var shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
         if (!(shapeKey in this.freeTextures)) {
             this.freeTextures[shapeKey] = [];
         }
@@ -18113,26 +19207,31 @@ var TextureManager = (function () {
     return TextureManager;
 }());
 exports.TextureManager = TextureManager;
-function getPhysicalFromLogicalTextureType(logicalTexType) {
-    if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
+function getPhysicalFromLogicalTextureType(logicalTexType, isPacked) {
+    if (isPacked) {
+        return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT32 :
+            tex_util_1.PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    else if (logicalTexType === tex_util_1.TextureUsage.DOWNLOAD ||
         logicalTexType === tex_util_1.TextureUsage.PIXELS) {
-        return tex_util_1.PhysicalTextureType.UNSIGNED_BYTE;
+        return tex_util_1.PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.UPLOAD) {
-        return tex_util_1.PhysicalTextureType.FLOAT32;
+        return tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32;
     }
     else if (logicalTexType === tex_util_1.TextureUsage.RENDER) {
         return environment_1.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-            tex_util_1.PhysicalTextureType.FLOAT32 :
-            tex_util_1.PhysicalTextureType.FLOAT16;
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT32 :
+            tex_util_1.PhysicalTextureType.UNPACKED_FLOAT16;
     }
     throw new Error("Unknown logical texture type " + logicalTexType);
 }
-function getKeyFromTextureShape(shapeRowsCol, physicalTexType) {
-    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType;
+function getKeyFromTextureShape(shapeRowsCol, physicalTexType, isPacked) {
+    return shapeRowsCol[0] + "_" + shapeRowsCol[1] + "_" + physicalTexType + "_" + isPacked;
 }
 
-},{"../../environment":64,"./tex_util":126}],128:[function(require,module,exports){
+},{"../../environment":64,"./tex_util":136}],138:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18168,7 +19267,7 @@ function getSourceCoords(aShape) {
     return sourceCoords.join();
 }
 
-},{"./shader_compiler":123}],129:[function(require,module,exports){
+},{"./shader_compiler":133}],139:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var shader_compiler_1 = require("./shader_compiler");
@@ -18201,7 +19300,7 @@ function getSwitchedCoords(newDim) {
     return switchedCoords.join();
 }
 
-},{"./shader_compiler":123}],130:[function(require,module,exports){
+},{"./shader_compiler":133}],140:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var erf_util = require("../../ops/erf_util");
@@ -18268,12 +19367,33 @@ exports.RECIPROCAL = "return 1.0 / x;";
 exports.LOGICAL_NOT = "return float(!(x >= 1.0));";
 exports.TO_INT = "return float(int(x));";
 
-},{"../../ops/erf_util":146,"../../ops/selu_util":166}],131:[function(require,module,exports){
+},{"../../ops/erf_util":159,"../../ops/selu_util":183}],141:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var MAX_TEXTURE_SIZE = null;
-var util = require("../../util");
+var packing_util_1 = require("../packing_util");
+var shader_compiler_1 = require("./shader_compiler");
+var UnpackProgram = (function () {
+    function UnpackProgram(outputShape) {
+        this.variableNames = ['A'];
+        this.usesPackedTextures = true;
+        this.outputShape = outputShape;
+        var rank = outputShape.length;
+        var channels = packing_util_1.getChannels('rc');
+        var dtype = shader_compiler_1.getCoordsDataType(rank);
+        var sourceCoords = packing_util_1.getSourceCoords(rank, channels);
+        var innerDims = packing_util_1.getInnerDims(rank, channels);
+        var coords = rank === 1 ? 'rc' : innerDims.join(',');
+        this.userCode = "\n      void main() {\n        " + dtype + " rc = getOutputCoords();\n        vec2 modCoord = mod(vec2(" + coords + "), 2.);\n        vec4 packedInput = getA(" + sourceCoords + ");\n\n        setOutput(\n          modCoord.x == 0. ?\n            (modCoord.y == 0. ? packedInput.r : packedInput.g) :\n            (modCoord.y == 0. ? packedInput.b : packedInput.a)\n        );\n      }\n    ";
+    }
+    return UnpackProgram;
+}());
+exports.UnpackProgram = UnpackProgram;
+
+},{"../packing_util":86,"./shader_compiler":133}],142:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../../environment");
+var util = require("../../util");
 function createWebGLRenderingContext(attributes) {
     var canvas = document.createElement('canvas');
     canvas.width = 1;
@@ -18424,15 +19544,6 @@ function createStaticIndexBuffer(gl, data) {
     return buffer;
 }
 exports.createStaticIndexBuffer = createStaticIndexBuffer;
-function queryMaxTextureSize(gl) {
-    if (MAX_TEXTURE_SIZE != null) {
-        return MAX_TEXTURE_SIZE;
-    }
-    MAX_TEXTURE_SIZE =
-        callAndCheck(gl, function () { return gl.getParameter(gl.MAX_TEXTURE_SIZE); });
-    return MAX_TEXTURE_SIZE;
-}
-exports.queryMaxTextureSize = queryMaxTextureSize;
 function getNumChannels() {
     if (environment_1.ENV.get('WEBGL_VERSION') === 2) {
         return 1;
@@ -18444,8 +19555,8 @@ function createTexture(gl) {
     return throwIfNull(gl, function () { return gl.createTexture(); }, 'Unable to create WebGLTexture.');
 }
 exports.createTexture = createTexture;
-function validateTextureSize(gl, width, height) {
-    var maxTextureSize = queryMaxTextureSize(gl);
+function validateTextureSize(width, height) {
+    var maxTextureSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
     if ((width <= 0) || (height <= 0)) {
         var requested = "[" + width + "x" + height + "]";
         throw new Error('Requested texture size ' + requested + ' is invalid.');
@@ -18551,12 +19662,19 @@ function validateTextureUnit(gl, textureUnit) {
         throw new Error("textureUnit must be in " + textureUnitRange + ".");
     }
 }
-function getTextureShapeFromLogicalShape(gl, logShape) {
+function getTextureShapeFromLogicalShape(logShape, isPacked) {
+    if (isPacked === void 0) { isPacked = false; }
+    var maxTexSize = environment_1.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    if (isPacked) {
+        maxTexSize = maxTexSize * 2;
+        logShape = logShape.map(function (d, i) { return i >= logShape.length - 2 ?
+            util.nearestLargerEven(logShape[i]) :
+            logShape[i]; });
+    }
     if (logShape.length !== 2) {
         var squeezeResult = util.squeezeShape(logShape);
         logShape = squeezeResult.newShape;
     }
-    var maxTexSize = queryMaxTextureSize(gl);
     var size = util.sizeFromShape(logShape);
     if (logShape.length <= 1 && size <= maxTexSize) {
         return [size, 1];
@@ -18565,9 +19683,18 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
         logShape[1] <= maxTexSize) {
         return logShape;
     }
+    else if (logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+        logShape[2] <= maxTexSize) {
+        return [logShape[0] * logShape[1], logShape[2]];
+    }
     else if (logShape.length === 3 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] <= maxTexSize) {
         return [logShape[0], logShape[1] * logShape[2]];
+    }
+    else if (logShape.length === 4 &&
+        logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+        logShape[3] <= maxTexSize) {
+        return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
     }
     else if (logShape.length === 4 && logShape[0] <= maxTexSize &&
         logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
@@ -18579,7 +19706,7 @@ function getTextureShapeFromLogicalShape(gl, logShape) {
 }
 exports.getTextureShapeFromLogicalShape = getTextureShapeFromLogicalShape;
 
-},{"../../environment":64,"../../util":194}],132:[function(require,module,exports){
+},{"../../environment":64,"../../util":214}],143:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var array_ops_1 = require("../ops/array_ops");
@@ -18601,7 +19728,7 @@ function whereImpl(condShape, condVals) {
 }
 exports.whereImpl = whereImpl;
 
-},{"../ops/array_ops":134}],133:[function(require,module,exports){
+},{"../ops/array_ops":146}],144:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -18626,7 +19753,13 @@ function log() {
 }
 exports.log = log;
 
-},{"./environment":64}],134:[function(require,module,exports){
+},{"./environment":64}],145:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var confusion_matrix_1 = require("./ops/confusion_matrix");
+exports.confusionMatrix = confusion_matrix_1.confusionMatrix;
+
+},{"./ops/confusion_matrix":156}],146:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -19025,9 +20158,10 @@ function stack_(tensors, axis) {
 function batchToSpaceND_(x, blockShape, crops) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'batchToSpaceND');
     var prod = blockShape.reduce(function (a, b) { return a * b; });
-    util.assert($x.rank >= 1 + blockShape.length, "input rank should be > than [blockShape] but got " + $x.rank);
-    util.assert(crops.length === blockShape.length, "crops.shape[0] must be equal to [blockShape] but got " + crops.length);
-    util.assert($x.shape[0] % prod === 0, "input tensor batch must be divisible by prod( blockShape )");
+    util.assert($x.rank >= 1 + blockShape.length, "input rank is " + $x.rank + " but should be > than blockShape.length " + blockShape.length);
+    util.assert(crops.length === blockShape.length, "crops.length is " + crops.length + " but should be equal to blockShape.length  " + blockShape.length);
+    util.assert($x.shape[0] % prod === 0, "input tensor batch is " + $x.shape[0] + " but is not divisible by the product of " +
+        ("the elements of blockShape " + blockShape.join(' * ') + " === " + prod));
     var grad = function (dy) {
         return { $x: function () { return dy.spaceToBatchND(blockShape, crops); } };
     };
@@ -19154,7 +20288,7 @@ exports.tile = operation_1.op({ tile_: tile_ });
 exports.truncatedNormal = operation_1.op({ truncatedNormal_: truncatedNormal_ });
 exports.unstack = operation_1.op({ unstack_: unstack_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_split":142,"./operation":156,"./rand":159,"./tensor_ops":171}],135:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_split":154,"./operation":171,"./rand":174,"./tensor_ops":191}],147:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getReshaped(inputShape, blockShape, prod, batchToSpace) {
@@ -19252,7 +20386,7 @@ function getSliceSize(uncroppedShape, crops, blockShape) {
 }
 exports.getSliceSize = getSliceSize;
 
-},{}],136:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -19342,7 +20476,7 @@ function getInnerMostAxes(numAxes, rank) {
 }
 exports.getInnerMostAxes = getInnerMostAxes;
 
-},{"../util":194}],137:[function(require,module,exports){
+},{"../util":214}],149:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19562,7 +20696,7 @@ exports.batchNormalization3d = operation_1.op({ batchNormalization3d_: batchNorm
 exports.batchNormalization4d = operation_1.op({ batchNormalization4d_: batchNormalization4d_ });
 exports.batchNormalization = operation_1.op({ batchNormalization_: batchNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],138:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],150:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -19928,7 +21062,7 @@ exports.squaredDifferenceStrict = operation_1.op({ squaredDifferenceStrict_: squ
 exports.sub = operation_1.op({ sub_: sub_ });
 exports.subStrict = operation_1.op({ subStrict_: subStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../types":193,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171,"./unary_ops":174}],139:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../types":213,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191,"./unary_ops":194}],151:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function getBroadcastDims(inShape, outShape) {
@@ -19998,7 +21132,7 @@ function assertAndGetBroadcastShape(shapeA, shapeB) {
 }
 exports.assertAndGetBroadcastShape = assertAndGetBroadcastShape;
 
-},{}],140:[function(require,module,exports){
+},{}],152:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20102,7 +21236,7 @@ exports.lessStrict = operation_1.op({ lessStrict_: lessStrict_ });
 exports.notEqual = operation_1.op({ notEqual_: notEqual_ });
 exports.notEqualStrict = operation_1.op({ notEqualStrict_: notEqualStrict_ });
 
-},{"../environment":64,"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],141:[function(require,module,exports){
+},{"../environment":64,"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],153:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20128,7 +21262,7 @@ exports.complex = operation_1.op({ complex_: complex_ });
 exports.real = operation_1.op({ real_: real_ });
 exports.imag = operation_1.op({ imag_: imag_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],142:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],154:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20154,6 +21288,7 @@ function concat_(tensors, axis) {
     if (axis === void 0) { axis = 0; }
     util_1.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     var $tensors = tensor_util_env_1.convertToTensorArray(tensors, 'tensors', 'concat');
+    axis = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var outShape = concat_util_1.computeOutShape($tensors.map(function (t) { return t.shape; }), axis);
     if (util_1.sizeFromShape(outShape) === 0) {
         return tensor_ops_1.tensor([], outShape);
@@ -20162,16 +21297,15 @@ function concat_(tensors, axis) {
     if ($tensors.length === 1) {
         return $tensors[0];
     }
-    var axes = axis_util_1.parseAxisParam(axis, $tensors[0].shape)[0];
     var shapes = $tensors.map(function (t) { return t.shape; });
-    concat_util_1.assertParamsConsistent(shapes, axes);
+    concat_util_1.assertParamsConsistent(shapes, axis);
     var der = function (dy) {
         var sizeSplits = shapes.map(function (s) { return s[axis]; });
         var derTensors = exports.split(dy, sizeSplits, axis);
         return derTensors.map(function (t) { return function () { return t; }; });
     };
     var inputs = $tensors;
-    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axes); }, inputs, der);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.concat($tensors, axis); }, inputs, der);
 }
 function split_(x, numOrSizeSplits, axis) {
     if (axis === void 0) { axis = 0; }
@@ -20196,7 +21330,7 @@ exports.concat3d = operation_1.op({ concat3d_: concat3d_ });
 exports.concat4d = operation_1.op({ concat4d_: concat4d_ });
 exports.split = operation_1.op({ split_: split_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./concat_util":143,"./operation":156,"./tensor_ops":171}],143:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./concat_util":155,"./operation":171,"./tensor_ops":191}],155:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -20226,13 +21360,40 @@ function computeOutShape(shapes, axis) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194}],144:[function(require,module,exports){
+},{"../util":214}],156:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var tensor_util_env_1 = require("../tensor_util_env");
+var util = require("../util");
+var array_ops_1 = require("./array_ops");
+var operation_1 = require("./operation");
+function confusionMatrix_(labels, predictions, numClasses) {
+    var $labels = tensor_util_env_1.convertToTensor(labels, 'label', 'confusionMatrix', 'int32');
+    var $predictions = tensor_util_env_1.convertToTensor(predictions, 'label', 'confusionMatrix', 'int32');
+    util.assert(numClasses == null || numClasses > 0 && Number.isInteger(numClasses), "If provided, numClasses must be a positive integer, " +
+        ("but got " + numClasses));
+    util.assert($labels.rank === 1, "Expected the rank of labels to be 1, but got " + $labels.rank);
+    util.assert($predictions.rank === 1, "Expected the rank of predictions to be 1, " +
+        ("but got " + $predictions.rank));
+    util.assert($labels.shape[0] === $predictions.shape[0], "Mismatch in the number of examples: " +
+        ($labels.shape[0] + " vs. " + $predictions.shape[0] + ". ") +
+        "Labels and predictions should have the same number of elements.");
+    util.assert(numClasses > 0 && Number.isInteger(numClasses), "numClasses is required to be a positive integer, but got " + numClasses);
+    var oneHotLabels = array_ops_1.oneHot($labels, numClasses);
+    var oneHotPredictions = array_ops_1.oneHot($predictions, numClasses);
+    return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+exports.confusionMatrix_ = confusionMatrix_;
+exports.confusionMatrix = operation_1.op({ confusionMatrix_: confusionMatrix_ });
+
+},{"../tensor_util_env":210,"../util":214,"./array_ops":146,"./operation":171}],157:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
+var matmul_1 = require("./matmul");
 var operation_1 = require("./operation");
 function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) {
     if (dataFormat === void 0) { dataFormat = 'NWC'; }
@@ -20254,7 +21415,7 @@ function conv1d_(x, filter, stride, pad, dataFormat, dilation, dimRoundingMode) 
     }
     util.assert(x3D.shape[2] === $filter.shape[1], "Error in conv1d: depth of input (" + x3D.shape[2] + ") must match " +
         ("input depth for filter " + $filter.shape[1] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(stride, dilation), 'Error in conv1D: Either stride or dilation must be 1. ' +
         ("Got stride " + stride + " and dilation '" + dilation + "'"));
     util.assert(dataFormat === 'NWC', "Error in conv1d: got dataFormat of " + dataFormat + " but only NWC is currently supported.");
     var filter4D = $filter.as4D(1, $filter.shape[0], $filter.shape[1], $filter.shape[2]);
@@ -20288,19 +21449,30 @@ function conv2d_(x, filter, strides, pad, dataFormat, dilations, dimRoundingMode
     }
     util.assert(x4D.shape[3] === $filter.shape[2], "Error in conv2d: depth of input (" + x4D.shape[3] + ") must match " +
         ("input depth for filter " + $filter.shape[2] + "."));
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in conv2D: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert(dataFormat === 'NHWC', "Error in conv2d: got dataFormat of " + dataFormat + " but only NHWC is currently supported.");
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
-    var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
-            ("yet supported in gradients. Got dilations '" + dilations + "'"));
-        return {
-            x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
-            $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+    var res;
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' || convInfo.padInfo.type === 'VALID')) {
+        var x2d = x4D.reshape([-1, convInfo.inChannels]);
+        var w2d = $filter.reshape([convInfo.inChannels, convInfo.outChannels]);
+        res = matmul_1.matMul(x2d, w2d).reshape(convInfo.outShape);
+    }
+    else {
+        var grad = function (dy) {
+            util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+                ("yet supported in gradients. Got dilations '" + dilations + "'"));
+            return {
+                x: function () { return conv2dDerInput_(x4D.shape, dy, $filter, strides, pad); },
+                $filter: function () { return conv2dDerFilter_(x4D, dy, $filter.shape, strides, pad); }
+            };
         };
-    };
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+        res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2d(x4D, $filter, convInfo); }, { x: x4D, $filter: $filter }, grad);
+    }
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20334,8 +21506,15 @@ function conv2dDerInput_(xShape, dy, filter, strides, pad, dimRoundingMode) {
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
     var dilations = 1;
+    var grad = function (ddx) {
+        var dataFormat = 'NHWC';
+        return {
+            dy4D: function () { return exports.conv2d(ddx, filter, strides, pad, dataFormat, dilations, dimRoundingMode); },
+            filter: function () { return exports.conv2dDerFilter(ddx, dy4D, filter.shape, strides, pad, dimRoundingMode); }
+        };
+    };
     var convInfo = conv_util.computeConv2DInfo(xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D });
+    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.conv2dDerInput(dy4D, filter, convInfo); }, { dy4D: dy4D, filter: filter }, grad);
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
     }
@@ -20394,7 +21573,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     if (dilations == null) {
         dilations = [1, 1];
     }
-    util.assert(eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in depthwiseConv2d: Either strides or dilations must be 1. ' +
         ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in depthwiseConv2d: pad must be an integer when using, " +
@@ -20402,7 +21581,7 @@ function depthwiseConv2d_(x, filter, strides, pad, dataFormat, dilations, dimRou
     }
     var convInfo = conv_util.computeConv2DInfo(x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode, true);
     var grad = function (dy) {
-        util.assert(tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+        util.assert(conv_util.tupleValuesAreOne(dilations), 'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
             ("1 are not yet supported. Got dilations '" + dilations + "'"));
         return {
             x: function () { return depthwiseConv2dDerInput(x4D.shape, dy, $filter, convInfo); },
@@ -20454,16 +21633,6 @@ function separableConv2d_(x, depthwiseFilter, pointwiseFilter, strides, pad, dil
     }
     return res;
 }
-function parseTupleParam(param) {
-    return typeof param === 'number' ? [param, param] : param;
-}
-function tupleValuesAreOne(param) {
-    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
-    return dimA === 1 && dimB === 1;
-}
-function eitherStridesOrDilationsAreOne(strides, dilations) {
-    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
-}
 function depthwiseConv2dDerInput(xShape, dy, filter, convInfo) {
     var dy4D = dy;
     var reshapedTo4D = false;
@@ -20490,15 +21659,16 @@ function depthwiseConv2dDerFilter(x, dy, filterShape, convInfo) {
 }
 exports.conv1d = operation_1.op({ conv1d_: conv1d_ });
 exports.conv2d = operation_1.op({ conv2d_: conv2d_ });
+exports.conv2dDerFilter = operation_1.op({ conv2dDerFilter_: conv2dDerFilter_ });
 exports.depthwiseConv2d = operation_1.op({ depthwiseConv2d_: depthwiseConv2d_ });
 exports.separableConv2d = operation_1.op({ separableConv2d_: separableConv2d_ });
 exports.conv2dTranspose = operation_1.op({ conv2dTranspose_: conv2dTranspose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],145:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./matmul":168,"./operation":171}],158:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
-function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, dataFormat) {
+function computePool2DInfo(inShape, filterSize, strides, dilations, pad, roundingMode, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var _a = parseTupleParam(filterSize), filterHeight = _a[0], filterWidth = _a[1];
     var filterShape;
@@ -20511,7 +21681,6 @@ function computePool2DInfo(inShape, filterSize, strides, pad, roundingMode, data
     else {
         throw new Error("Unknown dataFormat " + dataFormat);
     }
-    var dilations = 1;
     return computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundingMode, false, dataFormat);
 }
 exports.computePool2DInfo = computePool2DInfo;
@@ -20556,6 +21725,8 @@ function computeConv2DInfo(inShape, filterShape, strides, dilations, pad, roundi
         strideWidth: strideWidth,
         filterHeight: filterHeight,
         filterWidth: filterWidth,
+        effectiveFilterHeight: effectiveFilterHeight,
+        effectiveFilterWidth: effectiveFilterWidth,
         dilationHeight: dilationHeight,
         dilationWidth: dilationWidth,
         inShape: inShape,
@@ -20640,8 +21811,17 @@ function conditionalRound(value, roundingMode) {
             throw new Error("Unknown roundingMode " + roundingMode);
     }
 }
+function tupleValuesAreOne(param) {
+    var _a = parseTupleParam(param), dimA = _a[0], dimB = _a[1];
+    return dimA === 1 && dimB === 1;
+}
+exports.tupleValuesAreOne = tupleValuesAreOne;
+function eitherStridesOrDilationsAreOne(strides, dilations) {
+    return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+exports.eitherStridesOrDilationsAreOne = eitherStridesOrDilationsAreOne;
 
-},{"../util":194}],146:[function(require,module,exports){
+},{"../util":214}],159:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ERF_P = 0.3275911;
@@ -20651,7 +21831,64 @@ exports.ERF_A3 = 1.421413741;
 exports.ERF_A4 = -1.453152027;
 exports.ERF_A5 = 1.061405429;
 
-},{}],147:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function gatherND_(x, indices) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'gatherND', 'int32');
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'gatherND');
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.gatherND($x, $indices); }, { $x: $x, $indices: $indices });
+}
+exports.gatherND = operation_1.op({ gatherND_: gatherND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],161:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function prepareAndValidate(tensor, indices) {
+    if (tensor.rank < 1) {
+        throw new Error('tf.gatherND() expects the input to be rank 1 or higher,' +
+            (" but the rank was " + tensor.rank + "."));
+    }
+    if (indices.rank < 1) {
+        throw new Error('tf.gatherND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error('tf.gatherND() expects the indices to be int32 type,' +
+            (" but the dtype was " + indices.dtype + "."));
+    }
+    if (indices.shape[indices.rank - 1] > tensor.rank) {
+        throw new Error('index innermost dimension length must be <= tensor rank; saw: ' +
+            (indices.shape[indices.rank - 1] + " vs. " + tensor.rank));
+    }
+    if (tensor.size === 0) {
+        throw new Error('Requested more than 0 entries, but input is empty.' +
+            (" Input shape: " + tensor.shape + "."));
+    }
+    var indicesShape = indices.shape;
+    var sliceRank = indicesShape[indicesShape.length - 1];
+    var nResult = 1;
+    for (var i = 0; i < indicesShape.length - 1; ++i) {
+        nResult *= indicesShape[i];
+    }
+    var inputShape = tensor.shape;
+    var resultShape = indicesShape.slice();
+    resultShape.pop();
+    var sliceSize = 1;
+    for (var i = sliceRank; i < tensor.rank; ++i) {
+        sliceSize *= inputShape[i];
+        resultShape.push(inputShape[i]);
+    }
+    var strides = util_1.computeStrides(tensor.shape).map(function (stride) { return stride / sliceSize; }).concat([1]).slice(0, sliceRank);
+    return [resultShape, nResult, sliceSize, strides];
+}
+exports.prepareAndValidate = prepareAndValidate;
+
+},{"../util":214}],162:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -20846,7 +22083,7 @@ exports.nonMaxSuppression = operation_1.op({ nonMaxSuppression_: nonMaxSuppressi
 exports.nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
 exports.cropAndResize = cropAndResize_;
 
-},{"../environment":64,"../kernels/non_max_suppression_impl":84,"../tensor_util_env":190,"../util":194,"./operation":156}],148:[function(require,module,exports){
+},{"../environment":64,"../kernels/non_max_suppression_impl":85,"../tensor_util_env":210,"../util":214,"./operation":171}],163:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -20992,7 +22229,7 @@ function qr2d(x, fullMatrices) {
 exports.gramSchmidt = operation_1.op({ gramSchmidt_: gramSchmidt_ });
 exports.qr = operation_1.op({ qr_: qr_ });
 
-},{"../environment":64,"../globals":66,"../util":194,"./array_ops":134,"./concat_split":142,"./norm":155,"./operation":156,"./reduction_ops":161,"./tensor_ops":171}],149:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../util":214,"./array_ops":146,"./concat_split":154,"./norm":170,"./operation":171,"./reduction_ops":176,"./tensor_ops":191}],164:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -21109,7 +22346,7 @@ exports.logicalXor = operation_1.op({ logicalXor_: logicalXor_ });
 exports.where = operation_1.op({ where_: where_ });
 exports.whereAsync = whereAsync_;
 
-},{"../environment":64,"../kernels/where_impl":132,"../tensor_util_env":190,"../util":194,"./broadcast_util":139,"./operation":156,"./tensor_ops":171}],150:[function(require,module,exports){
+},{"../environment":64,"../kernels/where_impl":143,"../tensor_util_env":210,"../util":214,"./broadcast_util":151,"./operation":171,"./tensor_ops":191}],165:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var globals_1 = require("../globals");
@@ -21334,7 +22571,7 @@ exports.meanSquaredError = operation_1.op({ meanSquaredError_: meanSquaredError_
 exports.sigmoidCrossEntropy = operation_1.op({ sigmoidCrossEntropy_: sigmoidCrossEntropy_ });
 exports.softmaxCrossEntropy = operation_1.op({ softmaxCrossEntropy_: softmaxCrossEntropy_ });
 
-},{"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],151:[function(require,module,exports){
+},{"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],166:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21371,7 +22608,7 @@ function localResponseNormalization_(x, depthRadius, bias, alpha, beta) {
 }
 exports.localResponseNormalization = operation_1.op({ localResponseNormalization_: localResponseNormalization_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],152:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],167:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21420,7 +22657,7 @@ function basicLSTMCell_(forgetBias, lstmKernel, lstmBias, data, c, h) {
 exports.basicLSTMCell = operation_1.op({ basicLSTMCell_: basicLSTMCell_ });
 exports.multiRNNCell = operation_1.op({ multiRNNCell_: multiRNNCell_ });
 
-},{"../tensor_util_env":190,"./operation":156}],153:[function(require,module,exports){
+},{"../tensor_util_env":210,"./operation":171}],168:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21516,7 +22753,7 @@ exports.matMul = operation_1.op({ matMul_: matMul_ });
 exports.dot = operation_1.op({ dot_: dot_ });
 exports.outerProduct = operation_1.op({ outerProduct_: outerProduct_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156}],154:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171}],169:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_1 = require("../tensor_util");
@@ -21544,7 +22781,7 @@ function movingAverage_(v, x, decay, step, zeroDebias) {
 }
 exports.movingAverage = operation_1.op({ movingAverage_: movingAverage_ });
 
-},{"../tensor_util":189,"../tensor_util_env":190,"../util":194,"./binary_ops":138,"./operation":156,"./tensor_ops":171}],155:[function(require,module,exports){
+},{"../tensor_util":209,"../tensor_util_env":210,"../util":214,"./binary_ops":150,"./operation":171,"./tensor_ops":191}],170:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_util_env_1 = require("../tensor_util_env");
@@ -21607,7 +22844,7 @@ function normImpl(x, p, axis) {
 }
 exports.norm = operation_1.op({ norm_: norm_ });
 
-},{"../tensor_util_env":190,"./axis_util":136,"./operation":156,"./tensor_ops":171}],156:[function(require,module,exports){
+},{"../tensor_util_env":210,"./axis_util":148,"./operation":171,"./tensor_ops":191}],171:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21647,7 +22884,7 @@ function op(f) {
 }
 exports.op = op;
 
-},{"../environment":64}],157:[function(require,module,exports){
+},{"../environment":64}],172:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -21678,6 +22915,10 @@ __export(require("./lstm"));
 __export(require("./moving_average"));
 __export(require("./strided_slice"));
 __export(require("./topk"));
+__export(require("./scatter_nd"));
+__export(require("./spectral_ops"));
+__export(require("./sparse_to_dense"));
+__export(require("./gather_nd"));
 var operation_1 = require("./operation");
 exports.op = operation_1.op;
 var losses = require("./loss_ops");
@@ -21686,8 +22927,10 @@ var linalg = require("./linalg_ops");
 exports.linalg = linalg;
 var image = require("./image_ops");
 exports.image = image;
+var spectral = require("./spectral_ops");
+exports.spectral = spectral;
 
-},{"./array_ops":134,"./batchnorm":137,"./binary_ops":138,"./compare":140,"./complex_ops":141,"./concat_split":142,"./conv":144,"./image_ops":147,"./linalg_ops":148,"./logical_ops":149,"./loss_ops":150,"./lrn":151,"./lstm":152,"./matmul":153,"./moving_average":154,"./norm":155,"./operation":156,"./pool":158,"./reduction_ops":161,"./relu_ops":162,"./reverse":163,"./segment_ops":164,"./slice":167,"./softmax":169,"./strided_slice":170,"./tensor_ops":171,"./topk":172,"./transpose":173,"./unary_ops":174}],158:[function(require,module,exports){
+},{"./array_ops":146,"./batchnorm":149,"./binary_ops":150,"./compare":152,"./complex_ops":153,"./concat_split":154,"./conv":157,"./gather_nd":160,"./image_ops":162,"./linalg_ops":163,"./logical_ops":164,"./loss_ops":165,"./lrn":166,"./lstm":167,"./matmul":168,"./moving_average":169,"./norm":170,"./operation":171,"./pool":173,"./reduction_ops":176,"./relu_ops":177,"./reverse":178,"./scatter_nd":179,"./segment_ops":181,"./slice":184,"./softmax":186,"./sparse_to_dense":187,"./spectral_ops":189,"./strided_slice":190,"./tensor_ops":191,"./topk":192,"./transpose":193,"./unary_ops":194}],173:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21695,7 +22938,7 @@ var tensor_util_env_1 = require("../tensor_util_env");
 var util = require("../util");
 var conv_util = require("./conv_util");
 var operation_1 = require("./operation");
-function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'maxPool');
     var x4D = $x;
     var reshapedTo4D = false;
@@ -21703,18 +22946,21 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
         reshapedTo4D = true;
         x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
     }
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
     util.assert(x4D.rank === 4, "Error in maxPool: input must be rank 4 but got rank " + x4D.rank + ".");
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     if (dimRoundingMode != null) {
         util.assert(util.isInt(pad), "Error in maxPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var grad = function (dy, saved) {
         var y4D = saved[0];
         return {
-            x: function () {
-                return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, pad);
-            }
+            x: function () { return maxPoolBackprop(dy, x4D, y4D, filterSize, strides, dilations, pad); }
         };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.maxPool(x4D, convInfo)); }, { x: x4D }, grad);
@@ -21723,9 +22969,17 @@ function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+function maxPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return maxPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function avgPoolImpl_(x, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'avgPool');
     util.assert($x.dtype === 'float32', 'The input dtype to avgPool must be float32');
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPool: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var x4D = $x;
     var reshapedTo4D = false;
     if ($x.rank === 3) {
@@ -21737,9 +22991,11 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
         util.assert(util.isInt(pad), "Error in avgPool: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(x4D.shape, filterSize, strides, dilations, pad);
     var grad = function (dy) {
-        return { x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, pad); } };
+        return {
+            x: function () { return avgPoolBackprop(dy, x4D, filterSize, strides, dilations, pad); }
+        };
     };
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPool(x4D, convInfo); }, { x: x4D }, grad);
     res = res.cast($x.dtype);
@@ -21748,11 +23004,33 @@ function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
     }
     return res;
 }
-function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundingMode) {
+function avgPool_(x, filterSize, strides, pad, dimRoundingMode) {
+    return avgPoolImpl_(x, filterSize, strides, 1, pad, dimRoundingMode);
+}
+function pool_(input, windowShape, poolingType, padding, dilationRate, strides) {
+    if (dilationRate == null) {
+        dilationRate = 1;
+    }
+    if (strides == null) {
+        strides = 1;
+    }
+    if (poolingType === 'avg') {
+        return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+    else {
+        return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+    }
+}
+function maxPoolBackprop(dy, input, output, filterSize, strides, dilations, pad, dimRoundingMode) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'maxPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'maxPoolBackprop');
     var $output = tensor_util_env_1.convertToTensor(output, 'output', 'maxPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in maxPoolBackProp: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     util.assert($dy.rank === 4, "Error in maxPoolBackprop: dy must be rank 4 but got rank " +
         ($dy.rank + "."));
     util.assert($input.rank === 4, "Error in maxPoolBackprop: input must be rank 4 but got rank " +
@@ -21761,14 +23039,19 @@ function maxPoolBackprop(dy, input, output, filterSize, strides, pad, dimRoundin
         util.assert(util.isInt(pad), "Error in maxPoolBackprop: pad must be an integer when using, " +
             ("dimRoundingMode " + dimRoundingMode + " but got pad " + pad + "."));
     }
-    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, pad, dimRoundingMode);
+    var convInfo = conv_util.computePool2DInfo($input.shape, filterSize, strides, dilations, pad, dimRoundingMode);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.maxPoolBackprop($dy, $input, $output, convInfo); }, { $dy: $dy, $input: $input });
     return res;
 }
-function avgPoolBackprop(dy, input, filterSize, strides, pad) {
+function avgPoolBackprop(dy, input, filterSize, strides, dilations, pad) {
     var $dy = tensor_util_env_1.convertToTensor(dy, 'dy', 'avgPoolBackprop');
     var $input = tensor_util_env_1.convertToTensor(input, 'input', 'avgPoolBackprop');
     util.assert($input.rank === $dy.rank, "Rank of input (" + $input.rank + ") does not match rank of dy (" + $dy.rank + ")");
+    if (dilations == null) {
+        dilations = [1, 1];
+    }
+    util.assert(conv_util.eitherStridesOrDilationsAreOne(strides, dilations), 'Error in avgPoolBackprop: Either strides or dilations must be 1. ' +
+        ("Got strides " + strides + " and dilations '" + dilations + "'"));
     var input4D = $input;
     var dy4D = $dy;
     var reshapedTo4D = false;
@@ -21781,7 +23064,7 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
         (dy4D.rank + "."));
     util.assert(input4D.rank === 4, "Error in avgPoolBackprop: input must be rank 4 but got rank " +
         (input4D.rank + "."));
-    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, pad);
+    var convInfo = conv_util.computePool2DInfo(input4D.shape, filterSize, strides, dilations, pad);
     var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.avgPoolBackprop(dy4D, input4D, convInfo); }, { dy4D: dy4D, input4D: input4D });
     if (reshapedTo4D) {
         return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
@@ -21790,8 +23073,9 @@ function avgPoolBackprop(dy, input, filterSize, strides, pad) {
 }
 exports.maxPool = operation_1.op({ maxPool_: maxPool_ });
 exports.avgPool = operation_1.op({ avgPool_: avgPool_ });
+exports.pool = operation_1.op({ pool_: pool_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./conv_util":145,"./operation":156}],159:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./conv_util":158,"./operation":171}],174:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var seedrandom = require("seedrandom");
@@ -21849,7 +23133,7 @@ var MPRandGauss = (function () {
 }());
 exports.MPRandGauss = MPRandGauss;
 
-},{"seedrandom":281}],160:[function(require,module,exports){
+},{"seedrandom":305}],175:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -21862,7 +23146,7 @@ function computeOptimalWindowSize(inSize) {
 }
 exports.computeOptimalWindowSize = computeOptimalWindowSize;
 
-},{"../util":194}],161:[function(require,module,exports){
+},{"../util":214}],176:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -21923,6 +23207,28 @@ function sum_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function prod_(x, axis, keepDims) {
+    if (axis === void 0) { axis = null; }
+    if (keepDims === void 0) { keepDims = false; }
+    var $x = tensor_util_env_1.convertToTensor(x, 'x', 'prod');
+    if ($x.dtype === 'bool') {
+        $x = $x.toInt();
+    }
+    var axes = axis_util.parseAxisParam(axis, $x.shape);
+    var permutation = axis_util.getAxesPermutation(axes, $x.rank);
+    var reductionAxes = axes;
+    var permutedX = $x;
+    if (permutation != null) {
+        permutedX = $x.transpose(permutation);
+        reductionAxes = axis_util.getInnerMostAxes(reductionAxes.length, $x.rank);
+    }
+    var value = environment_1.ENV.engine.runKernel(function (backend) { return backend.prod(permutedX, reductionAxes); }, { permutedX: permutedX });
+    if (keepDims) {
+        var newShape = axis_util.expandShapeToKeepDim(value.shape, axes);
+        value = value.reshape(newShape);
+    }
+    return value;
+}
 function mean_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
@@ -21949,10 +23255,26 @@ function mean_(x, axis, keepDims) {
     });
     return customOp($x);
 }
+function gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes) {
+    var y = saved[0];
+    if (y.rank < xOrig.rank) {
+        y = y.reshape(axis_util.expandShapeToKeepDim(y.shape, origAxes));
+    }
+    if (dy.rank < xOrig.rank) {
+        dy = dy.reshape(axis_util.expandShapeToKeepDim(dy.shape, origAxes));
+    }
+    return {
+        $x: function () {
+            var dx = dy.mul(xOrig.equal(y).cast(dy.dtype));
+            return permutedAxes == null ? dx : dx.transpose(permutedAxes);
+        }
+    };
+}
 function min_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'min');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -21960,10 +23282,13 @@ function min_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.min($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.min($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -21971,6 +23296,7 @@ function max_(x, axis, keepDims) {
     if (axis === void 0) { axis = null; }
     if (keepDims === void 0) { keepDims = false; }
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'max');
+    var xOrig = $x;
     var origAxes = axis_util.parseAxisParam(axis, $x.shape);
     var axes = origAxes;
     var permutedAxes = axis_util.getAxesPermutation(axes, $x.rank);
@@ -21978,10 +23304,13 @@ function max_(x, axis, keepDims) {
         $x = $x.transpose(permutedAxes);
         axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
     }
-    var res = environment_1.ENV.engine.runKernel(function (backend) { return backend.max($x, axes); }, { $x: $x });
+    var grad = function (dy, saved) {
+        return gradForMinAndMax(dy, saved, xOrig, origAxes, permutedAxes);
+    };
+    var res = environment_1.ENV.engine.runKernel(function (backend, save) { return save(backend.max($x, axes)); }, { $x: $x }, grad);
     if (keepDims) {
         var newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
-        return res.reshape(newShape);
+        res = res.reshape(newShape);
     }
     return res;
 }
@@ -22081,8 +23410,9 @@ exports.mean = operation_1.op({ mean_: mean_ });
 exports.min = operation_1.op({ min_: min_ });
 exports.moments = operation_1.op({ moments_: moments_ });
 exports.sum = operation_1.op({ sum_: sum_ });
+exports.prod = operation_1.op({ prod_: prod_ });
 
-},{"../environment":64,"../globals":66,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156,"./tensor_ops":171}],162:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171,"./tensor_ops":191}],177:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22148,7 +23478,7 @@ exports.prelu = operation_1.op({ prelu_: prelu_ });
 exports.relu = operation_1.op({ relu_: relu_ });
 exports.selu = operation_1.op({ selu_: selu_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./binary_ops":138,"./logical_ops":149,"./operation":156,"./selu_util":166,"./tensor_ops":171}],163:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./binary_ops":150,"./logical_ops":164,"./operation":171,"./selu_util":183,"./tensor_ops":191}],178:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22194,7 +23524,99 @@ exports.reverse2d = operation_1.op({ reverse2d_: reverse2d_ });
 exports.reverse3d = operation_1.op({ reverse3d_: reverse3d_ });
 exports.reverse4d = operation_1.op({ reverse4d_: reverse4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],164:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],179:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+var scatter_nd_util = require("./scatter_nd_util");
+function scatterND_(indices, updates, shape) {
+    var $indices = tensor_util_env_1.convertToTensor(indices, 'indices', 'scatterND', 'int32');
+    var $updates = tensor_util_env_1.convertToTensor(updates, 'updates', 'scatterND');
+    scatter_nd_util.validateInput($updates, $indices, shape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.scatterND($indices, $updates, shape); }, { $indices: $indices, $updates: $updates });
+}
+exports.scatterND = operation_1.op({ scatterND_: scatterND_ });
+
+},{"../environment":64,"../tensor_util_env":210,"./operation":171,"./scatter_nd_util":180}],180:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var util_1 = require("../util");
+function validateUpdateShape(shape, indices, updates) {
+    var sliceDim = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var batchDim = (indices.rank > 1) ? indices.rank - 1 : 1;
+    var shapeError = 'Must have updates.shape = indices.shape[:batchDim] + ' +
+        ("shape[sliceDim:], got updates.shape: " + updates.shape) +
+        (", indices.shape: " + indices.shape + ", shape: " + shape) +
+        (", sliceDim: " + sliceDim + ", and batchDim: " + batchDim + ".");
+    if (updates.rank < batchDim) {
+        throw new Error(shapeError + (" update.rank < " + batchDim + ". "));
+    }
+    if (shape.length < sliceDim + (updates.rank - batchDim)) {
+        throw new Error(shapeError +
+            (" Output shape length < " + (sliceDim + (updates.rank - batchDim))));
+    }
+    if (updates.rank !== batchDim + shape.length - sliceDim) {
+        throw new Error(shapeError + (" update.rank != " + (batchDim + shape.length - sliceDim)));
+    }
+    for (var d = 0; d < batchDim; ++d) {
+        if (updates.shape[d] !== indices.shape[d]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + d + "] (" + updates.shape[d] + ") != indices.shape[" + d + "] (" + indices.shape[d] + ")."));
+        }
+    }
+    for (var d = 0; d < updates.rank - batchDim; ++d) {
+        if (updates.shape[d + batchDim] !== shape[d + sliceDim]) {
+            throw new Error(shapeError +
+                (" updates.shape[" + (d + batchDim) + "] (" + updates.shape[d + batchDim] + ") != shape[" + (d + batchDim) + "] (" + shape[d + batchDim] + ")"));
+        }
+    }
+}
+exports.validateUpdateShape = validateUpdateShape;
+function validateInput(updates, indices, shape) {
+    if (indices.rank < 1) {
+        throw new Error('tf.scatterND() expects the indices to be rank 1 or higher,' +
+            (" but the rank was " + indices.rank + "."));
+    }
+    if (updates.rank < 1) {
+        throw new Error('tf.scatterND() expects the updates to be rank 1 or higher,' +
+            (" but the rank was " + updates.rank + "."));
+    }
+    if (indices.dtype !== 'int32') {
+        throw new Error("The dtype of 'indices' should be int32, but got dtype: " + indices.dtype);
+    }
+    if (shape.length < 1) {
+        throw new Error("Output rank must be greater or equal to 1, but got shape: " + shape);
+    }
+    if (shape.length === 0) {
+        if (indices.size === 0) {
+            throw new Error("Indices specified for empty output. indices shape: " + indices.shape);
+        }
+        if (updates.size === 0) {
+            throw new Error("Updates specified for empty output. updates shape: " + updates.shape);
+        }
+    }
+    validateUpdateShape(shape, indices, updates);
+}
+exports.validateInput = validateInput;
+function calculateShapes(updates, indices, shape) {
+    var sliceRank = (indices.rank > 1) ? indices.shape[indices.rank - 1] : 1;
+    var totalNd = shape.length;
+    var sliceSize = 1;
+    for (var i = sliceRank; i < totalNd; ++i) {
+        sliceSize *= shape[i];
+    }
+    var safeSliceDim = (sliceRank < 1) ? 1 : sliceRank;
+    var numUpdates = indices.size / safeSliceDim;
+    var outputStrides = util_1.computeStrides(shape).concat([1]);
+    var strides = outputStrides.slice(outputStrides.length - sliceRank, outputStrides.length);
+    var outputSize = util_1.sizeFromShape(shape);
+    return { sliceRank: sliceRank, numUpdates: numUpdates, sliceSize: sliceSize, strides: strides, outputSize: outputSize };
+}
+exports.calculateShapes = calculateShapes;
+
+},{"../util":214}],181:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22286,7 +23708,7 @@ function gatherDropNegatives(x, indices) {
 exports.gather = operation_1.op({ gather_: gather_ });
 exports.unsortedSegmentSum = operation_1.op({ unsortedSegmentSum_: unsortedSegmentSum_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./array_ops":134,"./axis_util":136,"./binary_ops":138,"./compare":140,"./logical_ops":149,"./operation":156,"./tensor_ops":171}],165:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./array_ops":146,"./axis_util":148,"./binary_ops":150,"./compare":152,"./logical_ops":164,"./operation":171,"./tensor_ops":191}],182:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("../util");
@@ -22328,13 +23750,13 @@ function computeOutShape(aShape, axis, numSegments) {
 }
 exports.computeOutShape = computeOutShape;
 
-},{"../util":194,"./reduce_util":160}],166:[function(require,module,exports){
+},{"../util":214,"./reduce_util":175}],183:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SELU_SCALEALPHA = 1.7580993408473768599402175208123;
 exports.SELU_SCALE = 1.0507009873554804934193349852946;
 
-},{}],167:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22349,17 +23771,17 @@ function slice1d_(x, begin, size) {
 }
 function slice2d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice2d');
-    util.assert($x.rank === 2, "slice1d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 2, "slice2d expects a rank-2 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice3d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice3d');
-    util.assert($x.rank === 3, "slice1d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 3, "slice3d expects a rank-3 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice4d_(x, begin, size) {
     var $x = tensor_util_env_1.convertToTensor(x, 'x', 'slice4d');
-    util.assert($x.rank === 4, "slice1d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
+    util.assert($x.rank === 4, "slice4d expects a rank-4 tensor, but got a rank-" + $x.rank + " tensor");
     return exports.slice($x, begin, size);
 }
 function slice_(x, begin, size) {
@@ -22416,7 +23838,7 @@ exports.slice2d = operation_1.op({ slice2d_: slice2d_ });
 exports.slice3d = operation_1.op({ slice3d_: slice3d_ });
 exports.slice4d = operation_1.op({ slice4d_: slice4d_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./slice_util":168}],168:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./slice_util":185}],185:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("../util");
@@ -22507,7 +23929,7 @@ function stopForAxis(endMask, stopIndices, strides, inputShape, axis) {
 }
 exports.stopForAxis = stopForAxis;
 
-},{"../util":194}],169:[function(require,module,exports){
+},{"../util":214}],186:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gradients_1 = require("../gradients");
@@ -22539,7 +23961,67 @@ function softmax_(logits, dim) {
 }
 exports.softmax = operation_1.op({ softmax_: softmax_ });
 
-},{"../gradients":67,"../tensor_util_env":190,"./operation":156}],170:[function(require,module,exports){
+},{"../gradients":67,"../tensor_util_env":210,"./operation":171}],187:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var sparse_to_dense = require("../ops/sparse_to_dense_util");
+var tensor_util_env_1 = require("../tensor_util_env");
+var operation_1 = require("./operation");
+function sparseToDense_(sparseIndices, sparseValues, outputShape, defaultValue) {
+    var $sparseIndices = tensor_util_env_1.convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
+    var $sparseValues = tensor_util_env_1.convertToTensor(sparseValues, 'sparseValues', 'sparseToDense');
+    var $defaultValue = tensor_util_env_1.convertToTensor(defaultValue, 'defaultValue', 'sparseToDense');
+    sparse_to_dense.validateInput($sparseIndices, $sparseValues, outputShape);
+    return environment_1.ENV.engine.runKernel(function (backend) { return backend.sparseToDense($sparseIndices, $sparseValues, outputShape, $defaultValue); }, { $sparseIndices: $sparseIndices, $sparseValues: $sparseValues, $defaultValue: $defaultValue });
+}
+exports.sparseToDense = operation_1.op({ sparseToDense_: sparseToDense_ });
+
+},{"../environment":64,"../ops/sparse_to_dense_util":188,"../tensor_util_env":210,"./operation":171}],188:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateInput(sparseIndices, sparseValues, outputShape) {
+    if (sparseIndices.dtype !== 'int32') {
+        throw new Error('tf.sparseToDense() expects the indices to be int32 type,' +
+            (" but the dtype was " + sparseIndices.dtype + "."));
+    }
+    if (sparseIndices.rank > 2) {
+        throw new Error('sparseIndices should be a scalar, vector, or matrix,' +
+            (" but got shape " + sparseIndices.shape + "."));
+    }
+    var numElems = sparseIndices.rank > 0 ? sparseIndices.shape[0] : 1;
+    var numDims = sparseIndices.rank > 1 ? sparseIndices.shape[1] : 1;
+    if (outputShape.length !== numDims) {
+        throw new Error('outputShape has incorrect number of elements:,' +
+            (" " + outputShape.length + ", should be: " + numDims + "."));
+    }
+    var numValues = sparseValues.size;
+    if (!(sparseValues.rank === 0 ||
+        sparseValues.rank === 1 && numValues === numElems)) {
+        throw new Error('sparseValues has incorrect shape ' +
+            (sparseValues.shape + ", should be [] or [" + numElems + "]"));
+    }
+}
+exports.validateInput = validateInput;
+
+},{}],189:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var environment_1 = require("../environment");
+var operation_1 = require("../ops/operation");
+var util_1 = require("../util");
+function fft_(input) {
+    util_1.assert(input.dtype === 'complex64', "The dtype for tf.spectral.fft() must be complex64 " +
+        ("but got " + input.dtype + "."));
+    var innerDimensionSize = input.shape[input.shape.length - 1];
+    var batch = input.size / innerDimensionSize;
+    var input2D = input.as2D(batch, innerDimensionSize);
+    var ret = environment_1.ENV.engine.runKernel(function (backend) { return backend.fft(input2D); }, { input: input });
+    return ret.reshape(input.shape);
+}
+exports.fft = operation_1.op({ fft_: fft_ });
+
+},{"../environment":64,"../ops/operation":171,"../util":214}],190:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22562,12 +24044,13 @@ function stridedSlice_(x, begin, end, strides, beginMask, endMask, ellipsisMask,
 }
 exports.stridedSlice = operation_1.op({ stridedSlice_: stridedSlice_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],171:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],191:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
 var tensor_1 = require("../tensor");
 var tensor_util_env_1 = require("../tensor_util_env");
+var tensor_util_env_2 = require("../tensor_util_env");
 var util_1 = require("../util");
 var complex_ops_1 = require("./complex_ops");
 var operation_1 = require("./operation");
@@ -22582,7 +24065,7 @@ function tensor(values, shape, dtype) {
         throw new Error('values passed to tensor(values) must be an ' +
             'array of numbers or booleans, or a TypedArray');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (shape != null && inferredShape.length !== 1) {
         util_1.assertShapesMatch(shape, inferredShape, "Error creating a new Tensor. " +
             ("Inferred shape (" + inferredShape + ") does not match the ") +
@@ -22609,7 +24092,7 @@ exports.scalar = scalar;
 function tensor1d(values, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     util_1.assertNonNull(values);
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 1) {
         throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
@@ -22622,7 +24105,7 @@ function tensor2d(values, shape, dtype) {
     if (shape != null && shape.length !== 2) {
         throw new Error('tensor2d() requires shape to have two numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
         throw new Error('tensor2d() requires values to be number[][] or flat/TypedArray');
     }
@@ -22640,7 +24123,7 @@ function tensor3d(values, shape, dtype) {
     if (shape != null && shape.length !== 3) {
         throw new Error('tensor3d() requires shape to have three numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
         throw new Error('tensor3d() requires values to be number[][][] or flat/TypedArray');
     }
@@ -22658,7 +24141,7 @@ function tensor4d(values, shape, dtype) {
     if (shape != null && shape.length !== 4) {
         throw new Error('tensor4d() requires shape to have four numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
         throw new Error('tensor4d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22676,7 +24159,7 @@ function tensor5d(values, shape, dtype) {
     if (shape != null && shape.length !== 5) {
         throw new Error('tensor5d() requires shape to have five numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 5 && inferredShape.length !== 1) {
         throw new Error('tensor5d() requires values to be ' +
             'number[][][][][] or flat/TypedArray');
@@ -22695,7 +24178,7 @@ function tensor6d(values, shape, dtype) {
     if (shape != null && shape.length !== 6) {
         throw new Error('tensor6d() requires shape to have six numbers');
     }
-    var inferredShape = util_1.inferShape(values);
+    var inferredShape = tensor_util_env_2.inferShape(values);
     if (inferredShape.length !== 6 && inferredShape.length !== 1) {
         throw new Error('tensor6d() requires values to be number[][][][] or flat/TypedArray');
     }
@@ -22786,7 +24269,7 @@ exports.range = range;
 exports.onesLike = operation_1.op({ onesLike_: onesLike_ });
 exports.zerosLike = operation_1.op({ zerosLike_: zerosLike_ });
 
-},{"../environment":64,"../tensor":187,"../tensor_util_env":190,"../util":194,"./complex_ops":141,"./operation":156}],172:[function(require,module,exports){
+},{"../environment":64,"../tensor":207,"../tensor_util_env":210,"../util":214,"./complex_ops":153,"./operation":171}],192:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22809,7 +24292,7 @@ function topk_(x, k, sorted) {
 }
 exports.topk = operation_1.op({ topk_: topk_ });
 
-},{"../environment":64,"../tensor_util_env":190,"./operation":156}],173:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"./operation":171}],193:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -22839,7 +24322,7 @@ function transpose_(x, perm) {
 }
 exports.transpose = operation_1.op({ transpose_: transpose_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./axis_util":136,"./operation":156}],174:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./axis_util":148,"./operation":171}],194:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("../environment");
@@ -23129,7 +24612,7 @@ exports.step = operation_1.op({ step_: step_ });
 exports.tan = operation_1.op({ tan_: tan_ });
 exports.tanh = operation_1.op({ tanh_: tanh_ });
 
-},{"../environment":64,"../tensor_util_env":190,"../util":194,"./operation":156,"./tensor_ops":171}],175:[function(require,module,exports){
+},{"../environment":64,"../tensor_util_env":210,"../util":214,"./operation":171,"./tensor_ops":191}],195:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23236,7 +24719,7 @@ var AdadeltaOptimizer = (function (_super) {
 exports.AdadeltaOptimizer = AdadeltaOptimizer;
 serialization_1.registerClass(AdadeltaOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],176:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],196:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23318,7 +24801,7 @@ var AdagradOptimizer = (function (_super) {
 exports.AdagradOptimizer = AdagradOptimizer;
 serialization_1.registerClass(AdagradOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],177:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],197:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23437,7 +24920,7 @@ var AdamOptimizer = (function (_super) {
 exports.AdamOptimizer = AdamOptimizer;
 serialization_1.registerClass(AdamOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],178:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],198:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23558,7 +25041,7 @@ var AdamaxOptimizer = (function (_super) {
 exports.AdamaxOptimizer = AdamaxOptimizer;
 serialization_1.registerClass(AdamaxOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],179:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],199:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23648,7 +25131,7 @@ var MomentumOptimizer = (function (_super) {
 exports.MomentumOptimizer = MomentumOptimizer;
 serialization_1.registerClass(MomentumOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./sgd_optimizer":183}],180:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./sgd_optimizer":203}],200:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23689,7 +25172,7 @@ var Optimizer = (function (_super) {
 }(serialization_1.Serializable));
 exports.Optimizer = Optimizer;
 
-},{"../globals":66,"../serialization":185}],181:[function(require,module,exports){
+},{"../globals":66,"../serialization":205}],201:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./adadelta_optimizer");
@@ -23745,7 +25228,7 @@ var OptimizerConstructors = (function () {
 }());
 exports.OptimizerConstructors = OptimizerConstructors;
 
-},{"./adadelta_optimizer":175,"./adagrad_optimizer":176,"./adam_optimizer":177,"./adamax_optimizer":178,"./momentum_optimizer":179,"./rmsprop_optimizer":182,"./sgd_optimizer":183}],182:[function(require,module,exports){
+},{"./adadelta_optimizer":195,"./adagrad_optimizer":196,"./adam_optimizer":197,"./adamax_optimizer":198,"./momentum_optimizer":199,"./rmsprop_optimizer":202,"./sgd_optimizer":203}],202:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23889,7 +25372,7 @@ var RMSPropOptimizer = (function (_super) {
 exports.RMSPropOptimizer = RMSPropOptimizer;
 serialization_1.registerClass(RMSPropOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],183:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],203:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -23949,7 +25432,7 @@ var SGDOptimizer = (function (_super) {
 exports.SGDOptimizer = SGDOptimizer;
 serialization_1.registerClass(SGDOptimizer);
 
-},{"../environment":64,"../globals":66,"../ops/ops":157,"../serialization":185,"./optimizer":180}],184:[function(require,module,exports){
+},{"../environment":64,"../globals":66,"../ops/ops":172,"../serialization":205,"./optimizer":200}],204:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util = require("./util");
@@ -23973,7 +25456,11 @@ var Profiler = (function () {
             var vals = r.dataSync();
             util.checkComputationForNaN(vals, r.dtype, name);
             timer.then(function (timing) {
-                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+                var extraInfo = '';
+                if (timing.getExtraProfileInfo != null) {
+                    extraInfo = timing.getExtraProfileInfo();
+                }
+                _this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
             });
         });
         return result;
@@ -23984,19 +25471,19 @@ exports.Profiler = Profiler;
 var Logger = (function () {
     function Logger() {
     }
-    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs) {
+    Logger.prototype.logKernelProfile = function (name, result, vals, timeMs, extraInfo) {
         var time = util.rightPad(timeMs + "ms", 9);
         var paddedName = util.rightPad(name, 25);
         var rank = result.rank;
         var size = result.size;
         var shape = util.rightPad(result.shape.toString(), 14);
-        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        console.log("%c" + paddedName + "\t%c" + time + "\t%c" + rank + "D " + shape + "\t%c" + size + "\t%c" + extraInfo, 'font-weight:bold', 'color:red', 'color:blue', 'color: orange', 'color: green');
     };
     return Logger;
 }());
 exports.Logger = Logger;
 
-},{"./util":194}],185:[function(require,module,exports){
+},{"./util":214}],205:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -24041,7 +25528,7 @@ function registerClass(cls) {
 }
 exports.registerClass = registerClass;
 
-},{"./util":194}],186:[function(require,module,exports){
+},{"./util":214}],206:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -24154,7 +25641,7 @@ function backpropagateGradients(tensorAccumulatedGradientMap, filteredTape) {
 }
 exports.backpropagateGradients = backpropagateGradients;
 
-},{"./tensor":187,"./util":194}],187:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],207:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -24540,6 +26027,12 @@ var Tensor = (function () {
         if (keepDims === void 0) { keepDims = false; }
         this.throwIfDisposed();
         return opHandler.sum(this, axis, keepDims);
+    };
+    Tensor.prototype.prod = function (axis, keepDims) {
+        if (axis === void 0) { axis = null; }
+        if (keepDims === void 0) { keepDims = false; }
+        this.throwIfDisposed();
+        return opHandler.prod(this, axis, keepDims);
     };
     Tensor.prototype.mean = function (axis, keepDims) {
         if (axis === void 0) { axis = null; }
@@ -24941,6 +26434,10 @@ var Tensor = (function () {
         if (beta === void 0) { beta = 0.5; }
         return opHandler.localResponseNormalization(this, radius, bias, alpha, beta);
     };
+    Tensor.prototype.pool = function (windowShape, poolingType, padding, dilationRate, strides) {
+        this.throwIfDisposed();
+        return opHandler.pool(this, windowShape, poolingType, padding, dilationRate, strides);
+    };
     Tensor.prototype.variable = function (trainable, name, dtype) {
         if (trainable === void 0) { trainable = true; }
         this.throwIfDisposed();
@@ -24973,6 +26470,10 @@ var Tensor = (function () {
     Tensor.prototype.depthToSpace = function (blockSize, dataFormat) {
         this.throwIfDisposed();
         return opHandler.depthToSpace(this, blockSize, dataFormat);
+    };
+    Tensor.prototype.fft = function () {
+        this.throwIfDisposed();
+        return opHandler.spectral.fft(this);
     };
     Tensor.nextId = 0;
     return Tensor;
@@ -25036,7 +26537,7 @@ Object.defineProperty(Variable, Symbol.hasInstance, {
 var variable = Variable.variable;
 exports.variable = variable;
 
-},{"./tensor_format":188,"./util":194}],188:[function(require,module,exports){
+},{"./tensor_format":208,"./util":214}],208:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var util_1 = require("./util");
@@ -25167,7 +26668,7 @@ function createComplexTuples(vals) {
     return complexTuples;
 }
 
-},{"./util":194}],189:[function(require,module,exports){
+},{"./util":214}],209:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tensor_1 = require("./tensor");
@@ -25242,12 +26743,47 @@ function isIterable(obj) {
     return Array.isArray(obj) || typeof obj === 'object';
 }
 
-},{"./tensor":187,"./util":194}],190:[function(require,module,exports){
+},{"./tensor":207,"./util":214}],210:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
 var tensor_1 = require("./tensor");
 var util_1 = require("./util");
+function inferShape(val) {
+    var firstElem = val;
+    if (util_1.isTypedArray(val)) {
+        return [val.length];
+    }
+    if (!Array.isArray(val)) {
+        return [];
+    }
+    var shape = [];
+    while (firstElem instanceof Array) {
+        shape.push(firstElem.length);
+        firstElem = firstElem[0];
+    }
+    if (val instanceof Array && environment_1.ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+        deepAssertShapeConsistency(val, shape, []);
+    }
+    return shape;
+}
+exports.inferShape = inferShape;
+function deepAssertShapeConsistency(val, shape, indices) {
+    indices = indices || [];
+    if (!(val instanceof Array)) {
+        util_1.assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
+            ("but should be an array of " + shape[0] + " elements"); });
+        return;
+    }
+    util_1.assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
+        ("but is an array of " + val.length + " elements"); });
+    util_1.assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
+        ("elements, but has " + val.length + " elements"); });
+    var subShape = shape.slice(1);
+    for (var i = 0; i < val.length; ++i) {
+        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
+    }
+}
 function convertToTensor(x, argName, functionName, dtype) {
     if (dtype === void 0) { dtype = 'float32'; }
     dtype = dtype || 'float32';
@@ -25259,7 +26795,7 @@ function convertToTensor(x, argName, functionName, dtype) {
         throw new Error("Argument '" + argName + "' passed to '" + functionName + "' must be a " +
             ("Tensor or TensorLike, but got " + x.constructor.name));
     }
-    var inferredShape = util_1.inferShape(x);
+    var inferredShape = inferShape(x);
     if (!util_1.isTypedArray(x) && !Array.isArray(x)) {
         x = [x];
     }
@@ -25276,7 +26812,7 @@ function convertToTensorArray(arg, argName, functionName) {
 }
 exports.convertToTensorArray = convertToTensorArray;
 
-},{"./environment":64,"./tensor":187,"./util":194}],191:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],211:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var environment_1 = require("./environment");
@@ -25296,6 +26832,9 @@ exports.BROWSER_ENVS = {
 };
 exports.CPU_ENVS = {
     'HAS_WEBGL': false
+};
+exports.BROWSER_CPU_ENVS = {
+    'BACKEND': 'test-cpu'
 };
 exports.ALL_ENVS = {};
 function expectArraysClose(actual, expected, epsilon) {
@@ -25397,7 +26936,7 @@ function expectArrayBuffersEqual(actual, expected) {
 }
 exports.expectArrayBuffersEqual = expectArrayBuffersEqual;
 
-},{"./environment":64,"./tensor":187,"./util":194}],192:[function(require,module,exports){
+},{"./environment":64,"./tensor":207,"./util":214}],212:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var adadelta_optimizer_1 = require("./optimizers/adadelta_optimizer");
@@ -25420,7 +26959,7 @@ exports.train = {
     adam: optimizer_constructors_1.OptimizerConstructors.adam
 };
 
-},{"./optimizers/adadelta_optimizer":175,"./optimizers/adagrad_optimizer":176,"./optimizers/adam_optimizer":177,"./optimizers/adamax_optimizer":178,"./optimizers/momentum_optimizer":179,"./optimizers/optimizer_constructors":181,"./optimizers/rmsprop_optimizer":182,"./optimizers/sgd_optimizer":183}],193:[function(require,module,exports){
+},{"./optimizers/adadelta_optimizer":195,"./optimizers/adagrad_optimizer":196,"./optimizers/adam_optimizer":197,"./optimizers/adamax_optimizer":198,"./optimizers/momentum_optimizer":199,"./optimizers/optimizer_constructors":201,"./optimizers/rmsprop_optimizer":202,"./optimizers/sgd_optimizer":203}],213:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var DType;
@@ -25482,7 +27021,7 @@ function sumOutType(type) {
 }
 exports.sumOutType = sumOutType;
 
-},{}],194:[function(require,module,exports){
+},{}],214:[function(require,module,exports){
 (function (process){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -25503,6 +27042,18 @@ function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 exports.clamp = clamp;
+function nearestLargerEven(val) {
+    return val % 2 === 0 ? val : val + 1;
+}
+exports.nearestLargerEven = nearestLargerEven;
+function sum(arr) {
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) {
+        sum += arr[i];
+    }
+    return sum;
+}
+exports.sum = sum;
 function randUniform(a, b) {
     var r = Math.random();
     return (b * r) + (1 - r) * a;
@@ -25545,41 +27096,6 @@ function flatten(arr, ret) {
     return ret;
 }
 exports.flatten = flatten;
-function inferShape(val) {
-    var firstElem = val;
-    if (isTypedArray(val)) {
-        return [val.length];
-    }
-    if (!Array.isArray(val)) {
-        return [];
-    }
-    var shape = [];
-    while (firstElem instanceof Array) {
-        shape.push(firstElem.length);
-        firstElem = firstElem[0];
-    }
-    if (val instanceof Array) {
-        deepAssertShapeConsistency(val, shape, []);
-    }
-    return shape;
-}
-exports.inferShape = inferShape;
-function deepAssertShapeConsistency(val, shape, indices) {
-    indices = indices || [];
-    if (!(val instanceof Array)) {
-        assert(shape.length === 0, function () { return "Element arr[" + indices.join('][') + "] is a primitive, " +
-            ("but should be an array of " + shape[0] + " elements"); });
-        return;
-    }
-    assert(shape.length > 0, function () { return "Element arr[" + indices.join('][') + "] should be a primitive, " +
-        ("but is an array of " + val.length + " elements"); });
-    assert(val.length === shape[0], function () { return "Element arr[" + indices.join('][') + "] should have " + shape[0] + " " +
-        ("elements, but has " + val.length + " elements"); });
-    var subShape = shape.slice(1);
-    for (var i = 0; i < val.length; ++i) {
-        deepAssertShapeConsistency(val[i], subShape, indices.concat(i));
-    }
-}
 function sizeFromShape(shape) {
     if (shape.length === 0) {
         return 1;
@@ -25596,6 +27112,12 @@ function isScalarShape(shape) {
 }
 exports.isScalarShape = isScalarShape;
 function arraysEqual(n1, n2) {
+    if (n1 === n2) {
+        return true;
+    }
+    if (n1 == null || n2 == null) {
+        return false;
+    }
     if (n1.length !== n2.length) {
         return false;
     }
@@ -25913,13 +27435,13 @@ function now() {
 exports.now = now;
 
 }).call(this,require('_process'))
-},{"_process":269}],195:[function(require,module,exports){
+},{"_process":293}],215:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.17';
+var version = '0.13.8';
 exports.version = version;
 
-},{}],196:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var gpgpu_util = require("./kernels/webgl/gpgpu_util");
@@ -25931,7 +27453,7 @@ exports.MathBackendWebGL = backend_webgl_1.MathBackendWebGL;
 var gpgpu_context_1 = require("./kernels/webgl/gpgpu_context");
 exports.GPGPUContext = gpgpu_context_1.GPGPUContext;
 
-},{"./kernels/backend_webgl":82,"./kernels/webgl/gpgpu_context":104,"./kernels/webgl/gpgpu_util":106,"./kernels/webgl/webgl_util":131}],197:[function(require,module,exports){
+},{"./kernels/backend_webgl":83,"./kernels/webgl/gpgpu_context":110,"./kernels/webgl/gpgpu_util":112,"./kernels/webgl/webgl_util":142}],217:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -25973,7 +27495,7 @@ var Elu = (function (_super) {
     return Elu;
 }(Activation));
 exports.Elu = Elu;
-tfjs_core_1.serialization.SerializationMap.register(Elu);
+tfjs_core_1.serialization.registerClass(Elu);
 var Selu = (function (_super) {
     __extends(Selu, _super);
     function Selu() {
@@ -25986,7 +27508,7 @@ var Selu = (function (_super) {
     return Selu;
 }(Activation));
 exports.Selu = Selu;
-tfjs_core_1.serialization.SerializationMap.register(Selu);
+tfjs_core_1.serialization.registerClass(Selu);
 var Relu = (function (_super) {
     __extends(Relu, _super);
     function Relu() {
@@ -25999,7 +27521,7 @@ var Relu = (function (_super) {
     return Relu;
 }(Activation));
 exports.Relu = Relu;
-tfjs_core_1.serialization.SerializationMap.register(Relu);
+tfjs_core_1.serialization.registerClass(Relu);
 var Relu6 = (function (_super) {
     __extends(Relu6, _super);
     function Relu6() {
@@ -26012,7 +27534,7 @@ var Relu6 = (function (_super) {
     return Relu6;
 }(Activation));
 exports.Relu6 = Relu6;
-tfjs_core_1.serialization.SerializationMap.register(Relu6);
+tfjs_core_1.serialization.registerClass(Relu6);
 var Linear = (function (_super) {
     __extends(Linear, _super);
     function Linear() {
@@ -26025,7 +27547,7 @@ var Linear = (function (_super) {
     return Linear;
 }(Activation));
 exports.Linear = Linear;
-tfjs_core_1.serialization.SerializationMap.register(Linear);
+tfjs_core_1.serialization.registerClass(Linear);
 var Sigmoid = (function (_super) {
     __extends(Sigmoid, _super);
     function Sigmoid() {
@@ -26038,7 +27560,7 @@ var Sigmoid = (function (_super) {
     return Sigmoid;
 }(Activation));
 exports.Sigmoid = Sigmoid;
-tfjs_core_1.serialization.SerializationMap.register(Sigmoid);
+tfjs_core_1.serialization.registerClass(Sigmoid);
 var HardSigmoid = (function (_super) {
     __extends(HardSigmoid, _super);
     function HardSigmoid() {
@@ -26051,7 +27573,7 @@ var HardSigmoid = (function (_super) {
     return HardSigmoid;
 }(Activation));
 exports.HardSigmoid = HardSigmoid;
-tfjs_core_1.serialization.SerializationMap.register(HardSigmoid);
+tfjs_core_1.serialization.registerClass(HardSigmoid);
 var Softplus = (function (_super) {
     __extends(Softplus, _super);
     function Softplus() {
@@ -26064,7 +27586,7 @@ var Softplus = (function (_super) {
     return Softplus;
 }(Activation));
 exports.Softplus = Softplus;
-tfjs_core_1.serialization.SerializationMap.register(Softplus);
+tfjs_core_1.serialization.registerClass(Softplus);
 var Softsign = (function (_super) {
     __extends(Softsign, _super);
     function Softsign() {
@@ -26077,7 +27599,7 @@ var Softsign = (function (_super) {
     return Softsign;
 }(Activation));
 exports.Softsign = Softsign;
-tfjs_core_1.serialization.SerializationMap.register(Softsign);
+tfjs_core_1.serialization.registerClass(Softsign);
 var Tanh = (function (_super) {
     __extends(Tanh, _super);
     function Tanh() {
@@ -26090,7 +27612,7 @@ var Tanh = (function (_super) {
     return Tanh;
 }(Activation));
 exports.Tanh = Tanh;
-tfjs_core_1.serialization.SerializationMap.register(Tanh);
+tfjs_core_1.serialization.registerClass(Tanh);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax() {
@@ -26104,7 +27626,7 @@ var Softmax = (function (_super) {
     return Softmax;
 }(Activation));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 function serializeActivation(activation) {
     return activation.getClassName();
 }
@@ -26132,7 +27654,7 @@ function getActivation(identifier) {
 }
 exports.getActivation = getActivation;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],198:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],218:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26150,7 +27672,7 @@ function imageDataFormat() {
 }
 exports.imageDataFormat = imageDataFormat;
 
-},{"@tensorflow/tfjs-core":68}],199:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -26195,7 +27717,7 @@ function disposeScalarCache() {
 }
 exports.disposeScalarCache = disposeScalarCache;
 
-},{"@tensorflow/tfjs-core":68}],200:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -26404,27 +27926,42 @@ function randomNormal(shape, mean, stddev, dtype, seed) {
 }
 exports.randomNormal = randomNormal;
 function dot(x, y) {
-    if (y.rank !== 2) {
-        throw new errors_1.NotImplementedError("dot support for y other than rank 2 is not yet implemented: " +
-            ("y shape = " + y.shape));
+    if ((x.rank < 2) || (y.rank < 2)) {
+        throw new errors_1.NotImplementedError("dot requires both inputs to be rank >= 2" +
+            (" but got x shape = " + x.shape + " and y shape = " + y.shape));
+    }
+    if (y.rank >= 3) {
+        var xLastDim = x.shape.slice(-1)[0];
+        var ySecondLastDim = y.shape.slice(-2)[0];
+        if (xLastDim !== ySecondLastDim) {
+            throw new errors_1.NotImplementedError("If rank y >= 3, then the second last dim" +
+                (" of y must equal the last dim of x but got x shape = " + x.shape + " and ") +
+                (" y shape = " + y.shape));
+        }
+    }
+    if ((x.rank === 2) && (y.rank === 2)) {
+        return tfc.matMul(x, y);
     }
     else {
-        if (x.rank === 2) {
-            return tfc.matMul(x, y);
-        }
-        else if (x.rank === 3) {
-            var xShape0 = x.shape[0];
-            var xShape1 = x.shape[1];
-            var xShape2 = x.shape[2];
-            x = x.reshape([xShape0 * xShape1, xShape2]);
-            return tfc.matMul(x, y).reshape([
-                xShape0, xShape1, y.shape[1]
-            ]);
-        }
-        else {
-            throw new errors_1.NotImplementedError("dot support for x of rank " + x.rank + " is not yet implemented: " +
-                ("x shape = " + x.shape));
-        }
+        var xFirstDims = x.shape.slice();
+        var xLastDim = xFirstDims.pop();
+        x = x.reshape([-1, xLastDim]);
+        var yShape = y.shape.slice();
+        var yLastDim = yShape.pop();
+        var ySecondLastDim = yShape.pop();
+        var yOtherDims = yShape.concat([yLastDim]);
+        var perm = Array.from({ length: y.rank }, function (_, i) {
+            if (i === 0) {
+                return y.rank - 2;
+            }
+            else if (i <= y.rank - 2) {
+                return i - 1;
+            }
+            return i;
+        });
+        y = y.transpose(perm).reshape([ySecondLastDim, -1]);
+        var outputShape = xFirstDims.concat(yOtherDims);
+        return tfc.matMul(x, y).reshape(outputShape);
     }
 }
 exports.dot = dot;
@@ -26592,7 +28129,7 @@ function inTrainPhase(x, alt, training) {
 }
 exports.inTrainPhase = inTrainPhase;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/math_utils":240,"./common":198,"@tensorflow/tfjs-core":68}],201:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/math_utils":264,"./common":218,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -26642,8 +28179,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("./backend/state");
+var errors_1 = require("./errors");
 var logs_1 = require("./logs");
 var generic_utils = require("./utils/generic_utils");
+var ModelLoggingVerbosity;
+(function (ModelLoggingVerbosity) {
+    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
+    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
+})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
 var BaseCallback = (function () {
     function BaseCallback() {
         this.validationData = null;
@@ -26797,19 +28340,22 @@ var CallbackList = (function () {
                         if (logs == null) {
                             logs = {};
                         }
-                        _i = 0, _a = this.callbacks;
-                        _b.label = 1;
+                        return [4, logs_1.resolveScalarsInLogs(logs)];
                     case 1:
-                        if (!(_i < _a.length)) return [3, 4];
+                        _b.sent();
+                        _i = 0, _a = this.callbacks;
+                        _b.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3, 5];
                         callback = _a[_i];
                         return [4, callback.onBatchEnd(batch, logs)];
-                    case 2:
-                        _b.sent();
-                        _b.label = 3;
                     case 3:
+                        _b.sent();
+                        _b.label = 4;
+                    case 4:
                         _i++;
-                        return [3, 1];
-                    case 4: return [2];
+                        return [3, 2];
+                    case 5: return [2];
                 }
             });
         });
@@ -27293,8 +28839,70 @@ function standardizeCallbacks(callbacks) {
     return callbackConfigs.map(function (callbackConfig) { return new CustomCallback(callbackConfig); });
 }
 exports.standardizeCallbacks = standardizeCallbacks;
+var CallbackConstructorRegistry = (function () {
+    function CallbackConstructorRegistry() {
+    }
+    CallbackConstructorRegistry.registerCallbackConstructor = function (verbosityLevel, callbackConstructor) {
+        tfjs_core_1.util.assert(verbosityLevel >= 0 && Number.isInteger(verbosityLevel), "Verbosity level is expected to be an integer >= 0, " +
+            ("but got " + verbosityLevel));
+        CallbackConstructorRegistry.checkForDuplicate(callbackConstructor);
+        if (CallbackConstructorRegistry.constructors[verbosityLevel] == null) {
+            CallbackConstructorRegistry.constructors[verbosityLevel] = [];
+        }
+        CallbackConstructorRegistry.constructors[verbosityLevel].push(callbackConstructor);
+    };
+    CallbackConstructorRegistry.checkForDuplicate = function (callbackConstructor) {
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var constructors = CallbackConstructorRegistry.constructors[+levelName];
+            constructors.forEach(function (ctor) {
+                if (ctor === callbackConstructor) {
+                    throw new errors_1.ValueError('Duplicate callback constructor.');
+                }
+            });
+        }
+    };
+    CallbackConstructorRegistry.clear = function () {
+        CallbackConstructorRegistry.constructors = {};
+    };
+    CallbackConstructorRegistry.createCallbacks = function (verbosityLevel) {
+        var constructors = [];
+        for (var levelName in CallbackConstructorRegistry.constructors) {
+            var level = +levelName;
+            if (verbosityLevel >= level) {
+                constructors.push.apply(constructors, CallbackConstructorRegistry.constructors[level]);
+            }
+        }
+        return constructors.map(function (ctor) { return new ctor(); });
+    };
+    CallbackConstructorRegistry.constructors = {};
+    return CallbackConstructorRegistry;
+}());
+exports.CallbackConstructorRegistry = CallbackConstructorRegistry;
+function configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics) {
+    var history = new History();
+    var actualCallbacks = [
+        new BaseLogger(yieldEvery)
+    ].concat(CallbackConstructorRegistry.createCallbacks(verbose));
+    if (callbacks != null) {
+        actualCallbacks.push.apply(actualCallbacks, callbacks);
+    }
+    actualCallbacks.push(history);
+    var callbackList = new CallbackList(actualCallbacks);
+    callbackList.setParams({
+        epochs: epochs,
+        initialEpoch: initialEpoch,
+        samples: numTrainSamples,
+        steps: stepsPerEpoch,
+        batchSize: batchSize,
+        verbose: verbose,
+        doValidation: doValidation,
+        metrics: callbackMetrics,
+    });
+    return { callbackList: callbackList, history: history };
+}
+exports.configureCallbacks = configureCallbacks;
 
-},{"./backend/state":199,"./logs":231,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],202:[function(require,module,exports){
+},{"./backend/state":219,"./errors":233,"./logs":255,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27326,7 +28934,7 @@ var Callback = (function (_super) {
 }(base_callbacks_1.BaseCallback));
 exports.Callback = Callback;
 
-},{"./base_callbacks":201,"./engine/training":209}],203:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/training":230}],223:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils_1 = require("./utils/generic_utils");
@@ -27395,13 +29003,13 @@ function getUniqueTensorName(scopedName) {
     }
 }
 exports.getUniqueTensorName = getUniqueTensorName;
-var tensorNameRegex = new RegExp(/^[A-Za-z][A-Za-z0-9\._\/]*$/);
+var tensorNameRegex = new RegExp(/^[A-Za-z][-A-Za-z0-9\._\/]*$/);
 function isValidTensorName(name) {
     return name.match(tensorNameRegex) ? true : false;
 }
 exports.isValidTensorName = isValidTensorName;
 
-},{"./utils/generic_utils":238}],204:[function(require,module,exports){
+},{"./utils/generic_utils":262}],224:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -27459,7 +29067,7 @@ var MaxNorm = (function (_super) {
     return MaxNorm;
 }(Constraint));
 exports.MaxNorm = MaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MaxNorm);
+tfjs_core_1.serialization.registerClass(MaxNorm);
 var UnitNorm = (function (_super) {
     __extends(UnitNorm, _super);
     function UnitNorm(config) {
@@ -27479,7 +29087,7 @@ var UnitNorm = (function (_super) {
     return UnitNorm;
 }(Constraint));
 exports.UnitNorm = UnitNorm;
-tfjs_core_1.serialization.SerializationMap.register(UnitNorm);
+tfjs_core_1.serialization.registerClass(UnitNorm);
 var NonNeg = (function (_super) {
     __extends(NonNeg, _super);
     function NonNeg() {
@@ -27492,7 +29100,7 @@ var NonNeg = (function (_super) {
     return NonNeg;
 }(Constraint));
 exports.NonNeg = NonNeg;
-tfjs_core_1.serialization.SerializationMap.register(NonNeg);
+tfjs_core_1.serialization.registerClass(NonNeg);
 var MinMaxNorm = (function (_super) {
     __extends(MinMaxNorm, _super);
     function MinMaxNorm(config) {
@@ -27529,7 +29137,7 @@ var MinMaxNorm = (function (_super) {
     return MinMaxNorm;
 }(Constraint));
 exports.MinMaxNorm = MinMaxNorm;
-tfjs_core_1.serialization.SerializationMap.register(MinMaxNorm);
+tfjs_core_1.serialization.registerClass(MinMaxNorm);
 exports.CONSTRAINT_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'maxNorm': 'MaxNorm',
     'minMaxNorm': 'MinMaxNorm',
@@ -27565,7 +29173,7 @@ function getConstraint(identifier) {
 }
 exports.getConstraint = getConstraint;
 
-},{"./backend/common":198,"./backend/state":199,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],205:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28228,7 +29836,7 @@ var Container = (function (_super) {
             keptNodes = layer instanceof Container ? 1 : 0;
             for (var originalNodeIndex = 0; originalNodeIndex < layer.inboundNodes.length; originalNodeIndex++) {
                 var nodeKey = Container.nodeKey(layer, originalNodeIndex);
-                if (nodeKey in this.containerNodes) {
+                if (this.containerNodes.has(nodeKey)) {
                     nodeConversionMap[nodeKey] = keptNodes;
                     keptNodes += 1;
                 }
@@ -28311,7 +29919,7 @@ var Container = (function (_super) {
                             var tensorIndex = node.tensorIndices[i];
                             var nodeKey_1 = Container.nodeKey(inboundLayer, nodeIndex);
                             var newNodeIndex = nodeConversionMap[nodeKey_1];
-                            if (newNodeIndex === null || newNodeIndex === undefined) {
+                            if (newNodeIndex == null) {
                                 newNodeIndex = 0;
                             }
                             nodeData.push([inboundLayer.name, newNodeIndex, tensorIndex, kwargs]);
@@ -28432,19 +30040,20 @@ var Container = (function (_super) {
                 var layerData = layersFromConfig_2[_a];
                 var layer = createdLayers[layerData.name];
                 if (layer.name in unprocessedNodes) {
-                    for (var _b = 0, _c = unprocessedNodes[layer.name]; _b < _c.length; _b++) {
-                        var nodeData = _c[_b];
+                    var currentUnprocessedNodesForLayer = unprocessedNodes[layer.name];
+                    delete unprocessedNodes[layer.name];
+                    for (var _b = 0, currentUnprocessedNodesForLayer_1 = currentUnprocessedNodesForLayer; _b < currentUnprocessedNodesForLayer_1.length; _b++) {
+                        var nodeData = currentUnprocessedNodesForLayer_1[_b];
                         processNode(layer, nodeData);
                     }
-                    delete unprocessedNodes[layer.name];
                 }
             }
         }
         var inputTensors = [];
         var outputTensors = [];
         var inputLayersFromConfig = config.inputLayers;
-        for (var _d = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _d < inputLayersFromConfig_1.length; _d++) {
-            var layerData = inputLayersFromConfig_1[_d];
+        for (var _c = 0, inputLayersFromConfig_1 = inputLayersFromConfig; _c < inputLayersFromConfig_1.length; _c++) {
+            var layerData = inputLayersFromConfig_1[_c];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28454,8 +30063,8 @@ var Container = (function (_super) {
             inputTensors.push(layerOutputTensors[tensorIndex]);
         }
         var outputLayersFromConfig = config.outputLayers;
-        for (var _e = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _e < outputLayersFromConfig_1.length; _e++) {
-            var layerData = outputLayersFromConfig_1[_e];
+        for (var _d = 0, outputLayersFromConfig_1 = outputLayersFromConfig; _d < outputLayersFromConfig_1.length; _d++) {
+            var layerData = outputLayersFromConfig_1[_d];
             var layerName = layerData[0];
             var nodeIndex = layerData[1];
             var tensorIndex = layerData[2];
@@ -28498,7 +30107,23 @@ var Container = (function (_super) {
 }(topology_1.Layer));
 exports.Container = Container;
 
-},{"../backend/state":199,"../errors":210,"../layers/serialization":229,"../utils/generic_utils":238,"../utils/serialization_utils":241,"../utils/types_utils":242,"../variables":244,"../version":245,"./input_layer":207,"./topology":208,"@tensorflow/tfjs-core":68}],206:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"../layers/serialization":253,"../utils/generic_utils":262,"../utils/serialization_utils":265,"../utils/types_utils":266,"../variables":268,"../version":269,"./input_layer":228,"./topology":229,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyIterator = (function () {
+    function LazyIterator() {
+    }
+    return LazyIterator;
+}());
+exports.LazyIterator = LazyIterator;
+var Dataset = (function () {
+    function Dataset() {
+    }
+    return Dataset;
+}());
+exports.Dataset = Dataset;
+
+},{}],227:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -28632,7 +30257,7 @@ function getNodeOutputs(fetch) {
     return layerOutputs;
 }
 
-},{"../errors":210,"./input_layer":207,"@tensorflow/tfjs-core":68}],207:[function(require,module,exports){
+},{"../errors":233,"./input_layer":228,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -28711,10 +30336,7 @@ var InputLayer = (function (_super) {
             ("InputLayer's apply() method. InputLayer name: " + this.name));
     };
     InputLayer.prototype.dispose = function () {
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: 0
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: 0 };
     };
     InputLayer.prototype.getConfig = function () {
         return {
@@ -28728,7 +30350,7 @@ var InputLayer = (function (_super) {
     return InputLayer;
 }(topology_1.Layer));
 exports.InputLayer = InputLayer;
-tfjs_core_1.serialization.SerializationMap.register(InputLayer);
+tfjs_core_1.serialization.registerClass(InputLayer);
 function Input(config) {
     if (config.batchShape == null && config.shape == null) {
         throw new Error('Please provide to Input either a `shape`' +
@@ -28759,7 +30381,7 @@ function Input(config) {
 }
 exports.Input = Input;
 
-},{"../backend/state":199,"../errors":210,"./topology":208,"@tensorflow/tfjs-core":68}],208:[function(require,module,exports){
+},{"../backend/state":219,"../errors":233,"./topology":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29447,10 +31069,7 @@ var Layer = (function (_super) {
         if (--this._refCount === 0) {
             numDisposedVariables = this.disposeWeights();
         }
-        return {
-            refCountAfterDispose: this._refCount,
-            numDisposedVariables: numDisposedVariables
-        };
+        return { refCountAfterDispose: this._refCount, numDisposedVariables: numDisposedVariables };
     };
     return Layer;
 }(tfjs_core_1.serialization.Serializable));
@@ -29501,7 +31120,7 @@ function getSourceInputs(tensor, layer, nodeIndex) {
 }
 exports.getSourceInputs = getSourceInputs;
 
-},{"../backend/state":199,"../common":203,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"../utils/variable_utils":243,"../variables":244,"@tensorflow/tfjs-core":68}],209:[function(require,module,exports){
+},{"../backend/state":219,"../common":223,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"../utils/variable_utils":267,"../variables":268,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -29553,10 +31172,8 @@ var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
-var base_callbacks_1 = require("../base_callbacks");
 var common_1 = require("../common");
 var errors_1 = require("../errors");
-var logs_1 = require("../logs");
 var losses = require("../losses");
 var Metrics = require("../metrics");
 var optimizers = require("../optimizers");
@@ -29565,6 +31182,8 @@ var layer_utils_1 = require("../utils/layer_utils");
 var math_utils_1 = require("../utils/math_utils");
 var container_1 = require("./container");
 var executor_1 = require("./executor");
+var training_dataset_1 = require("./training_dataset");
+var training_tensors_1 = require("./training_tensors");
 function isDataTensor(x) {
     return x instanceof tfjs_core_1.Tensor;
 }
@@ -29729,46 +31348,6 @@ function checkLossAndTargetCompatibility(targets, lossFns, outputShapes) {
         }
     }
 }
-function makeBatches(size, batchSize) {
-    var output = [];
-    var batchStart = 0;
-    var batchEnd = null;
-    while (batchStart < size) {
-        batchEnd = batchStart + batchSize;
-        if (batchEnd >= size) {
-            batchEnd = size;
-        }
-        output.push([batchStart, batchEnd]);
-        batchStart = batchEnd;
-    }
-    return output;
-}
-exports.makeBatches = makeBatches;
-function sliceArrays(arrays, start, stop) {
-    if (arrays == null) {
-        return [null];
-    }
-    else if (Array.isArray(arrays)) {
-        return arrays.map(function (array) { return K.sliceAlongFirstAxis(array, start, stop - start); });
-    }
-    else {
-        return K.sliceAlongFirstAxis(arrays, start, stop - start);
-    }
-}
-function sliceArraysByIndices(arrays, indices) {
-    return tfc.tidy(function () {
-        if (arrays == null) {
-            return null;
-        }
-        else if (Array.isArray(arrays)) {
-            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
-        }
-        else {
-            return K.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
-        }
-    });
-}
-exports.sliceArraysByIndices = sliceArraysByIndices;
 function checkInputData(data, names, shapes, checkBatchAxis, exceptionPrefix) {
     if (checkBatchAxis === void 0) { checkBatchAxis = true; }
     if (exceptionPrefix === void 0) { exceptionPrefix = ''; }
@@ -29841,14 +31420,6 @@ function collectMetrics(metrics, outputNames) {
         throw new TypeError('Type of metrics argument not understood. Expected an Array or ' +
             'Object, found: ' + metrics);
     }
-}
-var ModelLoggingVerbosity;
-(function (ModelLoggingVerbosity) {
-    ModelLoggingVerbosity[ModelLoggingVerbosity["SILENT"] = 0] = "SILENT";
-    ModelLoggingVerbosity[ModelLoggingVerbosity["VERBOSE"] = 1] = "VERBOSE";
-})(ModelLoggingVerbosity = exports.ModelLoggingVerbosity || (exports.ModelLoggingVerbosity = {}));
-function checkBatchSize(batchSize) {
-    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
 }
 var Model = (function (_super) {
     __extends(Model, _super);
@@ -30039,13 +31610,21 @@ var Model = (function (_super) {
     Model.prototype.evaluate = function (x, y, config) {
         if (config === void 0) { config = {}; }
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         var standardizedOuts = this.standardizeUserData(x, y, true, batchSize);
         var ins = standardizedOuts[0].concat(standardizedOuts[1]);
         this.makeTestFunction();
         var f = this.testFunction;
         var testOuts = this.testLoop(f, ins, batchSize, config.verbose, config.steps);
         return generic_utils_1.singletonOrArray(testOuts);
+    };
+    Model.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                this.makeTestFunction();
+                return [2, training_dataset_1.evaluateDataset(this, dataset, config)];
+            });
+        });
     };
     Model.prototype.checkNumSamples = function (ins, batchSize, steps, stepsName) {
         if (stepsName === void 0) { stepsName = 'steps'; }
@@ -30150,13 +31729,13 @@ var Model = (function (_super) {
             if (verbose) {
                 throw new errors_1.NotImplementedError('Verbose predictLoop() is not implemented yet.');
             }
-            var batches = makeBatches(numSamples, batchSize);
+            var batches = training_tensors_1.makeBatches(numSamples, batchSize);
             var outs = [];
             var _loop_3 = function (batchIndex) {
                 var batchOuts = tfc.tidy(function () {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
-                    var insBatch = sliceArrays(ins, batchStart, batchEnd);
+                    var insBatch = training_tensors_1.sliceArrays(ins, batchStart, batchEnd);
                     var feeds = [];
                     if (Array.isArray(insBatch)) {
                         for (var i = 0; i < insBatch.length; ++i) {
@@ -30191,7 +31770,7 @@ var Model = (function (_super) {
         if (config === void 0) { config = {}; }
         checkInputData(x, this.inputNames, this.feedInputShapes, false);
         var batchSize = config.batchSize == null ? 32 : config.batchSize;
-        checkBatchSize(batchSize);
+        training_tensors_1.checkBatchSize(batchSize);
         return this.predictLoop(x, batchSize);
     };
     Model.prototype.predictOnBatch = function (x) {
@@ -30228,204 +31807,26 @@ var Model = (function (_super) {
         }
         return [x, y, null];
     };
-    Model.prototype.fitLoop = function (f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var doValidation, numTrainSamples, indexArray, baseLogger, callbackList, _loop_4, this_1, epoch, state_2;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (batchSize == null) {
-                            batchSize = 32;
-                        }
-                        if (epochs == null) {
-                            epochs = 1;
-                        }
-                        if (shuffle == null) {
-                            shuffle = true;
-                        }
-                        if (initialEpoch == null) {
-                            initialEpoch = 0;
-                        }
-                        doValidation = false;
-                        if (valF != null && valIns != null) {
-                            doValidation = true;
-                        }
-                        if (validationSteps != null) {
-                            doValidation = true;
-                            if (stepsPerEpoch == null) {
-                                throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
-                                    'i.e., `stepsPerEpoch` must be set.');
-                            }
-                        }
-                        numTrainSamples = this.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
-                        if (numTrainSamples != null) {
-                            indexArray = math_utils_1.range(0, numTrainSamples);
-                        }
-                        this.history = new base_callbacks_1.History();
-                        baseLogger = new base_callbacks_1.BaseLogger(yieldEvery);
-                        if (callbacks == null) {
-                            callbacks = [baseLogger];
-                        }
-                        else {
-                            callbacks = [baseLogger].concat(callbacks);
-                        }
-                        callbacks = callbacks.concat([this.history]);
-                        if (verbose > 0) {
-                            throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
-                        }
-                        callbackList = new base_callbacks_1.CallbackList(callbacks);
-                        callbackList.setModel(this);
-                        callbackList.setParams({
-                            epochs: epochs,
-                            initialEpoch: initialEpoch,
-                            samples: numTrainSamples,
-                            steps: stepsPerEpoch,
-                            batchSize: batchSize,
-                            verbose: verbose,
-                            doValidation: doValidation,
-                            metrics: callbackMetrics,
-                        });
-                        return [4, callbackList.onTrainBegin()];
-                    case 1:
-                        _a.sent();
-                        this.stopTraining_ = false;
-                        _loop_4 = function (epoch) {
-                            var epochLogs, epochIndexArray1D_1, batches_1, _loop_5, batchIndex, state_3;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0: return [4, callbackList.onEpochBegin(epoch)];
-                                    case 1:
-                                        _a.sent();
-                                        epochLogs = {};
-                                        if (!(stepsPerEpoch != null)) return [3, 2];
-                                        throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
-                                    case 2:
-                                        if (shuffle === 'batch') {
-                                            throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
-                                        }
-                                        else if (shuffle) {
-                                            tfjs_core_1.util.shuffle(indexArray);
-                                        }
-                                        epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
-                                        batches_1 = makeBatches(numTrainSamples, batchSize);
-                                        _loop_5 = function (batchIndex) {
-                                            var batchLogs;
-                                            return __generator(this, function (_a) {
-                                                switch (_a.label) {
-                                                    case 0:
-                                                        batchLogs = {};
-                                                        return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
-                                                    case 1:
-                                                        _a.sent();
-                                                        tfc.tidy(function () {
-                                                            var batchStart = batches_1[batchIndex][0];
-                                                            var batchEnd = batches_1[batchIndex][1];
-                                                            var batchIds = K.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
-                                                            batchLogs['batch'] = batchIndex;
-                                                            batchLogs['size'] = batchEnd - batchStart;
-                                                            var insBatch = sliceArraysByIndices(ins, batchIds);
-                                                            var outs = f(insBatch);
-                                                            for (var i = 0; i < outLabels.length; ++i) {
-                                                                var label = outLabels[i];
-                                                                var out = outs[i];
-                                                                batchLogs[label] = out;
-                                                                tfc.keep(out);
-                                                            }
-                                                            if (batchIndex === batches_1.length - 1) {
-                                                                if (doValidation) {
-                                                                    var valOuts = _this.testLoop(valF, valIns, batchSize);
-                                                                    for (var i = 0; i < outLabels.length; ++i) {
-                                                                        var label = outLabels[i];
-                                                                        var out = valOuts[i];
-                                                                        tfc.keep(out);
-                                                                        epochLogs['val_' + label] = out;
-                                                                    }
-                                                                }
-                                                            }
-                                                        });
-                                                        return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
-                                                    case 2:
-                                                        _a.sent();
-                                                        logs_1.disposeTensorsInLogs(batchLogs);
-                                                        if (this_1.stopTraining_) {
-                                                            return [2, "break"];
-                                                        }
-                                                        return [2];
-                                                }
-                                            });
-                                        };
-                                        batchIndex = 0;
-                                        _a.label = 3;
-                                    case 3:
-                                        if (!(batchIndex < batches_1.length)) return [3, 6];
-                                        return [5, _loop_5(batchIndex)];
-                                    case 4:
-                                        state_3 = _a.sent();
-                                        if (state_3 === "break")
-                                            return [3, 6];
-                                        _a.label = 5;
-                                    case 5:
-                                        ++batchIndex;
-                                        return [3, 3];
-                                    case 6:
-                                        epochIndexArray1D_1.dispose();
-                                        _a.label = 7;
-                                    case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
-                                    case 8:
-                                        _a.sent();
-                                        if (this_1.stopTraining_) {
-                                            return [2, "break"];
-                                        }
-                                        return [2];
-                                }
-                            });
-                        };
-                        this_1 = this;
-                        epoch = initialEpoch;
-                        _a.label = 2;
-                    case 2:
-                        if (!(epoch < epochs)) return [3, 5];
-                        return [5, _loop_4(epoch)];
-                    case 3:
-                        state_2 = _a.sent();
-                        if (state_2 === "break")
-                            return [3, 5];
-                        _a.label = 4;
-                    case 4:
-                        ++epoch;
-                        return [3, 2];
-                    case 5: return [4, callbackList.onTrainEnd()];
-                    case 6:
-                        _a.sent();
-                        return [4, this.history.syncData()];
-                    case 7:
-                        _a.sent();
-                        return [2, this.history];
-                }
-            });
-        });
-    };
     Model.prototype.testLoop = function (f, ins, batchSize, verbose, steps) {
         var _this = this;
         if (verbose === void 0) { verbose = 0; }
         return tfc.tidy(function () {
             var numSamples = _this.checkNumSamples(ins, batchSize, steps, 'steps');
             var outs = [];
-            if (verbose === 1) {
+            if (verbose > 0) {
                 throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
             }
             if (steps != null) {
                 throw new errors_1.NotImplementedError('steps mode in testLoop() is not implemented yet');
             }
             else {
-                var batches = makeBatches(numSamples, batchSize);
+                var batches = training_tensors_1.makeBatches(numSamples, batchSize);
                 var indexArray = tfjs_core_1.tensor1d(math_utils_1.range(0, numSamples));
                 for (var batchIndex = 0; batchIndex < batches.length; ++batchIndex) {
                     var batchStart = batches[batchIndex][0];
                     var batchEnd = batches[batchIndex][1];
                     var batchIds = K.sliceAlongFirstAxis(indexArray, batchStart, batchEnd - batchStart);
-                    var insBatch = sliceArraysByIndices(ins, batchIds);
+                    var insBatch = training_tensors_1.sliceArraysByIndices(ins, batchIds);
                     var batchOuts = f(insBatch);
                     if (batchIndex === 0) {
                         for (var i = 0; i < batchOuts.length; ++i) {
@@ -30458,6 +31859,54 @@ var Model = (function (_super) {
             dedupedOutLabels.push(newLabel);
         }
         return dedupedOutLabels;
+    };
+    Model.prototype.makeTrainFunction = function () {
+        var _this = this;
+        return function (data) {
+            var losses = [];
+            var lossValues = [];
+            var inputs = data.slice(0, _this.inputs.length);
+            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
+            var metricsValues = [];
+            var totalLossFunction = function () {
+                var feeds = [];
+                for (var i = 0; i < _this.inputs.length; ++i) {
+                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
+                }
+                var feedDict = new executor_1.FeedDict(feeds);
+                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
+                var totalLoss;
+                for (var i = 0; i < _this.lossFunctions.length; ++i) {
+                    var lossFunction = _this.lossFunctions[i];
+                    var loss = lossFunction(targets[i], outputs[i]);
+                    losses.push(loss);
+                    var meanLoss = tfc.mean(loss);
+                    lossValues.push(meanLoss);
+                    if (i === 0) {
+                        totalLoss = loss;
+                    }
+                    else {
+                        totalLoss = tfc.add(totalLoss, loss);
+                    }
+                }
+                for (var i = 0; i < _this.metricsTensors.length; ++i) {
+                    var metric = _this.metricsTensors[i][0];
+                    var outputIndex = _this.metricsTensors[i][1];
+                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
+                    tfc.keep(meanMetric);
+                    metricsValues.push(meanMetric);
+                }
+                totalLoss = tfc.mean(totalLoss);
+                _this.calculateLosses().forEach(function (regularizerLoss) {
+                    totalLoss = tfc.add(totalLoss, regularizerLoss);
+                });
+                return totalLoss;
+            };
+            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
+            var returnCost = true;
+            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
+            return [totalLossValue].concat(metricsValues);
+        };
     };
     Model.prototype.makeTestFunction = function () {
         var _this = this;
@@ -30497,139 +31946,15 @@ var Model = (function (_super) {
     Model.prototype.fit = function (x, y, config) {
         if (config === void 0) { config = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var _this = this;
-            var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (this.isTraining) {
-                            throw new Error('Cannot start training because another fit() call is ongoing.');
-                        }
-                        this.isTraining = true;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, , 3, 4]);
-                        batchSize = config.batchSize == null ? 32 : config.batchSize;
-                        checkBatchSize(batchSize);
-                        standardizedOuts = this.standardizeUserData(x, y, false, batchSize);
-                        inputs = standardizedOuts[0];
-                        targets = standardizedOuts[1];
-                        doValidation = false;
-                        valX = void 0;
-                        valY = void 0;
-                        valIns = void 0;
-                        needValidationDisposal = false;
-                        if (config.validationData != null && config.validationData.length > 0) {
-                            doValidation = true;
-                            if (config.validationData.length === 2) {
-                                valX = config.validationData[0];
-                                valY = config.validationData[1];
-                            }
-                            else if (config.validationData.length === 3) {
-                                throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
-                            }
-                            else {
-                                throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
-                                    "or 3 (valX, valY, valSampleWeight) items; " +
-                                    (config.validationData + " is invalid."));
-                            }
-                            valStandardized = this.standardizeUserData(valX, valY, true, batchSize);
-                            valX = valStandardized[0];
-                            valY = valStandardized[1];
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSplit != null && config.validationSplit > 0 &&
-                            config.validationSplit < 1) {
-                            doValidation = true;
-                            splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
-                            originalBatchSize = inputs[0].shape[0];
-                            valX = sliceArrays(inputs, splitAt, originalBatchSize);
-                            inputs = sliceArrays(inputs, 0, splitAt);
-                            valY = sliceArrays(targets, splitAt, originalBatchSize);
-                            targets = sliceArrays(targets, 0, splitAt);
-                            needValidationDisposal = true;
-                            valIns = valX.concat(valY);
-                        }
-                        else if (config.validationSteps != null) {
-                            doValidation = true;
-                        }
-                        ins = inputs.concat(targets);
-                        this.checkTrainableWeightsConsistency();
-                        trainFunction = function (data) {
-                            var losses = [];
-                            var lossValues = [];
-                            var inputs = data.slice(0, _this.inputs.length);
-                            var targets = data.slice(_this.inputs.length, _this.inputs.length + _this.outputs.length);
-                            var metricsValues = [];
-                            var totalLossFunction = function () {
-                                var feeds = [];
-                                for (var i = 0; i < _this.inputs.length; ++i) {
-                                    feeds.push({ key: _this.inputs[i], value: inputs[i] });
-                                }
-                                var feedDict = new executor_1.FeedDict(feeds);
-                                var outputs = executor_1.execute(_this.outputs, feedDict, { 'training': true });
-                                var totalLoss;
-                                for (var i = 0; i < _this.lossFunctions.length; ++i) {
-                                    var lossFunction = _this.lossFunctions[i];
-                                    var loss = lossFunction(targets[i], outputs[i]);
-                                    losses.push(loss);
-                                    var meanLoss = tfc.mean(loss);
-                                    lossValues.push(meanLoss);
-                                    if (i === 0) {
-                                        totalLoss = loss;
-                                    }
-                                    else {
-                                        totalLoss = tfc.add(totalLoss, loss);
-                                    }
-                                }
-                                for (var i = 0; i < _this.metricsTensors.length; ++i) {
-                                    var metric = _this.metricsTensors[i][0];
-                                    var outputIndex = _this.metricsTensors[i][1];
-                                    var meanMetric = tfc.mean(metric(targets[outputIndex], outputs[outputIndex]));
-                                    tfc.keep(meanMetric);
-                                    metricsValues.push(meanMetric);
-                                }
-                                totalLoss = tfc.mean(totalLoss);
-                                _this.calculateLosses().forEach(function (regularizerLoss) {
-                                    totalLoss = tfc.add(totalLoss, regularizerLoss);
-                                });
-                                return totalLoss;
-                            };
-                            var variables = _this.collectedTrainableWeights.map(function (param) { return param.read(); });
-                            var returnCost = true;
-                            var totalLossValue = _this.optimizer.minimize(totalLossFunction, returnCost, variables);
-                            return [totalLossValue].concat(metricsValues);
-                        };
-                        outLabels = this.getDedupedMetricsNames();
-                        valFunction = void 0;
-                        callbackMetrics = void 0;
-                        if (doValidation) {
-                            this.makeTestFunction();
-                            valFunction = this.testFunction;
-                            callbackMetrics =
-                                outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
-                        }
-                        else {
-                            valFunction = null;
-                            valIns = [];
-                            callbackMetrics = outLabels.slice();
-                        }
-                        callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
-                        return [4, this.fitLoop(trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
-                    case 2:
-                        out = _a.sent();
-                        if (needValidationDisposal) {
-                            valIns.forEach(function (tensor) { return tensor.dispose(); });
-                            inputs.forEach(function (tensor) { return tensor.dispose(); });
-                            targets.forEach(function (tensor) { return tensor.dispose(); });
-                        }
-                        this.isTraining = false;
-                        return [2, out];
-                    case 3:
-                        this.isTraining = false;
-                        return [7];
-                    case 4: return [2];
-                }
+                return [2, training_tensors_1.fitTensors(this, x, y, config)];
+            });
+        });
+    };
+    Model.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, training_dataset_1.fitDataset(this, dataset, config)];
             });
         });
     };
@@ -30693,9 +32018,699 @@ var Model = (function (_super) {
     return Model;
 }(container_1.Container));
 exports.Model = Model;
-tfjs_core_1.serialization.SerializationMap.register(Model);
+tfjs_core_1.serialization.registerClass(Model);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../base_callbacks":201,"../common":203,"../errors":210,"../logs":231,"../losses":232,"../metrics":233,"../optimizers":235,"../utils/generic_utils":238,"../utils/layer_utils":239,"../utils/math_utils":240,"./container":205,"./executor":206,"@tensorflow/tfjs-core":68}],210:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../errors":233,"../losses":256,"../metrics":257,"../optimizers":259,"../utils/generic_utils":262,"../utils/layer_utils":263,"../utils/math_utils":264,"./container":225,"./executor":227,"./training_dataset":231,"./training_tensors":232,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var state_1 = require("../backend/state");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var generic_utils_1 = require("../utils/generic_utils");
+var dataset_stub_1 = require("./dataset_stub");
+var DEFAULT_VALIDATION_BATCH_SIZE = 32;
+function standardizeDataIteratorOutput(model, iteratorOut) {
+    if (model.outputs.length > 1) {
+        throw new errors_1.NotImplementedError("Support for training a model with multiple output tensors with " +
+            "a dataset object is not implemented yet.");
+    }
+    tfc.util.assert(Array.isArray(iteratorOut) && iteratorOut.length === 2, 'Dataset iterator for fitDataset() is expected to generate ' +
+        'an Array of length 2: `[xs, ys]`, but instead generates ' +
+        iteratorOut);
+    iteratorOut = iteratorOut;
+    var ys = iteratorOut[1];
+    var xs = iteratorOut[0];
+    if (xs instanceof tfc.Tensor) {
+        tfc.util.assert(model.inputs.length === 1, "Model has multiple " + model.inputs.length + " inputs, hence it " +
+            "expects the input dataset to generate a dictionary of tensors " +
+            (" (with keys " + JSON.stringify(model.inputNames) + ", ") +
+            "but received a single tensor.");
+        tfc.util.assert(xs.shape[0] === ys.shape[0], "Mismatch in batch size between x and y tensors (" + xs.shape[0] + " vs. " +
+            (ys.shape[0] + ")"));
+        return [xs, ys];
+    }
+    else {
+        var batchSize = void 0;
+        xs = xs;
+        var flattendXs = [];
+        for (var _i = 0, _a = model.inputNames; _i < _a.length; _i++) {
+            var inputName = _a[_i];
+            if (xs[inputName] == null) {
+                throw new errors_1.ValueError("The feature data generated by the dataset lacks the required " +
+                    ("input key '" + inputName + "'."));
+            }
+            flattendXs.push(xs[inputName]);
+            if (batchSize == null) {
+                batchSize = xs[inputName].shape[0];
+            }
+            else {
+                tfc.util.assert(xs[inputName].shape[0] === batchSize, "Mismatch in batch size between x and y tensors " +
+                    ("(" + xs[inputName].shape[0] + " vs. " + ys.shape[0] + ")"));
+            }
+        }
+        return flattendXs.concat(ys);
+    }
+}
+function standardizeTensorValidationData(data) {
+    if (data.length === 3) {
+        throw new errors_1.NotImplementedError('Validation with sample weights is not implemented yet.');
+    }
+    return { xs: data[0], ys: data[1] };
+}
+function fitDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, validationDataIterator, valXs, valYs, validationData, trainFunction, outLabels, callbackMetrics, callbacks, _a, callbackList, history_1, epoch, epochLogs, dataIterator, stepsDone, batchIndex, iteratorOut, xsAndYs, batchLogs, outs, i, label, out, valOuts, _b, i;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    tfc.util.assert(model.optimizer != null, 'You must compile a model before training/testing. Use ' +
+                        'Model.compile(modelCompileConfig).');
+                    tfc.util.assert(config != null, "For fitDataset(), the 2nd argument (config) is required, " +
+                        "but it is not provided in this call.");
+                    tfc.util.assert(config.epochs != null && config.epochs > 0 &&
+                        Number.isInteger(config.epochs), "For fitDataset(), config.epochs is expected to be a positive " +
+                        ("integer, but got " + config.epochs));
+                    tfc.util.assert(config.batchesPerEpoch != null && config.batchesPerEpoch > 0 &&
+                        Number.isInteger(config.batchesPerEpoch), "For fitDataset(), config.batchesPerEpoch is expected to be a " +
+                        ("positive integer, but got " + config.batchesPerEpoch));
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _c.label = 1;
+                case 1:
+                    _c.trys.push([1, , 21, 22]);
+                    doValidation = config.validationData != null;
+                    validationDataIterator = void 0;
+                    valXs = void 0;
+                    valYs = void 0;
+                    if (!doValidation) return [3, 4];
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 3];
+                    tfc.util.assert(config.validationBatches > 0 &&
+                        Number.isInteger(config.validationBatches), "For fitDataset() with dataset-based validation, " +
+                        "config.validationBatches is expected to be a " +
+                        ("positive integer, but got " + config.validationBatches));
+                    return [4, config.validationData.iterator()];
+                case 2:
+                    validationDataIterator = _c.sent();
+                    return [3, 4];
+                case 3:
+                    validationData = standardizeTensorValidationData(config.validationData);
+                    valXs = validationData.xs;
+                    valYs = validationData.ys;
+                    _c.label = 4;
+                case 4:
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    _a = base_callbacks_1.configureCallbacks(callbacks, config.yieldEvery, config.verbose, config.epochs, null, null, config.batchesPerEpoch, null, doValidation, callbackMetrics), callbackList = _a.callbackList, history_1 = _a.history;
+                    model.history = history_1;
+                    return [4, callbackList.onTrainBegin()];
+                case 5:
+                    _c.sent();
+                    epoch = config.initialEpoch == null ? 0 : config.initialEpoch;
+                    epochLogs = {};
+                    return [4, dataset.iterator()];
+                case 6:
+                    dataIterator = _c.sent();
+                    _c.label = 7;
+                case 7:
+                    if (!(epoch < config.epochs)) return [3, 18];
+                    return [4, callbackList.onEpochBegin(epoch)];
+                case 8:
+                    _c.sent();
+                    stepsDone = 0;
+                    batchIndex = 0;
+                    _c.label = 9;
+                case 9:
+                    if (!(stepsDone < config.batchesPerEpoch)) return [3, 16];
+                    return [4, dataIterator.next()];
+                case 10:
+                    iteratorOut = _c.sent();
+                    if (iteratorOut.done) {
+                        console.warn('Your dataset iterator ran out of data; ' +
+                            'interrupting training. Make sure that your ' +
+                            'dataset can generate at least `batchesPerEpoch * epochs` ' +
+                            'batches (in this case, ' +
+                            (config.batchesPerEpoch * config.epochs + " batches). ") +
+                            'You may need to use the repeat() function when building ' +
+                            'your dataset.');
+                        return [3, 16];
+                    }
+                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                    batchLogs = {};
+                    batchLogs['batch'] = batchIndex;
+                    batchLogs['size'] = xsAndYs[0].shape[0];
+                    callbackList.onBatchBegin(batchIndex, batchLogs);
+                    outs = trainFunction(xsAndYs);
+                    tfc.dispose(xsAndYs);
+                    for (i = 0; i < outLabels.length; ++i) {
+                        label = outLabels[i];
+                        out = outs[i];
+                        batchLogs[label] = out;
+                        tfc.keep(out);
+                    }
+                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                case 11:
+                    _c.sent();
+                    logs_1.disposeTensorsInLogs(batchLogs);
+                    batchIndex++;
+                    stepsDone++;
+                    if (!(stepsDone >= config.batchesPerEpoch && doValidation)) return [3, 15];
+                    valOuts = void 0;
+                    if (!(config.validationData instanceof dataset_stub_1.Dataset)) return [3, 13];
+                    _b = generic_utils_1.toList;
+                    return [4, model.evaluateDataset(validationDataIterator, { batches: config.validationBatches })];
+                case 12:
+                    valOuts = _b.apply(void 0, [_c.sent()]);
+                    return [3, 14];
+                case 13:
+                    valOuts = generic_utils_1.toList(model.evaluate(valXs, valYs, {
+                        batchSize: config.validationBatchSize == null ?
+                            DEFAULT_VALIDATION_BATCH_SIZE :
+                            config.validationBatchSize,
+                        verbose: 0
+                    }));
+                    _c.label = 14;
+                case 14:
+                    for (i = 0; i < model.metricsNames.length; ++i) {
+                        epochLogs["val_" + model.metricsNames[i]] = valOuts[i];
+                    }
+                    _c.label = 15;
+                case 15:
+                    if (model.stopTraining_) {
+                        return [3, 16];
+                    }
+                    return [3, 9];
+                case 16: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                case 17:
+                    _c.sent();
+                    epoch++;
+                    if (model.stopTraining_) {
+                        return [3, 18];
+                    }
+                    return [3, 7];
+                case 18: return [4, callbackList.onTrainEnd()];
+                case 19:
+                    _c.sent();
+                    return [4, model.history.syncData()];
+                case 20:
+                    _c.sent();
+                    return [2, model.history];
+                case 21:
+                    model.isTraining = false;
+                    return [7];
+                case 22: return [2];
+            }
+        });
+    });
+}
+exports.fitDataset = fitDataset;
+function evaluateDataset(model, dataset, config) {
+    return __awaiter(this, void 0, void 0, function () {
+        var f, outs, dataIterator, _a, numExamples, _loop_1, batch, state_2, _loop_2, i;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    f = model.testFunction;
+                    outs = [];
+                    if (config.verbose > 0) {
+                        throw new errors_1.NotImplementedError('Verbose mode is not implemented yet.');
+                    }
+                    tfc.util.assert(config.batches > 0 && Number.isInteger(config.batches), 'Test loop expects `batches` to be a positive integer, but ' +
+                        ("received " + JSON.stringify(config.batches)));
+                    if (!(dataset instanceof dataset_stub_1.LazyIterator)) return [3, 1];
+                    _a = dataset;
+                    return [3, 3];
+                case 1: return [4, dataset.iterator()];
+                case 2:
+                    _a = _b.sent();
+                    _b.label = 3;
+                case 3:
+                    dataIterator = _a;
+                    numExamples = 0;
+                    _loop_1 = function (batch) {
+                        var iteratorOut, xsAndYs, batchOuts, i, batchSize, _loop_3, i;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, dataIterator.next()];
+                                case 1:
+                                    iteratorOut = _a.sent();
+                                    if (iteratorOut.done) {
+                                        console.warn('Your dataset iterator ran out of data during evaluateDataset(). ' +
+                                            'Interrupting evalution. Make sure that your ' +
+                                            'dataset can generate at least `batches` ' +
+                                            ("batches (in this case, " + config.batches + " batches). ") +
+                                            'You may need to use the repeat() function when building ' +
+                                            'your dataset.');
+                                        return [2, "break"];
+                                    }
+                                    xsAndYs = standardizeDataIteratorOutput(model, iteratorOut.value);
+                                    batchOuts = tfc.tidy(function () { return f(xsAndYs); });
+                                    tfc.dispose(xsAndYs);
+                                    if (batch === 0) {
+                                        for (i = 0; i < batchOuts.length; ++i) {
+                                            outs.push(state_1.getScalar(0));
+                                        }
+                                    }
+                                    batchSize = xsAndYs[0].shape[0];
+                                    _loop_3 = function (i) {
+                                        var batchOut = batchOuts[i];
+                                        var oldScalar = outs[i];
+                                        outs[i] = tfc.tidy(function () { return tfc.add(outs[i], tfc.mul(state_1.getScalar(batchSize), batchOut)); });
+                                        if (batch > 0) {
+                                            tfc.dispose(oldScalar);
+                                        }
+                                    };
+                                    for (i = 0; i < batchOuts.length; ++i) {
+                                        _loop_3(i);
+                                    }
+                                    tfc.dispose(batchOuts);
+                                    numExamples += batchSize;
+                                    return [2];
+                            }
+                        });
+                    };
+                    batch = 0;
+                    _b.label = 4;
+                case 4:
+                    if (!(batch < config.batches)) return [3, 7];
+                    return [5, _loop_1(batch)];
+                case 5:
+                    state_2 = _b.sent();
+                    if (state_2 === "break")
+                        return [3, 7];
+                    _b.label = 6;
+                case 6:
+                    ++batch;
+                    return [3, 4];
+                case 7:
+                    _loop_2 = function (i) {
+                        var oldScalar = outs[i];
+                        outs[i] =
+                            tfc.tidy(function () { return tfc.div(outs[i], state_1.getScalar(numExamples)); });
+                        tfc.dispose(oldScalar);
+                    };
+                    for (i = 0; i < outs.length; ++i) {
+                        _loop_2(i);
+                    }
+                    return [2, generic_utils_1.singletonOrArray(outs)];
+            }
+        });
+    });
+}
+exports.evaluateDataset = evaluateDataset;
+
+},{"../backend/state":219,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/generic_utils":262,"./dataset_stub":226,"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfjs_backend_1 = require("../backend/tfjs_backend");
+var base_callbacks_1 = require("../base_callbacks");
+var errors_1 = require("../errors");
+var logs_1 = require("../logs");
+var math_utils_1 = require("../utils/math_utils");
+function checkBatchSize(batchSize) {
+    tfc.util.assert(batchSize > 0 && Number.isInteger(batchSize), "batchSize is required to be a positive integer, but got " + batchSize);
+}
+exports.checkBatchSize = checkBatchSize;
+function sliceArrays(arrays, start, stop) {
+    if (arrays == null) {
+        return [null];
+    }
+    else if (Array.isArray(arrays)) {
+        return arrays.map(function (array) { return tfjs_backend_1.sliceAlongFirstAxis(array, start, stop - start); });
+    }
+    else {
+        return tfjs_backend_1.sliceAlongFirstAxis(arrays, start, stop - start);
+    }
+}
+exports.sliceArrays = sliceArrays;
+function sliceArraysByIndices(arrays, indices) {
+    return tfc.tidy(function () {
+        if (arrays == null) {
+            return null;
+        }
+        else if (Array.isArray(arrays)) {
+            return arrays.map(function (array) { return sliceArraysByIndices(array, indices); });
+        }
+        else {
+            return tfjs_backend_1.gather(arrays, indices.dtype === 'int32' ? indices : indices.toInt());
+        }
+    });
+}
+exports.sliceArraysByIndices = sliceArraysByIndices;
+function makeBatches(size, batchSize) {
+    var output = [];
+    var batchStart = 0;
+    var batchEnd = null;
+    while (batchStart < size) {
+        batchEnd = batchStart + batchSize;
+        if (batchEnd >= size) {
+            batchEnd = size;
+        }
+        output.push([batchStart, batchEnd]);
+        batchStart = batchEnd;
+    }
+    return output;
+}
+exports.makeBatches = makeBatches;
+function fitLoop(model, f, ins, outLabels, batchSize, epochs, verbose, callbacks, valF, valIns, shuffle, callbackMetrics, initialEpoch, stepsPerEpoch, validationSteps, yieldEvery) {
+    return __awaiter(this, void 0, void 0, function () {
+        var doValidation, numTrainSamples, indexArray, _a, callbackList, history, _loop_1, epoch, state_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (batchSize == null) {
+                        batchSize = 32;
+                    }
+                    if (epochs == null) {
+                        epochs = 1;
+                    }
+                    if (shuffle == null) {
+                        shuffle = true;
+                    }
+                    if (initialEpoch == null) {
+                        initialEpoch = 0;
+                    }
+                    doValidation = false;
+                    if (valF != null && valIns != null) {
+                        doValidation = true;
+                    }
+                    if (validationSteps != null) {
+                        doValidation = true;
+                        if (stepsPerEpoch == null) {
+                            throw new errors_1.ValueError('Can only use `validationSteps` when doing step-wise training, ' +
+                                'i.e., `stepsPerEpoch` must be set.');
+                        }
+                    }
+                    numTrainSamples = model.checkNumSamples(ins, batchSize, stepsPerEpoch, 'steps_per_epoch');
+                    if (numTrainSamples != null) {
+                        indexArray = math_utils_1.range(0, numTrainSamples);
+                    }
+                    if (verbose == null) {
+                        verbose = 1;
+                    }
+                    _a = base_callbacks_1.configureCallbacks(callbacks, yieldEvery, verbose, epochs, initialEpoch, numTrainSamples, stepsPerEpoch, batchSize, doValidation, callbackMetrics), callbackList = _a.callbackList, history = _a.history;
+                    callbackList.setModel(model);
+                    model.history = history;
+                    return [4, callbackList.onTrainBegin()];
+                case 1:
+                    _b.sent();
+                    model.stopTraining_ = false;
+                    _loop_1 = function (epoch) {
+                        var epochLogs, epochIndexArray1D_1, batches_1, _loop_2, batchIndex, state_2;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4, callbackList.onEpochBegin(epoch)];
+                                case 1:
+                                    _a.sent();
+                                    epochLogs = {};
+                                    if (!(stepsPerEpoch != null)) return [3, 2];
+                                    throw new errors_1.NotImplementedError('stepsPerEpoch mode is not implemented yet.');
+                                case 2:
+                                    if (shuffle === 'batch') {
+                                        throw new errors_1.NotImplementedError('batch shuffling is not implemneted yet');
+                                    }
+                                    else if (shuffle) {
+                                        tfjs_core_1.util.shuffle(indexArray);
+                                    }
+                                    epochIndexArray1D_1 = tfjs_core_1.tensor1d(indexArray);
+                                    batches_1 = makeBatches(numTrainSamples, batchSize);
+                                    _loop_2 = function (batchIndex) {
+                                        var batchLogs;
+                                        return __generator(this, function (_a) {
+                                            switch (_a.label) {
+                                                case 0:
+                                                    batchLogs = {};
+                                                    return [4, callbackList.onBatchBegin(batchIndex, batchLogs)];
+                                                case 1:
+                                                    _a.sent();
+                                                    tfc.tidy(function () {
+                                                        var batchStart = batches_1[batchIndex][0];
+                                                        var batchEnd = batches_1[batchIndex][1];
+                                                        var batchIds = tfjs_backend_1.sliceAlongFirstAxis(epochIndexArray1D_1, batchStart, batchEnd - batchStart);
+                                                        batchLogs['batch'] = batchIndex;
+                                                        batchLogs['size'] = batchEnd - batchStart;
+                                                        var insBatch = sliceArraysByIndices(ins, batchIds);
+                                                        var outs = f(insBatch);
+                                                        for (var i = 0; i < outLabels.length; ++i) {
+                                                            var label = outLabels[i];
+                                                            var out = outs[i];
+                                                            batchLogs[label] = out;
+                                                            tfc.keep(out);
+                                                        }
+                                                        if (batchIndex === batches_1.length - 1) {
+                                                            if (doValidation) {
+                                                                var valOuts = model.testLoop(valF, valIns, batchSize);
+                                                                for (var i = 0; i < outLabels.length; ++i) {
+                                                                    var label = outLabels[i];
+                                                                    var out = valOuts[i];
+                                                                    tfc.keep(out);
+                                                                    epochLogs['val_' + label] = out;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                    return [4, callbackList.onBatchEnd(batchIndex, batchLogs)];
+                                                case 2:
+                                                    _a.sent();
+                                                    logs_1.disposeTensorsInLogs(batchLogs);
+                                                    if (model.stopTraining_) {
+                                                        return [2, "break"];
+                                                    }
+                                                    return [2];
+                                            }
+                                        });
+                                    };
+                                    batchIndex = 0;
+                                    _a.label = 3;
+                                case 3:
+                                    if (!(batchIndex < batches_1.length)) return [3, 6];
+                                    return [5, _loop_2(batchIndex)];
+                                case 4:
+                                    state_2 = _a.sent();
+                                    if (state_2 === "break")
+                                        return [3, 6];
+                                    _a.label = 5;
+                                case 5:
+                                    ++batchIndex;
+                                    return [3, 3];
+                                case 6:
+                                    epochIndexArray1D_1.dispose();
+                                    _a.label = 7;
+                                case 7: return [4, callbackList.onEpochEnd(epoch, epochLogs)];
+                                case 8:
+                                    _a.sent();
+                                    if (model.stopTraining_) {
+                                        return [2, "break"];
+                                    }
+                                    return [2];
+                            }
+                        });
+                    };
+                    epoch = initialEpoch;
+                    _b.label = 2;
+                case 2:
+                    if (!(epoch < epochs)) return [3, 5];
+                    return [5, _loop_1(epoch)];
+                case 3:
+                    state_1 = _b.sent();
+                    if (state_1 === "break")
+                        return [3, 5];
+                    _b.label = 4;
+                case 4:
+                    ++epoch;
+                    return [3, 2];
+                case 5: return [4, callbackList.onTrainEnd()];
+                case 6:
+                    _b.sent();
+                    return [4, model.history.syncData()];
+                case 7:
+                    _b.sent();
+                    return [2, model.history];
+            }
+        });
+    });
+}
+function fitTensors(model, x, y, config) {
+    if (config === void 0) { config = {}; }
+    return __awaiter(this, void 0, void 0, function () {
+        var batchSize, standardizedOuts, inputs, targets, doValidation, valX, valY, valIns, needValidationDisposal, valStandardized, splitAt, originalBatchSize, ins, trainFunction, outLabels, valFunction, callbackMetrics, callbacks, out;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (model.isTraining) {
+                        throw new Error('Cannot start training because another fit() call is ongoing.');
+                    }
+                    model.isTraining = true;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, , 3, 4]);
+                    batchSize = config.batchSize == null ? 32 : config.batchSize;
+                    checkBatchSize(batchSize);
+                    standardizedOuts = model.standardizeUserData(x, y, false, batchSize);
+                    inputs = standardizedOuts[0];
+                    targets = standardizedOuts[1];
+                    doValidation = false;
+                    valX = void 0;
+                    valY = void 0;
+                    valIns = void 0;
+                    needValidationDisposal = false;
+                    if (config.validationData != null && config.validationData.length > 0) {
+                        doValidation = true;
+                        if (config.validationData.length === 2) {
+                            valX = config.validationData[0];
+                            valY = config.validationData[1];
+                        }
+                        else if (config.validationData.length === 3) {
+                            throw new errors_1.NotImplementedError('validationData including sample weights is not supported yet.');
+                        }
+                        else {
+                            throw new errors_1.ValueError("When passing validation data, it must contain 2 (valX, valY) " +
+                                "or 3 (valX, valY, valSampleWeight) items; " +
+                                (config.validationData + " is invalid."));
+                        }
+                        valStandardized = model.standardizeUserData(valX, valY, true, batchSize);
+                        valX = valStandardized[0];
+                        valY = valStandardized[1];
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSplit != null && config.validationSplit > 0 &&
+                        config.validationSplit < 1) {
+                        doValidation = true;
+                        splitAt = Math.floor(inputs[0].shape[0] * (1 - config.validationSplit));
+                        originalBatchSize = inputs[0].shape[0];
+                        valX = sliceArrays(inputs, splitAt, originalBatchSize);
+                        inputs = sliceArrays(inputs, 0, splitAt);
+                        valY = sliceArrays(targets, splitAt, originalBatchSize);
+                        targets = sliceArrays(targets, 0, splitAt);
+                        needValidationDisposal = true;
+                        valIns = valX.concat(valY);
+                    }
+                    else if (config.validationSteps != null) {
+                        doValidation = true;
+                    }
+                    ins = inputs.concat(targets);
+                    model.checkTrainableWeightsConsistency();
+                    trainFunction = model.makeTrainFunction();
+                    outLabels = model.getDedupedMetricsNames();
+                    valFunction = void 0;
+                    callbackMetrics = void 0;
+                    if (doValidation) {
+                        model.makeTestFunction();
+                        valFunction = model.testFunction;
+                        callbackMetrics =
+                            outLabels.slice().concat(outLabels.map(function (n) { return 'val_' + n; }));
+                    }
+                    else {
+                        valFunction = null;
+                        valIns = [];
+                        callbackMetrics = outLabels.slice();
+                    }
+                    callbacks = base_callbacks_1.standardizeCallbacks(config.callbacks);
+                    return [4, fitLoop(model, trainFunction, ins, outLabels, batchSize, config.epochs, config.verbose, callbacks, valFunction, valIns, config.shuffle, callbackMetrics, config.initialEpoch, null, null, config.yieldEvery)];
+                case 2:
+                    out = _a.sent();
+                    if (needValidationDisposal) {
+                        valIns.forEach(function (tensor) { return tensor.dispose(); });
+                        inputs.forEach(function (tensor) { return tensor.dispose(); });
+                        targets.forEach(function (tensor) { return tensor.dispose(); });
+                    }
+                    model.isTraining = false;
+                    return [2, out];
+                case 3:
+                    model.isTraining = false;
+                    return [7];
+                case 4: return [2];
+            }
+        });
+    });
+}
+exports.fitTensors = fitTensors;
+
+},{"../backend/tfjs_backend":220,"../base_callbacks":221,"../errors":233,"../logs":255,"../utils/math_utils":264,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -30769,12 +32784,13 @@ var IndexError = (function (_super) {
 }(Error));
 exports.IndexError = IndexError;
 
-},{}],211:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
 var training_1 = require("./engine/training");
 var models_1 = require("./models");
+var base_callbacks_1 = require("./base_callbacks");
 function model(config) {
     return new training_1.Model(config);
 }
@@ -30792,8 +32808,12 @@ function input(config) {
     return input_layer_1.Input(config);
 }
 exports.input = input;
+function registerCallbackConstructor(verbosityLevel, callbackConstructor) {
+    base_callbacks_1.CallbackConstructorRegistry.registerCallbackConstructor(verbosityLevel, callbackConstructor);
+}
+exports.registerCallbackConstructor = registerCallbackConstructor;
 
-},{"./engine/input_layer":207,"./engine/training":209,"./models":234}],212:[function(require,module,exports){
+},{"./base_callbacks":221,"./engine/input_layer":228,"./engine/training":230,"./models":258}],235:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints_1 = require("./constraints");
@@ -30814,7 +32834,7 @@ function minMaxNorm(config) {
 }
 exports.minMaxNorm = minMaxNorm;
 
-},{"./constraints":204}],213:[function(require,module,exports){
+},{"./constraints":224}],236:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var initializers_1 = require("./initializers");
@@ -30871,7 +32891,7 @@ function orthogonal(config) {
 }
 exports.orthogonal = orthogonal;
 
-},{"./initializers":218}],214:[function(require,module,exports){
+},{"./initializers":242}],237:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var input_layer_1 = require("./engine/input_layer");
@@ -31000,6 +33020,10 @@ function multiply(config) {
     return new merge_1.Multiply(config);
 }
 exports.multiply = multiply;
+function dot(config) {
+    return new merge_1.Dot(config);
+}
+exports.dot = dot;
 function batchNormalization(config) {
     return new normalization_1.BatchNormalization(config);
 }
@@ -31101,7 +33125,7 @@ exports.globalMaxPool2d = globalMaxPooling2d;
 exports.maxPool1d = maxPooling1d;
 exports.maxPool2d = maxPooling2d;
 
-},{"./engine/input_layer":207,"./engine/topology":208,"./exports":211,"./layers/advanced_activations":219,"./layers/convolutional":220,"./layers/convolutional_depthwise":221,"./layers/core":222,"./layers/embeddings":223,"./layers/merge":224,"./layers/normalization":225,"./layers/padding":226,"./layers/pooling":227,"./layers/recurrent":228,"./layers/wrappers":230}],215:[function(require,module,exports){
+},{"./engine/input_layer":228,"./engine/topology":229,"./exports":234,"./layers/advanced_activations":243,"./layers/convolutional":244,"./layers/convolutional_depthwise":245,"./layers/core":246,"./layers/embeddings":247,"./layers/merge":248,"./layers/normalization":249,"./layers/padding":250,"./layers/pooling":251,"./layers/recurrent":252,"./layers/wrappers":254}],238:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var losses = require("./losses");
@@ -31122,6 +33146,14 @@ function categoricalCrossentropy(yTrue, yPred) {
     return metrics.categoricalCrossentropy(yTrue, yPred);
 }
 exports.categoricalCrossentropy = categoricalCrossentropy;
+function precision(yTrue, yPred) {
+    return metrics.precision(yTrue, yPred);
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return metrics.recall(yTrue, yPred);
+}
+exports.recall = recall;
 function cosineProximity(yTrue, yPred) {
     return losses.cosineProximity(yTrue, yPred);
 }
@@ -31155,7 +33187,13 @@ function mse(yTrue, yPred) {
 }
 exports.mse = mse;
 
-},{"./losses":232,"./metrics":233}],216:[function(require,module,exports){
+},{"./losses":256,"./metrics":257}],239:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var models_1 = require("./models");
+exports.modelFromJSON = models_1.modelFromJSON;
+
+},{"./models":258}],240:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var regularizers = require("./regularizers");
@@ -31173,7 +33211,7 @@ function l2(config) {
 }
 exports.l2 = l2;
 
-},{"./regularizers":236}],217:[function(require,module,exports){
+},{"./regularizers":260}],241:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var constraints = require("./exports_constraints");
@@ -31182,6 +33220,8 @@ var initializers = require("./exports_initializers");
 exports.initializers = initializers;
 var layers = require("./exports_layers");
 exports.layers = layers;
+var models = require("./exports_models");
+exports.models = models;
 var metrics = require("./exports_metrics");
 exports.metrics = metrics;
 var regularizers = require("./exports_regularizers");
@@ -31193,6 +33233,7 @@ exports.History = base_callbacks_1.History;
 var callbacks_1 = require("./callbacks");
 exports.Callback = callbacks_1.Callback;
 var topology_1 = require("./engine/topology");
+exports.InputSpec = topology_1.InputSpec;
 exports.SymbolicTensor = topology_1.SymbolicTensor;
 var training_1 = require("./engine/training");
 exports.Model = training_1.Model;
@@ -31200,6 +33241,7 @@ var exports_1 = require("./exports");
 exports.input = exports_1.input;
 exports.loadModel = exports_1.loadModel;
 exports.model = exports_1.model;
+exports.registerCallbackConstructor = exports_1.registerCallbackConstructor;
 exports.sequential = exports_1.sequential;
 var recurrent_1 = require("./layers/recurrent");
 exports.RNN = recurrent_1.RNN;
@@ -31210,7 +33252,7 @@ exports.LayerVariable = variables_1.LayerVariable;
 var version_1 = require("./version");
 exports.version_layers = version_1.version;
 
-},{"./base_callbacks":201,"./callbacks":202,"./engine/topology":208,"./engine/training":209,"./exports":211,"./exports_constraints":212,"./exports_initializers":213,"./exports_layers":214,"./exports_metrics":215,"./exports_regularizers":216,"./layers/recurrent":228,"./models":234,"./variables":244,"./version":245}],218:[function(require,module,exports){
+},{"./base_callbacks":221,"./callbacks":222,"./engine/topology":229,"./engine/training":230,"./exports":234,"./exports_constraints":235,"./exports_initializers":236,"./exports_layers":237,"./exports_metrics":238,"./exports_models":239,"./exports_regularizers":240,"./layers/recurrent":252,"./models":258,"./variables":268,"./version":269}],242:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31266,7 +33308,7 @@ var Zeros = (function (_super) {
     return Zeros;
 }(Initializer));
 exports.Zeros = Zeros;
-tfjs_core_1.serialization.SerializationMap.register(Zeros);
+tfjs_core_1.serialization.registerClass(Zeros);
 var Ones = (function (_super) {
     __extends(Ones, _super);
     function Ones() {
@@ -31279,7 +33321,7 @@ var Ones = (function (_super) {
     return Ones;
 }(Initializer));
 exports.Ones = Ones;
-tfjs_core_1.serialization.SerializationMap.register(Ones);
+tfjs_core_1.serialization.registerClass(Ones);
 var Constant = (function (_super) {
     __extends(Constant, _super);
     function Constant(config) {
@@ -31306,7 +33348,7 @@ var Constant = (function (_super) {
     return Constant;
 }(Initializer));
 exports.Constant = Constant;
-tfjs_core_1.serialization.SerializationMap.register(Constant);
+tfjs_core_1.serialization.registerClass(Constant);
 var RandomUniform = (function (_super) {
     __extends(RandomUniform, _super);
     function RandomUniform(config) {
@@ -31328,7 +33370,7 @@ var RandomUniform = (function (_super) {
     return RandomUniform;
 }(Initializer));
 exports.RandomUniform = RandomUniform;
-tfjs_core_1.serialization.SerializationMap.register(RandomUniform);
+tfjs_core_1.serialization.registerClass(RandomUniform);
 var RandomNormal = (function (_super) {
     __extends(RandomNormal, _super);
     function RandomNormal(config) {
@@ -31341,8 +33383,9 @@ var RandomNormal = (function (_super) {
         return _this;
     }
     RandomNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
         }
         return K.randomNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31353,7 +33396,7 @@ var RandomNormal = (function (_super) {
     return RandomNormal;
 }(Initializer));
 exports.RandomNormal = RandomNormal;
-tfjs_core_1.serialization.SerializationMap.register(RandomNormal);
+tfjs_core_1.serialization.registerClass(RandomNormal);
 var TruncatedNormal = (function (_super) {
     __extends(TruncatedNormal, _super);
     function TruncatedNormal(config) {
@@ -31366,8 +33409,9 @@ var TruncatedNormal = (function (_super) {
         return _this;
     }
     TruncatedNormal.prototype.apply = function (shape, dtype) {
-        if (dtype === 'bool') {
-            throw new errors_1.NotImplementedError("truncatedNormal does not support dType bool.");
+        dtype = dtype || 'float32';
+        if (dtype !== 'float32' && dtype !== 'int32') {
+            throw new errors_1.NotImplementedError("truncatedNormal does not support dType " + dtype + ".");
         }
         return tfjs_core_1.truncatedNormal(shape, this.mean, this.stddev, dtype, this.seed);
     };
@@ -31378,7 +33422,7 @@ var TruncatedNormal = (function (_super) {
     return TruncatedNormal;
 }(Initializer));
 exports.TruncatedNormal = TruncatedNormal;
-tfjs_core_1.serialization.SerializationMap.register(TruncatedNormal);
+tfjs_core_1.serialization.registerClass(TruncatedNormal);
 var Identity = (function (_super) {
     __extends(Identity, _super);
     function Identity(config) {
@@ -31405,7 +33449,7 @@ var Identity = (function (_super) {
     return Identity;
 }(Initializer));
 exports.Identity = Identity;
-tfjs_core_1.serialization.SerializationMap.register(Identity);
+tfjs_core_1.serialization.registerClass(Identity);
 function computeFans(shape, dataFormat) {
     if (dataFormat === void 0) { dataFormat = 'channelsLast'; }
     var fanIn;
@@ -31465,8 +33509,9 @@ var VarianceScaling = (function (_super) {
         }
         if (this.distribution === 'normal') {
             var stddev = Math.sqrt(scale);
-            if (dtype === 'bool') {
-                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType bool.");
+            dtype = dtype || 'float32';
+            if (dtype !== 'float32' && dtype !== 'int32') {
+                throw new errors_1.NotImplementedError(this.getClassName() + " does not support dType " + dtype + ".");
             }
             return tfjs_core_1.truncatedNormal(shape, 0, stddev, dtype, this.seed);
         }
@@ -31487,7 +33532,7 @@ var VarianceScaling = (function (_super) {
     return VarianceScaling;
 }(Initializer));
 exports.VarianceScaling = VarianceScaling;
-tfjs_core_1.serialization.SerializationMap.register(VarianceScaling);
+tfjs_core_1.serialization.registerClass(VarianceScaling);
 var GlorotUniform = (function (_super) {
     __extends(GlorotUniform, _super);
     function GlorotUniform(config) {
@@ -31501,9 +33546,11 @@ var GlorotUniform = (function (_super) {
     GlorotUniform.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotUniform.className = 'GlorotUniform';
     return GlorotUniform;
 }(VarianceScaling));
 exports.GlorotUniform = GlorotUniform;
+tfjs_core_1.serialization.registerClass(GlorotUniform);
 var GlorotNormal = (function (_super) {
     __extends(GlorotNormal, _super);
     function GlorotNormal(config) {
@@ -31517,9 +33564,11 @@ var GlorotNormal = (function (_super) {
     GlorotNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    GlorotNormal.className = 'GlorotNormal';
     return GlorotNormal;
 }(VarianceScaling));
 exports.GlorotNormal = GlorotNormal;
+tfjs_core_1.serialization.registerClass(GlorotNormal);
 var HeNormal = (function (_super) {
     __extends(HeNormal, _super);
     function HeNormal(config) {
@@ -31533,9 +33582,11 @@ var HeNormal = (function (_super) {
     HeNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    HeNormal.className = 'HeNormal';
     return HeNormal;
 }(VarianceScaling));
 exports.HeNormal = HeNormal;
+tfjs_core_1.serialization.registerClass(HeNormal);
 var LeCunNormal = (function (_super) {
     __extends(LeCunNormal, _super);
     function LeCunNormal(config) {
@@ -31549,9 +33600,11 @@ var LeCunNormal = (function (_super) {
     LeCunNormal.prototype.getClassName = function () {
         return VarianceScaling.className;
     };
+    LeCunNormal.className = 'LeCunNormal';
     return LeCunNormal;
 }(VarianceScaling));
 exports.LeCunNormal = LeCunNormal;
+tfjs_core_1.serialization.registerClass(LeCunNormal);
 var Orthogonal = (function (_super) {
     __extends(Orthogonal, _super);
     function Orthogonal(config) {
@@ -31594,7 +33647,7 @@ var Orthogonal = (function (_super) {
     return Orthogonal;
 }(Initializer));
 exports.Orthogonal = Orthogonal;
-tfjs_core_1.serialization.SerializationMap.register(Orthogonal);
+tfjs_core_1.serialization.registerClass(Orthogonal);
 exports.INITIALIZER_IDENTIFIER_REGISTRY_SYMBOL_MAP = {
     'constant': 'Constant',
     'glorotNormal': 'GlorotNormal',
@@ -31649,7 +33702,7 @@ function getInitializer(identifier) {
 }
 exports.getInitializer = getInitializer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./common":203,"./errors":210,"./utils/generic_utils":238,"./utils/math_utils":240,"@tensorflow/tfjs-core":68}],219:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./common":223,"./errors":233,"./utils/generic_utils":262,"./utils/math_utils":264,"@tensorflow/tfjs-core":68}],243:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -31700,7 +33753,7 @@ var ReLU = (function (_super) {
     return ReLU;
 }(topology_1.Layer));
 exports.ReLU = ReLU;
-tfjs_core_1.serialization.SerializationMap.register(ReLU);
+tfjs_core_1.serialization.registerClass(ReLU);
 var LeakyReLU = (function (_super) {
     __extends(LeakyReLU, _super);
     function LeakyReLU(config) {
@@ -31729,7 +33782,7 @@ var LeakyReLU = (function (_super) {
     return LeakyReLU;
 }(topology_1.Layer));
 exports.LeakyReLU = LeakyReLU;
-tfjs_core_1.serialization.SerializationMap.register(LeakyReLU);
+tfjs_core_1.serialization.registerClass(LeakyReLU);
 var ELU = (function (_super) {
     __extends(ELU, _super);
     function ELU(config) {
@@ -31762,7 +33815,7 @@ var ELU = (function (_super) {
     return ELU;
 }(topology_1.Layer));
 exports.ELU = ELU;
-tfjs_core_1.serialization.SerializationMap.register(ELU);
+tfjs_core_1.serialization.registerClass(ELU);
 var ThresholdedReLU = (function (_super) {
     __extends(ThresholdedReLU, _super);
     function ThresholdedReLU(config) {
@@ -31792,7 +33845,7 @@ var ThresholdedReLU = (function (_super) {
     return ThresholdedReLU;
 }(topology_1.Layer));
 exports.ThresholdedReLU = ThresholdedReLU;
-tfjs_core_1.serialization.SerializationMap.register(ThresholdedReLU);
+tfjs_core_1.serialization.registerClass(ThresholdedReLU);
 var Softmax = (function (_super) {
     __extends(Softmax, _super);
     function Softmax(config) {
@@ -31822,9 +33875,9 @@ var Softmax = (function (_super) {
     return Softmax;
 }(topology_1.Layer));
 exports.Softmax = Softmax;
-tfjs_core_1.serialization.SerializationMap.register(Softmax);
+tfjs_core_1.serialization.registerClass(Softmax);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],220:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],244:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32139,7 +34192,7 @@ var Conv2D = (function (_super) {
     return Conv2D;
 }(Conv));
 exports.Conv2D = Conv2D;
-tfjs_core_1.serialization.SerializationMap.register(Conv2D);
+tfjs_core_1.serialization.registerClass(Conv2D);
 var Conv2DTranspose = (function (_super) {
     __extends(Conv2DTranspose, _super);
     function Conv2DTranspose(config) {
@@ -32255,7 +34308,7 @@ var Conv2DTranspose = (function (_super) {
     return Conv2DTranspose;
 }(Conv2D));
 exports.Conv2DTranspose = Conv2DTranspose;
-tfjs_core_1.serialization.SerializationMap.register(Conv2DTranspose);
+tfjs_core_1.serialization.registerClass(Conv2DTranspose);
 var SeparableConv = (function (_super) {
     __extends(SeparableConv, _super);
     function SeparableConv(rank, config) {
@@ -32382,7 +34435,7 @@ var SeparableConv2D = (function (_super) {
     return SeparableConv2D;
 }(SeparableConv));
 exports.SeparableConv2D = SeparableConv2D;
-tfjs_core_1.serialization.SerializationMap.register(SeparableConv2D);
+tfjs_core_1.serialization.registerClass(SeparableConv2D);
 var Conv1D = (function (_super) {
     __extends(Conv1D, _super);
     function Conv1D(config) {
@@ -32407,7 +34460,7 @@ var Conv1D = (function (_super) {
     return Conv1D;
 }(Conv));
 exports.Conv1D = Conv1D;
-tfjs_core_1.serialization.SerializationMap.register(Conv1D);
+tfjs_core_1.serialization.registerClass(Conv1D);
 var Cropping2D = (function (_super) {
     __extends(Cropping2D, _super);
     function Cropping2D(config) {
@@ -32431,15 +34484,17 @@ var Cropping2D = (function (_super) {
     Cropping2D.prototype.computeOutputShape = function (inputShape) {
         if (this.dataFormat === 'channelsFirst')
             return [
-                inputShape[0], inputShape[1],
+                inputShape[0],
+                inputShape[1],
                 inputShape[2] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1]
+                inputShape[3] - this.cropping[1][0] - this.cropping[1][1]
             ];
         else
             return [
                 inputShape[0],
                 inputShape[1] - this.cropping[0][0] - this.cropping[0][1],
-                inputShape[2] - this.cropping[1][0] - this.cropping[1][1], inputShape[3]
+                inputShape[2] - this.cropping[1][0] - this.cropping[1][1],
+                inputShape[3]
             ];
     };
     Cropping2D.prototype.call = function (inputs, kwargs) {
@@ -32466,7 +34521,7 @@ var Cropping2D = (function (_super) {
     return Cropping2D;
 }(topology_1.Layer));
 exports.Cropping2D = Cropping2D;
-tfjs_core_1.serialization.SerializationMap.register(Cropping2D);
+tfjs_core_1.serialization.registerClass(Cropping2D);
 var UpSampling2D = (function (_super) {
     __extends(UpSampling2D, _super);
     function UpSampling2D(config) {
@@ -32519,9 +34574,9 @@ var UpSampling2D = (function (_super) {
     return UpSampling2D;
 }(topology_1.Layer));
 exports.UpSampling2D = UpSampling2D;
-tfjs_core_1.serialization.SerializationMap.register(UpSampling2D);
+tfjs_core_1.serialization.registerClass(UpSampling2D);
 
-},{"../activations":197,"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],221:[function(require,module,exports){
+},{"../activations":217,"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32652,9 +34707,9 @@ var DepthwiseConv2D = (function (_super) {
     return DepthwiseConv2D;
 }(convolutional_1.BaseConv));
 exports.DepthwiseConv2D = DepthwiseConv2D;
-tfjs_core_1.serialization.SerializationMap.register(DepthwiseConv2D);
+tfjs_core_1.serialization.registerClass(DepthwiseConv2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../constraints":204,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],222:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../constraints":224,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],246:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -32737,7 +34792,7 @@ var Dropout = (function (_super) {
     return Dropout;
 }(topology_1.Layer));
 exports.Dropout = Dropout;
-tfjs_core_1.serialization.SerializationMap.register(Dropout);
+tfjs_core_1.serialization.registerClass(Dropout);
 var Dense = (function (_super) {
     __extends(Dense, _super);
     function Dense(config) {
@@ -32827,7 +34882,7 @@ var Dense = (function (_super) {
     return Dense;
 }(topology_1.Layer));
 exports.Dense = Dense;
-tfjs_core_1.serialization.SerializationMap.register(Dense);
+tfjs_core_1.serialization.registerClass(Dense);
 var Flatten = (function (_super) {
     __extends(Flatten, _super);
     function Flatten(config) {
@@ -32859,7 +34914,7 @@ var Flatten = (function (_super) {
     return Flatten;
 }(topology_1.Layer));
 exports.Flatten = Flatten;
-tfjs_core_1.serialization.SerializationMap.register(Flatten);
+tfjs_core_1.serialization.registerClass(Flatten);
 var Activation = (function (_super) {
     __extends(Activation, _super);
     function Activation(config) {
@@ -32886,7 +34941,7 @@ var Activation = (function (_super) {
     return Activation;
 }(topology_1.Layer));
 exports.Activation = Activation;
-tfjs_core_1.serialization.SerializationMap.register(Activation);
+tfjs_core_1.serialization.registerClass(Activation);
 var RepeatVector = (function (_super) {
     __extends(RepeatVector, _super);
     function RepeatVector(config) {
@@ -32917,7 +34972,7 @@ var RepeatVector = (function (_super) {
     return RepeatVector;
 }(topology_1.Layer));
 exports.RepeatVector = RepeatVector;
-tfjs_core_1.serialization.SerializationMap.register(RepeatVector);
+tfjs_core_1.serialization.registerClass(RepeatVector);
 var Reshape = (function (_super) {
     __extends(Reshape, _super);
     function Reshape(config) {
@@ -33001,7 +35056,7 @@ var Reshape = (function (_super) {
     return Reshape;
 }(topology_1.Layer));
 exports.Reshape = Reshape;
-tfjs_core_1.serialization.SerializationMap.register(Reshape);
+tfjs_core_1.serialization.registerClass(Reshape);
 var Permute = (function (_super) {
     __extends(Permute, _super);
     function Permute(config) {
@@ -33047,9 +35102,9 @@ var Permute = (function (_super) {
     return Permute;
 }(topology_1.Layer));
 exports.Permute = Permute;
-tfjs_core_1.serialization.SerializationMap.register(Permute);
+tfjs_core_1.serialization.registerClass(Permute);
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],223:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],247:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33166,9 +35221,9 @@ var Embedding = (function (_super) {
     return Embedding;
 }(topology_1.Layer));
 exports.Embedding = Embedding;
-tfjs_core_1.serialization.SerializationMap.register(Embedding);
+tfjs_core_1.serialization.registerClass(Embedding);
 
-},{"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],224:[function(require,module,exports){
+},{"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],248:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33187,6 +35242,7 @@ var state_1 = require("../backend/state");
 var K = require("../backend/tfjs_backend");
 var topology_1 = require("../engine/topology");
 var errors_1 = require("../errors");
+var losses_1 = require("../losses");
 var generic_utils = require("../utils/generic_utils");
 var mathUtils = require("../utils/math_utils");
 var types_utils_1 = require("../utils/types_utils");
@@ -33364,6 +35420,9 @@ var Merge = (function (_super) {
         }
         return outputShape;
     };
+    Merge.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Merge yet');
+    };
     return Merge;
 }(topology_1.Layer));
 exports.Merge = Merge;
@@ -33385,7 +35444,7 @@ var Add = (function (_super) {
     return Add;
 }(Merge));
 exports.Add = Add;
-tfjs_core_1.serialization.SerializationMap.register(Add);
+tfjs_core_1.serialization.registerClass(Add);
 function add(config) {
     if (Array.isArray(config)) {
         var layer = new Add({});
@@ -33414,7 +35473,7 @@ var Multiply = (function (_super) {
     return Multiply;
 }(Merge));
 exports.Multiply = Multiply;
-tfjs_core_1.serialization.SerializationMap.register(Multiply);
+tfjs_core_1.serialization.registerClass(Multiply);
 function multiply(config) {
     if (Array.isArray(config)) {
         var layer = new Multiply({});
@@ -33443,7 +35502,7 @@ var Average = (function (_super) {
     return Average;
 }(Merge));
 exports.Average = Average;
-tfjs_core_1.serialization.SerializationMap.register(Average);
+tfjs_core_1.serialization.registerClass(Average);
 function average(config) {
     if (Array.isArray(config)) {
         var layer = new Average({});
@@ -33472,7 +35531,7 @@ var Maximum = (function (_super) {
     return Maximum;
 }(Merge));
 exports.Maximum = Maximum;
-tfjs_core_1.serialization.SerializationMap.register(Maximum);
+tfjs_core_1.serialization.registerClass(Maximum);
 function maximum(config) {
     if (Array.isArray(config)) {
         var layer = new Maximum({});
@@ -33501,7 +35560,7 @@ var Minimum = (function (_super) {
     return Minimum;
 }(Merge));
 exports.Minimum = Minimum;
-tfjs_core_1.serialization.SerializationMap.register(Minimum);
+tfjs_core_1.serialization.registerClass(Minimum);
 function minimum(config) {
     if (Array.isArray(config)) {
         var layer = new Minimum({});
@@ -33588,6 +35647,9 @@ var Concatenate = (function (_super) {
         }
         return outputShape;
     };
+    Concatenate.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Concatenate yet');
+    };
     Concatenate.prototype.getConfig = function () {
         var config = {
             'axis': this.axis,
@@ -33600,7 +35662,7 @@ var Concatenate = (function (_super) {
     return Concatenate;
 }(Merge));
 exports.Concatenate = Concatenate;
-tfjs_core_1.serialization.SerializationMap.register(Concatenate);
+tfjs_core_1.serialization.registerClass(Concatenate);
 function concatenate(config) {
     if (Array.isArray(config)) {
         var layer = new Concatenate({});
@@ -33611,8 +35673,184 @@ function concatenate(config) {
     }
 }
 exports.concatenate = concatenate;
+function interpretAxis(axis, dim) {
+    while (axis < 0) {
+        axis += dim;
+    }
+    return axis;
+}
+function batchDot(x, y, axes) {
+    if (x.shape.length > 3 || y.shape.length > 3) {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for tensors of 4D or higher rank yet');
+    }
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of x to be >= 2, " +
+        ("but got " + x.shape.length));
+    tfc.util.assert(x.shape.length >= 2, "batchDot requires the rank of y to be >= 2, " +
+        ("but got " + y.shape.length));
+    if (typeof axes === 'number') {
+        axes = [axes, axes];
+    }
+    if (x.dtype === 'complex64' || y.dtype === 'complex64') {
+        throw new errors_1.NotImplementedError('batchDot is not implemented for complex64-type Tensors yet.');
+    }
+    var xNDim = x.shape.length;
+    var yNDim = y.shape.length;
+    if (axes == null) {
+        axes = [xNDim - 1, yNDim - 2];
+    }
+    var axesArray = axes;
+    return tfc.tidy(function () {
+        var diff;
+        if (xNDim > yNDim) {
+            diff = xNDim - yNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            y = y.reshape(y.shape.concat(diffShape));
+        }
+        else if (yNDim > xNDim) {
+            diff = yNDim - xNDim;
+            var diffShape = [];
+            for (var i = 0; i < diff; ++i) {
+                diffShape.push(1);
+            }
+            x = x.reshape(x.shape.concat(diffShape));
+        }
+        else {
+            diff = 0;
+        }
+        var out;
+        if (x.shape.length === 2 && y.shape.length === 2) {
+            if (axesArray[0] === axesArray[1]) {
+                out = x.mulStrict(y).sum(axesArray[0]);
+            }
+            else {
+                out = x.transpose([1, 0]).mulStrict(y).sum(axesArray[1]);
+            }
+        }
+        else {
+            var adjX = axesArray[0] === x.shape.length - 1 ? null : true;
+            var adjY = axesArray[1] === y.shape.length - 1 ? true : null;
+            out = x.matMul(y, adjX, adjY);
+        }
+        if (diff > 0) {
+            var idx = void 0;
+            if (xNDim > yNDim) {
+                idx = xNDim + yNDim - 3;
+            }
+            else {
+                idx = xNDim - 1;
+            }
+            var squeezeAxes = [];
+            for (var i = idx; i < idx + diff; ++i) {
+                squeezeAxes.push(i);
+            }
+            out = out.squeeze(squeezeAxes);
+        }
+        if (out.shape.length === 1) {
+            out = out.expandDims(1);
+        }
+        return out;
+    });
+}
+var Dot = (function (_super) {
+    __extends(Dot, _super);
+    function Dot(config) {
+        var _this = _super.call(this, config) || this;
+        _this.axes = config.axes;
+        _this.normalize = config.normalize == null ? false : config.normalize;
+        _this.supportsMasking = true;
+        _this.reshapeRequired = false;
+        return _this;
+    }
+    Dot.prototype.build = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0];
+        var shape2 = inputShape[1];
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        if (shape1[axes[0]] !== shape2[axes[1]]) {
+            throw new errors_1.ValueError("Dimension incompatibility: " +
+                (shape1[axes[0]] + " !== " + shape2[axes[1]]));
+        }
+    };
+    Dot.prototype.mergeFunction = function (inputs) {
+        if (inputs.length !== 2) {
+            throw new errors_1.ValueError('A `Dot` layer must be called on exactly 2 inputs, ' +
+                ("but received " + inputs.length + " input(s)."));
+        }
+        var x1 = inputs[0];
+        var x2 = inputs[1];
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, x1.shape.length),
+                interpretAxis(this.axes, x2.shape.length)
+            ];
+        }
+        else {
+            axes = this.axes.map(function (axis, i) { return interpretAxis(axis, inputs[i].shape.length); });
+        }
+        if (this.normalize) {
+            x1 = losses_1.l2Normalize(x1, axes[0]);
+            x2 = losses_1.l2Normalize(x2, axes[1]);
+        }
+        return batchDot(x1, x2, axes);
+    };
+    Dot.prototype.interpretAxes = function (shape1, shape2) {
+        var axes;
+        if (!Array.isArray(this.axes)) {
+            axes = [
+                interpretAxis(this.axes, shape1.length),
+                interpretAxis(this.axes, shape2.length)
+            ];
+        }
+        else {
+            axes = this.axes;
+        }
+        return axes;
+    };
+    Dot.prototype.computeOutputShape = function (inputShape) {
+        tfc.util.assert(Array.isArray(inputShape) && inputShape.length === 2 &&
+            Array.isArray(inputShape[0]) && Array.isArray(inputShape[1]), 'A `Dot` layer should be called on a list of exactly 2 inputs.');
+        var shape1 = inputShape[0].slice();
+        var shape2 = inputShape[1].slice();
+        if (shape1.length > 3 || shape2.length > 3) {
+            throw new errors_1.NotImplementedError('Dot layer does not support tensors of 4D or higher rank yet.');
+        }
+        var axes = this.interpretAxes(shape1, shape2);
+        shape1.splice(axes[0], 1);
+        shape2.splice(axes[1], 1);
+        shape2.splice(0, 1);
+        var outputShape = shape1.concat(shape2);
+        if (outputShape.length === 1) {
+            outputShape.push(1);
+        }
+        return outputShape;
+    };
+    Dot.prototype.computeMask = function (inputs, mask) {
+        throw new errors_1.NotImplementedError('computeMask has not been implemented for Dot yet');
+    };
+    Dot.prototype.getConfig = function () {
+        var config = {
+            'axes': this.axes,
+            'normalize': this.normalize
+        };
+        var baseConfig = _super.prototype.getConfig.call(this);
+        Object.assign(config, baseConfig);
+        return config;
+    };
+    Dot.className = 'Dot';
+    return Dot;
+}(Merge));
+exports.Dot = Dot;
+tfjs_core_1.serialization.registerClass(Dot);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],225:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../engine/topology":229,"../errors":233,"../losses":256,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],249:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33649,7 +35887,7 @@ function batchNormalization(x, mean, variance, beta, gamma, epsilon) {
         out = tfc.batchNormalization4d(x, mean, variance, epsilon, gamma, beta);
     }
     else {
-        throw new errors_1.NotImplementedError("batchNormalization is not implememnted for array of rank " + x.rank + " " +
+        throw new errors_1.NotImplementedError("batchNormalization is not implemented for array of rank " + x.rank + " " +
             "yet");
     }
     return out;
@@ -33702,7 +35940,11 @@ exports.normalizeBatchInTraining = normalizeBatchInTraining;
 var BatchNormalization = (function (_super) {
     __extends(BatchNormalization, _super);
     function BatchNormalization(config) {
-        var _this = _super.call(this, config) || this;
+        var _this = this;
+        if (config == null) {
+            config = {};
+        }
+        _this = _super.call(this, config) || this;
         _this.supportsMasking = true;
         _this.axis = config.axis == null ? -1 : config.axis;
         _this.momentum = config.momentum == null ? 0.99 : config.momentum;
@@ -33813,9 +36055,9 @@ var BatchNormalization = (function (_super) {
     return BatchNormalization;
 }(topology_1.Layer));
 exports.BatchNormalization = BatchNormalization;
-tfjs_core_1.serialization.SerializationMap.register(BatchNormalization);
+tfjs_core_1.serialization.registerClass(BatchNormalization);
 
-},{"../backend/state":199,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/generic_utils":238,"../utils/math_utils":240,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],226:[function(require,module,exports){
+},{"../backend/state":219,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/generic_utils":262,"../utils/math_utils":264,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],250:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -33985,9 +36227,9 @@ var ZeroPadding2D = (function (_super) {
     return ZeroPadding2D;
 }(topology_1.Layer));
 exports.ZeroPadding2D = ZeroPadding2D;
-tfjs_core_1.serialization.SerializationMap.register(ZeroPadding2D);
+tfjs_core_1.serialization.registerClass(ZeroPadding2D);
 
-},{"../backend/common":198,"../engine/topology":208,"../errors":210,"../utils/types_utils":242,"@tensorflow/tfjs-core":68}],227:[function(require,module,exports){
+},{"../backend/common":218,"../engine/topology":229,"../errors":233,"../utils/types_utils":266,"@tensorflow/tfjs-core":68}],251:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34129,7 +36371,7 @@ var MaxPooling1D = (function (_super) {
     return MaxPooling1D;
 }(Pooling1D));
 exports.MaxPooling1D = MaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling1D);
+tfjs_core_1.serialization.registerClass(MaxPooling1D);
 var AveragePooling1D = (function (_super) {
     __extends(AveragePooling1D, _super);
     function AveragePooling1D(config) {
@@ -34144,7 +36386,7 @@ var AveragePooling1D = (function (_super) {
     return AveragePooling1D;
 }(Pooling1D));
 exports.AveragePooling1D = AveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling1D);
+tfjs_core_1.serialization.registerClass(AveragePooling1D);
 var Pooling2D = (function (_super) {
     __extends(Pooling2D, _super);
     function Pooling2D(config) {
@@ -34228,7 +36470,7 @@ var MaxPooling2D = (function (_super) {
     return MaxPooling2D;
 }(Pooling2D));
 exports.MaxPooling2D = MaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(MaxPooling2D);
+tfjs_core_1.serialization.registerClass(MaxPooling2D);
 var AveragePooling2D = (function (_super) {
     __extends(AveragePooling2D, _super);
     function AveragePooling2D(config) {
@@ -34243,7 +36485,7 @@ var AveragePooling2D = (function (_super) {
     return AveragePooling2D;
 }(Pooling2D));
 exports.AveragePooling2D = AveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(AveragePooling2D);
+tfjs_core_1.serialization.registerClass(AveragePooling2D);
 var GlobalPooling1D = (function (_super) {
     __extends(GlobalPooling1D, _super);
     function GlobalPooling1D(config) {
@@ -34275,7 +36517,7 @@ var GlobalAveragePooling1D = (function (_super) {
     return GlobalAveragePooling1D;
 }(GlobalPooling1D));
 exports.GlobalAveragePooling1D = GlobalAveragePooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling1D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling1D);
 var GlobalMaxPooling1D = (function (_super) {
     __extends(GlobalMaxPooling1D, _super);
     function GlobalMaxPooling1D(config) {
@@ -34291,7 +36533,7 @@ var GlobalMaxPooling1D = (function (_super) {
     return GlobalMaxPooling1D;
 }(GlobalPooling1D));
 exports.GlobalMaxPooling1D = GlobalMaxPooling1D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling1D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling1D);
 var GlobalPooling2D = (function (_super) {
     __extends(GlobalPooling2D, _super);
     function GlobalPooling2D(config) {
@@ -34344,7 +36586,7 @@ var GlobalAveragePooling2D = (function (_super) {
     return GlobalAveragePooling2D;
 }(GlobalPooling2D));
 exports.GlobalAveragePooling2D = GlobalAveragePooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalAveragePooling2D);
+tfjs_core_1.serialization.registerClass(GlobalAveragePooling2D);
 var GlobalMaxPooling2D = (function (_super) {
     __extends(GlobalMaxPooling2D, _super);
     function GlobalMaxPooling2D() {
@@ -34366,9 +36608,9 @@ var GlobalMaxPooling2D = (function (_super) {
     return GlobalMaxPooling2D;
 }(GlobalPooling2D));
 exports.GlobalMaxPooling2D = GlobalMaxPooling2D;
-tfjs_core_1.serialization.SerializationMap.register(GlobalMaxPooling2D);
+tfjs_core_1.serialization.registerClass(GlobalMaxPooling2D);
 
-},{"../backend/common":198,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/conv_utils":237,"../utils/types_utils":242,"./convolutional":220,"@tensorflow/tfjs-core":68}],228:[function(require,module,exports){
+},{"../backend/common":218,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/conv_utils":261,"../utils/types_utils":266,"./convolutional":244,"@tensorflow/tfjs-core":68}],252:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -34424,9 +36666,10 @@ function standardizeArgs(inputs, initialState, constants, numConstants) {
     return { inputs: inputs, initialState: initialState, constants: constants };
 }
 exports.standardizeArgs = standardizeArgs;
-function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, inputLength) {
+function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, unroll, needPerStepOutputs) {
     if (goBackwards === void 0) { goBackwards = false; }
     if (unroll === void 0) { unroll = false; }
+    if (needPerStepOutputs === void 0) { needPerStepOutputs = false; }
     var ndim = inputs.shape.length;
     if (ndim < 3) {
         throw new errors_1.ValueError("Input should be at least 3D, but is " + ndim + "D.");
@@ -34452,24 +36695,27 @@ function rnn(stepFunction, inputs, initialStates, goBackwards, mask, constants, 
     var lastOutput;
     var states = initialStates;
     var timeSteps = inputs.shape[0];
-    for (var t = 0; t < timeSteps; ++t) {
+    var _loop_1 = function (t) {
         var currentInput = K.sliceAlongFirstAxis(inputs, t, 1);
         currentInput = currentInput.reshape(currentInput.shape.slice(1));
-        var stepOutputs = stepFunction(currentInput, states);
+        var stepOutputs = tfc.tidy(function () { return stepFunction(currentInput, states); });
         lastOutput = stepOutputs[0];
-        if (t === 0) {
-            outputs = lastOutput.reshape([1].concat(lastOutput.shape));
-        }
-        else {
-            outputs = K.concatAlongFirstAxis(outputs, lastOutput.reshape([1].concat(lastOutput.shape)));
+        if (needPerStepOutputs) {
+            if (t === 0) {
+                outputs = lastOutput.expandDims(1);
+            }
+            else {
+                var newOutputs = tfc.concat([outputs, lastOutput.expandDims(1)], 1);
+                outputs.dispose();
+                outputs = newOutputs;
+            }
         }
         states = stepOutputs[1];
+    };
+    for (var t = 0; t < timeSteps; ++t) {
+        _loop_1(t);
     }
-    return [
-        lastOutput,
-        tfc.transpose(outputs, [1, 0].concat(math_utils.range(2, outputs.shape.length))),
-        states
-    ];
+    return [lastOutput, outputs, states];
 }
 exports.rnn = rnn;
 var RNN = (function (_super) {
@@ -34718,8 +36964,6 @@ var RNN = (function (_super) {
                 throw new errors_1.ValueError("RNN Layer has " + numStates + " state(s) but was passed " +
                     (initialState.length + " initial state(s)."));
             }
-            var inputShape = inputs.shape;
-            var timesteps = inputShape[1];
             if (_this.unroll) {
                 console.warn('Ignoring unroll = true for RNN layer, due to imperative backend.');
             }
@@ -34728,7 +36972,7 @@ var RNN = (function (_super) {
                 var outputs = _this.cell.call([inputs].concat(states), cellCallKwargs);
                 return [outputs[0], outputs.slice(1)];
             };
-            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, timesteps);
+            var rnnOutputs = rnn(step, inputs, initialState, _this.goBackwards, null, null, _this.unroll, _this.returnSequences);
             var lastOutput = rnnOutputs[0];
             var outputs = rnnOutputs[1];
             var states = rnnOutputs[2];
@@ -34804,7 +37048,7 @@ var RNN = (function (_super) {
     return RNN;
 }(topology_2.Layer));
 exports.RNN = RNN;
-tfjs_core_1.serialization.SerializationMap.register(RNN);
+tfjs_core_1.serialization.registerClass(RNN);
 var RNNCell = (function (_super) {
     __extends(RNNCell, _super);
     function RNNCell() {
@@ -34923,7 +37167,7 @@ var SimpleRNNCell = (function (_super) {
     return SimpleRNNCell;
 }(RNNCell));
 exports.SimpleRNNCell = SimpleRNNCell;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNNCell);
+tfjs_core_1.serialization.registerClass(SimpleRNNCell);
 var SimpleRNN = (function (_super) {
     __extends(SimpleRNN, _super);
     function SimpleRNN(config) {
@@ -35074,7 +37318,7 @@ var SimpleRNN = (function (_super) {
     return SimpleRNN;
 }(RNN));
 exports.SimpleRNN = SimpleRNN;
-tfjs_core_1.serialization.SerializationMap.register(SimpleRNN);
+tfjs_core_1.serialization.registerClass(SimpleRNN);
 var GRUCell = (function (_super) {
     __extends(GRUCell, _super);
     function GRUCell(config) {
@@ -35249,7 +37493,7 @@ var GRUCell = (function (_super) {
     return GRUCell;
 }(RNNCell));
 exports.GRUCell = GRUCell;
-tfjs_core_1.serialization.SerializationMap.register(GRUCell);
+tfjs_core_1.serialization.registerClass(GRUCell);
 var GRU = (function (_super) {
     __extends(GRU, _super);
     function GRU(config) {
@@ -35426,7 +37670,7 @@ var GRU = (function (_super) {
     return GRU;
 }(RNN));
 exports.GRU = GRU;
-tfjs_core_1.serialization.SerializationMap.register(GRU);
+tfjs_core_1.serialization.registerClass(GRU);
 var LSTMCell = (function (_super) {
     __extends(LSTMCell, _super);
     function LSTMCell(config) {
@@ -35636,7 +37880,7 @@ var LSTMCell = (function (_super) {
     return LSTMCell;
 }(RNNCell));
 exports.LSTMCell = LSTMCell;
-tfjs_core_1.serialization.SerializationMap.register(LSTMCell);
+tfjs_core_1.serialization.registerClass(LSTMCell);
 var LSTM = (function (_super) {
     __extends(LSTM, _super);
     function LSTM(config) {
@@ -35821,7 +38065,7 @@ var LSTM = (function (_super) {
     return LSTM;
 }(RNN));
 exports.LSTM = LSTM;
-tfjs_core_1.serialization.SerializationMap.register(LSTM);
+tfjs_core_1.serialization.registerClass(LSTM);
 var StackedRNNCells = (function (_super) {
     __extends(StackedRNNCells, _super);
     function StackedRNNCells(config) {
@@ -35985,7 +38229,7 @@ var StackedRNNCells = (function (_super) {
     return StackedRNNCells;
 }(RNNCell));
 exports.StackedRNNCells = StackedRNNCells;
-tfjs_core_1.serialization.SerializationMap.register(StackedRNNCells);
+tfjs_core_1.serialization.registerClass(StackedRNNCells);
 function generateDropoutMask(ones, rate, training, count) {
     if (training === void 0) { training = null; }
     if (count === void 0) { count = 1; }
@@ -36005,7 +38249,7 @@ function generateDropoutMask(ones, rate, training, count) {
     }
 }
 
-},{"../activations":197,"../backend/state":199,"../backend/tfjs_backend":200,"../constraints":204,"../engine/topology":208,"../errors":210,"../initializers":218,"../regularizers":236,"../utils/math_utils":240,"../utils/types_utils":242,"../variables":244,"./serialization":229,"@tensorflow/tfjs-core":68}],229:[function(require,module,exports){
+},{"../activations":217,"../backend/state":219,"../backend/tfjs_backend":220,"../constraints":224,"../engine/topology":229,"../errors":233,"../initializers":242,"../regularizers":260,"../utils/math_utils":264,"../utils/types_utils":266,"../variables":268,"./serialization":253,"@tensorflow/tfjs-core":68}],253:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -36016,7 +38260,7 @@ function deserialize(config, customObjects) {
 }
 exports.deserialize = deserialize;
 
-},{"../utils/generic_utils":238,"@tensorflow/tfjs-core":68}],230:[function(require,module,exports){
+},{"../utils/generic_utils":262,"@tensorflow/tfjs-core":68}],254:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36157,10 +38401,10 @@ var TimeDistributed = (function (_super) {
         return tfjs_core_1.tidy(function () {
             inputs = types_utils_1.getExactlyOneTensor(inputs);
             var step = function (inputs, states) {
-                var output = _this.layer.call(inputs, kwargs);
+                var output = types_utils_1.getExactlyOneTensor(_this.layer.call(inputs, kwargs));
                 return [output, []];
             };
-            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, inputs.shape[1]);
+            var rnnOutputs = recurrent_1.rnn(step, inputs, [], false, null, null, false, true);
             var y = rnnOutputs[1];
             return y;
         });
@@ -36169,7 +38413,7 @@ var TimeDistributed = (function (_super) {
     return TimeDistributed;
 }(Wrapper));
 exports.TimeDistributed = TimeDistributed;
-tfjs_core_1.serialization.SerializationMap.register(TimeDistributed);
+tfjs_core_1.serialization.registerClass(TimeDistributed);
 exports.VALID_BIDIRECTIONAL_MERGE_MODES = ['sum', 'mul', 'concat', 'ave'];
 function checkBidirectionalMergeMode(value) {
     generic_utils.checkStringTypeUnionValue(exports.VALID_BIDIRECTIONAL_MERGE_MODES, 'BidirectionalMergeMode', value);
@@ -36340,7 +38584,7 @@ var Bidirectional = (function (_super) {
                 var forwardState = initialState.slice(0, initialState.length / 2);
                 var backwardState = initialState.slice(initialState.length / 2);
                 y = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: forwardState }));
-                yRev = _this.forwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
+                yRev = _this.backwardLayer.call(inputs, Object.assign(kwargs, { initialState: backwardState }));
             }
             var states;
             if (_this.returnState) {
@@ -36431,9 +38675,9 @@ var Bidirectional = (function (_super) {
     return Bidirectional;
 }(Wrapper));
 exports.Bidirectional = Bidirectional;
-tfjs_core_1.serialization.SerializationMap.register(Bidirectional);
+tfjs_core_1.serialization.registerClass(Bidirectional);
 
-},{"../backend/state":199,"../backend/tfjs_backend":200,"../common":203,"../engine/topology":208,"../errors":210,"../utils/generic_utils":238,"../utils/types_utils":242,"./recurrent":228,"./serialization":229,"@tensorflow/tfjs-core":68}],231:[function(require,module,exports){
+},{"../backend/state":219,"../backend/tfjs_backend":220,"../common":223,"../engine/topology":229,"../errors":233,"../utils/generic_utils":262,"../utils/types_utils":266,"./recurrent":252,"./serialization":253,"@tensorflow/tfjs-core":68}],255:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36519,14 +38763,14 @@ function disposeTensorsInLogs(logs) {
 }
 exports.disposeTensorsInLogs = disposeTensorsInLogs;
 
-},{"@tensorflow/tfjs-core":68}],232:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],256:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
 var common_1 = require("./backend/common");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 function l2Normalize(x, axis) {
     return tfjs_core_1.tidy(function () {
@@ -36703,7 +38947,13 @@ function get(identifierOrFn) {
         if (identifierOrFn in lossesMap) {
             return lossesMap[identifierOrFn];
         }
-        throw new errors_1.ValueError("Unknown loss " + identifierOrFn);
+        var errMsg = "Unknown loss " + identifierOrFn;
+        if (identifierOrFn.toLowerCase().includes('softmaxcrossentropy')) {
+            errMsg = "Unknown loss " + identifierOrFn + ". " +
+                'Use "categoricalCrossentropy" as the string name for ' +
+                'tf.losses.softmaxCrossEntropy';
+        }
+        throw new errors_1.ValueError(errMsg);
     }
     else {
         return identifierOrFn;
@@ -36711,13 +38961,13 @@ function get(identifierOrFn) {
 }
 exports.get = get;
 
-},{"./backend/common":198,"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"@tensorflow/tfjs-core":68}],233:[function(require,module,exports){
+},{"./backend/common":218,"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"@tensorflow/tfjs-core":68}],257:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var K = require("./backend/tfjs_backend");
 var state_1 = require("./backend/state");
+var K = require("./backend/tfjs_backend");
 var errors_1 = require("./errors");
 var losses_1 = require("./losses");
 var losses_2 = require("./losses");
@@ -36733,6 +38983,54 @@ function categoricalAccuracy(yTrue, yPred) {
     return tfjs_core_1.tidy(function () { return K.cast(tfc.equal(tfc.argMax(yTrue, -1), tfc.argMax(yPred, -1)), 'float32'); });
 }
 exports.categoricalAccuracy = categoricalAccuracy;
+function truePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function falseNegatives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(one), yPred.equal(zero))
+            .sum()
+            .cast('float32');
+    });
+}
+function falsePositives(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var one = state_1.getScalar(1);
+        var zero = state_1.getScalar(0);
+        return tfc.logicalAnd(yTrue.equal(zero), yPred.equal(one))
+            .sum()
+            .cast('float32');
+    });
+}
+function precision(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fp = falsePositives(yTrue, yPred);
+        var denominator = tp.add(fp);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.precision = precision;
+function recall(yTrue, yPred) {
+    return tfjs_core_1.tidy(function () {
+        var zero = state_1.getScalar(0);
+        var tp = truePositives(yTrue, yPred);
+        var fn = falseNegatives(yTrue, yPred);
+        var denominator = tp.add(fn);
+        return tfc.where(tfc.greater(denominator, zero), tp.div(denominator), zero)
+            .cast('float32');
+    });
+}
+exports.recall = recall;
 function binaryCrossentropy(yTrue, yPred) {
     return losses_2.binaryCrossentropy(yTrue, yPred);
 }
@@ -36762,6 +39060,7 @@ function get(identifier) {
     var metricsMap = {
         binaryAccuracy: binaryAccuracy,
         categoricalAccuracy: categoricalAccuracy,
+        precision: precision,
         categoricalCrossentropy: exports.categoricalCrossentropy,
         sparseCategoricalCrossentropy: exports.sparseCategoricalCrossentropy,
         mse: exports.mse,
@@ -36784,7 +39083,7 @@ function get(identifier) {
 }
 exports.get = get;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./errors":210,"./losses":232,"@tensorflow/tfjs-core":68}],234:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./errors":233,"./losses":256,"@tensorflow/tfjs-core":68}],258:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -36848,6 +39147,10 @@ function modelFromJSON(modelAndWeightsConfig, customObjects) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
+                    if (!('modelTopology' in modelAndWeightsConfig)) {
+                        modelAndWeightsConfig = { modelTopology: modelAndWeightsConfig };
+                    }
+                    modelAndWeightsConfig = modelAndWeightsConfig;
                     modelTopology = modelAndWeightsConfig.modelTopology;
                     if (modelTopology['model_config'] != null) {
                         modelTopology = modelTopology['model_config'];
@@ -36946,6 +39249,14 @@ var Sequential = (function (_super) {
         }
         return _this;
     }
+    Sequential.prototype.checkShape = function (layer) {
+        var shape = layer.inboundNodes[0].outputTensors[0].shape;
+        if (shape.some(function (x) { return x < 0; })) {
+            throw new errors_1.ValueError('Negative dimension size caused by adding layer ' +
+                (layer.name + " with input shape [") +
+                (layer.inboundNodes[0].inputTensors[0].shape + "]"));
+        }
+    };
     Sequential.prototype.add = function (layer) {
         var isLayerModelInstance = layer instanceof Sequential || layer instanceof training_1.Model;
         var modelLayer;
@@ -36994,6 +39305,7 @@ var Sequential = (function (_super) {
                         'For multi-output layers, ' +
                         'use the functional API.');
                 }
+                this.checkShape(layer);
                 this.outputs = [layer.inboundNodes[0].outputTensors[0]];
                 this.inputs = topology_1.getSourceInputs(this.outputs[0]);
             }
@@ -37019,6 +39331,7 @@ var Sequential = (function (_super) {
                     'For multi-output layers, ' +
                     'use the functional API.');
             }
+            this.checkShape(layer);
             this.outputs = [outputTensor];
             this.inboundNodes[0].outputTensors = this.outputs;
             this.inboundNodes[0].outputShapes = [this.outputs[0].shape];
@@ -37115,6 +39428,16 @@ var Sequential = (function (_super) {
         }
         return this.model.evaluate(x, y, config);
     };
+    Sequential.prototype.evaluateDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before being used.');
+                }
+                return [2, this.model.evaluateDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.prototype.predict = function (x, config) {
         if (config === void 0) { config = {}; }
         if (this.model == null) {
@@ -37149,19 +39472,40 @@ var Sequential = (function (_super) {
             });
         });
     };
+    Sequential.prototype.fitDataset = function (dataset, config) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (!this.built) {
+                    throw new errors_1.RuntimeError('The model needs to be compiled before ' +
+                        'being used.');
+                }
+                return [2, this.model.fitDataset(dataset, config)];
+            });
+        });
+    };
     Sequential.fromConfig = function (cls, config) {
-        var model = new cls({});
+        var configArray;
+        var extraModelConfig = {};
+        if (config instanceof Array) {
+            if (!(config[0].className != null) ||
+                config[0]['className'] === 'Merge') {
+                throw new errors_1.ValueError('Legacy serialization format not supported yet.');
+            }
+            configArray = config;
+        }
+        else {
+            tfjs_core_1.util.assert(config['layers'] != null, "When the config data for a Sequential model is not an Array, " +
+                "it must be an Object that contains the 'layers' field.");
+            configArray = config['layers'];
+            delete config['layers'];
+            extraModelConfig = config;
+        }
+        var model = new cls(extraModelConfig);
         if (!(model instanceof Sequential)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called on non-Sequential input: " + model);
+            throw new errors_1.NotImplementedError("Sequential.fromConfig called on non-Sequential input: " + model);
         }
-        if (!(config instanceof Array)) {
-            throw new errors_1.ValueError("Sequential.fromConfig called without an array of configs");
-        }
-        if (!(config[0].className != null) || config[0]['className'] === 'Merge') {
-            throw new errors_1.ValueError('Legacy serialization format not supported yet.');
-        }
-        for (var _i = 0, _a = config; _i < _a.length; _i++) {
-            var conf = _a[_i];
+        for (var _i = 0, configArray_1 = configArray; _i < configArray_1.length; _i++) {
+            var conf = configArray_1[_i];
             var layer = serialization_1.deserialize(conf);
             model.add(layer);
         }
@@ -37189,9 +39533,9 @@ var Sequential = (function (_super) {
     return Sequential;
 }(training_1.Model));
 exports.Sequential = Sequential;
-tfjs_core_1.serialization.SerializationMap.register(Sequential);
+tfjs_core_1.serialization.registerClass(Sequential);
 
-},{"./backend/state":199,"./engine/input_layer":207,"./engine/topology":208,"./engine/training":209,"./errors":210,"./layers/serialization":229,"./utils/generic_utils":238,"./utils/serialization_utils":241,"./utils/types_utils":242,"@tensorflow/tfjs-core":68}],235:[function(require,module,exports){
+},{"./backend/state":219,"./engine/input_layer":228,"./engine/topology":229,"./engine/training":230,"./errors":233,"./layers/serialization":253,"./utils/generic_utils":262,"./utils/serialization_utils":265,"./utils/types_utils":266,"@tensorflow/tfjs-core":68}],259:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
@@ -37219,7 +39563,7 @@ function getOptimizer(identifier) {
 }
 exports.getOptimizer = getOptimizer;
 
-},{"./backend/common":198,"./errors":210,"@tensorflow/tfjs-core":68}],236:[function(require,module,exports){
+},{"./backend/common":218,"./errors":233,"@tensorflow/tfjs-core":68}],260:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -37281,7 +39625,7 @@ var L1L2 = (function (_super) {
     return L1L2;
 }(Regularizer));
 exports.L1L2 = L1L2;
-tfjs_core_1.serialization.SerializationMap.register(L1L2);
+tfjs_core_1.serialization.registerClass(L1L2);
 function l1(config) {
     return new L1L2({ l1: config != null ? config.l1 : null, l2: 0 });
 }
@@ -37322,7 +39666,7 @@ function getRegularizer(identifier) {
 }
 exports.getRegularizer = getRegularizer;
 
-},{"./backend/state":199,"./backend/tfjs_backend":200,"./utils/generic_utils":238,"@tensorflow/tfjs-core":68}],237:[function(require,module,exports){
+},{"./backend/state":219,"./backend/tfjs_backend":220,"./utils/generic_utils":262,"@tensorflow/tfjs-core":68}],261:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -37382,7 +39726,7 @@ function deconvLength(dimSize, strideSize, kernelSize, padding) {
 }
 exports.deconvLength = deconvLength;
 
-},{"../errors":210,"./generic_utils":238,"./math_utils":240}],238:[function(require,module,exports){
+},{"../errors":233,"./generic_utils":262,"./math_utils":264}],262:[function(require,module,exports){
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -37651,7 +39995,7 @@ function checkArrayTypeAndLength(x, expectedType, minLength, maxLength) {
 }
 exports.checkArrayTypeAndLength = checkArrayTypeAndLength;
 
-},{"../errors":210}],239:[function(require,module,exports){
+},{"../errors":233}],263:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var variable_utils_1 = require("./variable_utils");
@@ -37811,7 +40155,7 @@ function printLayerSummaryWithConnections(layer, positions, relevantNodes, print
     }
 }
 
-},{"./variable_utils":243}],240:[function(require,module,exports){
+},{"./variable_utils":267}],264:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -37883,7 +40227,7 @@ function range(begin, end) {
 }
 exports.range = range;
 
-},{"../errors":210,"@tensorflow/tfjs-core":68}],241:[function(require,module,exports){
+},{"../errors":233,"@tensorflow/tfjs-core":68}],265:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var generic_utils = require("../utils/generic_utils");
@@ -37977,7 +40321,7 @@ function convertTsToPythonic(tsConfig, key) {
 }
 exports.convertTsToPythonic = convertTsToPythonic;
 
-},{"../utils/generic_utils":238}],242:[function(require,module,exports){
+},{"../utils/generic_utils":262}],266:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var errors_1 = require("../errors");
@@ -38025,7 +40369,7 @@ function getExactlyOneShape(shapes) {
 }
 exports.getExactlyOneShape = getExactlyOneShape;
 
-},{"../errors":210}],243:[function(require,module,exports){
+},{"../errors":233}],267:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 function countParamsInWeights(weights) {
@@ -38043,7 +40387,7 @@ function countParamsInWeights(weights) {
 }
 exports.countParamsInWeights = countParamsInWeights;
 
-},{}],244:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tfc = require("@tensorflow/tfjs-core");
@@ -38136,8 +40480,9 @@ function truncatedNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'truncatedNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormal does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormal does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.truncatedNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38146,8 +40491,9 @@ function randomNormalVariable(shape, mean, stddev, dtype, seed, name) {
     if (mean === void 0) { mean = 0.0; }
     if (stddev === void 0) { stddev = 1.0; }
     if (name === void 0) { name = 'randomNormal'; }
-    if (dtype === 'bool') {
-        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType bool.");
+    dtype = dtype || 'float32';
+    if (dtype !== 'float32' && dtype !== 'int32') {
+        throw new errors_1.NotImplementedError("randomNormalVariable does not support dType " + dtype + ".");
     }
     return new LayerVariable(tfc.randomNormal(shape, mean, stddev, dtype, seed), dtype, name);
 }
@@ -38182,13 +40528,13 @@ function gradients(lossFn, variables) {
 }
 exports.gradients = gradients;
 
-},{"./backend/state":199,"./common":203,"./errors":210,"@tensorflow/tfjs-core":68}],245:[function(require,module,exports){
+},{"./backend/state":219,"./common":223,"./errors":233,"@tensorflow/tfjs-core":68}],269:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.7.5';
+var version = '0.8.3';
 exports.version = version;
 
-},{}],246:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -38208,13 +40554,13 @@ exports.version = {
     'tfjs': version_1.version
 };
 
-},{"./version":247,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":217}],247:[function(require,module,exports){
+},{"./version":271,"@tensorflow/tfjs-converter":15,"@tensorflow/tfjs-core":68,"@tensorflow/tfjs-layers":241}],271:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var version = '0.12.7';
+var version = '0.13.3';
 exports.version = version;
 
-},{}],248:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -38332,7 +40678,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],249:[function(require,module,exports){
+},{}],273:[function(require,module,exports){
 /**
  * Bit twiddling hacks for JavaScript.
  *
@@ -38538,9 +40884,9 @@ exports.nextCombination = function(v) {
 }
 
 
-},{}],250:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 
-},{}],251:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -40278,7 +42624,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":248,"ieee754":259}],252:[function(require,module,exports){
+},{"base64-js":272,"ieee754":283}],276:[function(require,module,exports){
 "use strict"
 
 var createThunk = require("./lib/thunk.js")
@@ -40389,7 +42735,7 @@ function compileCwise(user_args) {
 
 module.exports = compileCwise
 
-},{"./lib/thunk.js":254}],253:[function(require,module,exports){
+},{"./lib/thunk.js":278}],277:[function(require,module,exports){
 "use strict"
 
 var uniq = require("uniq")
@@ -40749,7 +43095,7 @@ function generateCWiseOp(proc, typesig) {
 }
 module.exports = generateCWiseOp
 
-},{"uniq":300}],254:[function(require,module,exports){
+},{"uniq":324}],278:[function(require,module,exports){
 "use strict"
 
 // The function below is called when constructing a cwise function object, and does the following:
@@ -40837,9 +43183,9 @@ function createThunk(proc) {
 
 module.exports = createThunk
 
-},{"./compile.js":253}],255:[function(require,module,exports){
+},{"./compile.js":277}],279:[function(require,module,exports){
 module.exports = require("cwise-compiler")
-},{"cwise-compiler":252}],256:[function(require,module,exports){
+},{"cwise-compiler":276}],280:[function(require,module,exports){
 "use strict"
 
 function dupe_array(count, value, i) {
@@ -40889,7 +43235,7 @@ function dupe(count, value) {
 }
 
 module.exports = dupe
-},{}],257:[function(require,module,exports){
+},{}],281:[function(require,module,exports){
 'use strict';
 
 function FFT(size) {
@@ -41398,7 +43744,7 @@ FFT.prototype._singleRealTransform4 = function _singleRealTransform4(outOff,
   out[outOff + 7] = FDi;
 };
 
-},{}],258:[function(require,module,exports){
+},{}],282:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 1.3.2
@@ -41588,7 +43934,7 @@ if (typeof module !== "undefined" && module.exports) {
   });
 }
 
-},{}],259:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -41674,7 +44020,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],260:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 "use strict"
 
 function iota(n) {
@@ -41686,7 +44032,7 @@ function iota(n) {
 }
 
 module.exports = iota
-},{}],261:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -41709,10 +44055,10 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],262:[function(require,module,exports){
+},{}],286:[function(require,module,exports){
 !function(t,e){"object"==typeof exports&&"object"==typeof module?module.exports=e():"function"==typeof define&&define.amd?define([],e):"object"==typeof exports?exports.MidiConvert=e():t.MidiConvert=e()}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="",e(e.s=7)}([function(t,e,n){"use strict";n.d(e,"a",function(){return r}),n.d(e,"b",function(){return i}),n.d(e,"c",function(){return a});var r=["acoustic grand piano","bright acoustic piano","electric grand piano","honky-tonk piano","electric piano 1","electric piano 2","harpsichord","clavi","celesta","glockenspiel","music box","vibraphone","marimba","xylophone","tubular bells","dulcimer","drawbar organ","percussive organ","rock organ","church organ","reed organ","accordion","harmonica","tango accordion","acoustic guitar (nylon)","acoustic guitar (steel)","electric guitar (jazz)","electric guitar (clean)","electric guitar (muted)","overdriven guitar","distortion guitar","guitar harmonics","acoustic bass","electric bass (finger)","electric bass (pick)","fretless bass","slap bass 1","slap bass 2","synth bass 1","synth bass 2","violin","viola","cello","contrabass","tremolo strings","pizzicato strings","orchestral harp","timpani","string ensemble 1","string ensemble 2","synthstrings 1","synthstrings 2","choir aahs","voice oohs","synth voice","orchestra hit","trumpet","trombone","tuba","muted trumpet","french horn","brass section","synthbrass 1","synthbrass 2","soprano sax","alto sax","tenor sax","baritone sax","oboe","english horn","bassoon","clarinet","piccolo","flute","recorder","pan flute","blown bottle","shakuhachi","whistle","ocarina","lead 1 (square)","lead 2 (sawtooth)","lead 3 (calliope)","lead 4 (chiff)","lead 5 (charang)","lead 6 (voice)","lead 7 (fifths)","lead 8 (bass + lead)","pad 1 (new age)","pad 2 (warm)","pad 3 (polysynth)","pad 4 (choir)","pad 5 (bowed)","pad 6 (metallic)","pad 7 (halo)","pad 8 (sweep)","fx 1 (rain)","fx 2 (soundtrack)","fx 3 (crystal)","fx 4 (atmosphere)","fx 5 (brightness)","fx 6 (goblins)","fx 7 (echoes)","fx 8 (sci-fi)","sitar","banjo","shamisen","koto","kalimba","bag pipe","fiddle","shanai","tinkle bell","agogo","steel drums","woodblock","taiko drum","melodic tom","synth drum","reverse cymbal","guitar fret noise","breath noise","seashore","bird tweet","telephone ring","helicopter","applause","gunshot"],i=["piano","chromatic percussion","organ","guitar","bass","strings","ensemble","brass","reed","pipe","synth lead","synth pad","synth effects","ethnic","percussive","sound effects"],a={0:"standard kit",8:"room kit",16:"power kit",24:"electronic kit",25:"tr-808 kit",32:"jazz kit",40:"brush kit",48:"orchestra kit",56:"sound fx kit"}},function(t,e,n){"use strict";function r(t){return t.replace(/\u0000/g,"")}function i(t,e){return 60/e.bpm*(t/e.PPQ)}function a(t){return"number"==typeof t}function o(t){return"string"==typeof t}function s(t){return["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"][t%12]+(Math.floor(t/12)-1)}e.b=r,e.a=i,e.c=a,n.d(e,"d",function(){return u}),e.e=s,n.d(e,"f",function(){return c});var u=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i;return function(e){return o(e)&&t.test(e)}}(),c=function(){var t=/^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,e={cbb:-2,cb:-1,c:0,"c#":1,cx:2,dbb:0,db:1,d:2,"d#":3,dx:4,ebb:2,eb:3,e:4,"e#":5,ex:6,fbb:3,fb:4,f:5,"f#":6,fx:7,gbb:5,gb:6,g:7,"g#":8,gx:9,abb:7,ab:8,a:9,"a#":10,ax:11,bbb:9,bb:10,b:11,"b#":12,bx:13};return function(n){var r=t.exec(n),i=r[1],a=r[2];return e[i.toLowerCase()]+12*(parseInt(a)+1)}}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(11),a=(n.n(i),n(10)),o=(n.n(a),n(1)),s=n(9),u=n(5),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(){r(this,t),this.header={bpm:120,timeSignature:[4,4],PPQ:480},this.tracks=[]}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t;return n.header=e.header,e.tracks.forEach(function(t){var e=s.a.fromJSON(t);n.tracks.push(e)}),n}}]),c(t,[{key:"load",value:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:null,r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"GET";return new Promise(function(i,a){var o=new XMLHttpRequest;o.open(r,t),o.responseType="arraybuffer",o.addEventListener("load",function(){4===o.readyState&&200===o.status?i(e.decode(o.response)):a(o.status)}),o.addEventListener("error",a),o.send(n)}).catch(function(t){console.log(t)})}},{key:"decode",value:function(t){var e=this;if(t instanceof ArrayBuffer){var r=new Uint8Array(t);t=String.fromCharCode.apply(null,r)}var a=i(t);return this.header=n.i(u.a)(a),this.tracks=[],a.tracks.forEach(function(t,n){var r=new s.a;r.id=n,e.tracks.push(r);var i=0;t.forEach(function(t){i+=o.a(t.deltaTime,e.header),"meta"===t.type&&"trackName"===t.subtype?r.name=o.b(t.text):"noteOn"===t.subtype?(r.noteOn(t.noteNumber,i,t.velocity/127),-1===r.channelNumber&&(r.channelNumber=t.channel)):"noteOff"===t.subtype?r.noteOff(t.noteNumber,i):"controller"===t.subtype&&t.controllerType?r.cc(t.controllerType,i,t.value/127):"meta"===t.type&&"instrumentName"===t.subtype?r.instrument=t.text:"channel"===t.type&&"programChange"===t.subtype&&(r.patch(t.programNumber),r.channelNumber=t.channel)}),e.header.name||r.length||!r.name||(e.header.name=r.name)}),this}},{key:"encode",value:function(){var t=this,e=new a.File({ticks:this.header.PPQ}),n=this.tracks.filter(function(t){return!t.length})[0];if(this.header.name&&(!n||n.name!==this.header.name)){e.addTrack().addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:this.header.name}))}return this.tracks.forEach(function(n){var r=e.addTrack();r.setTempo(t.bpm),n.name&&r.addEvent(new a.MetaEvent({time:0,type:a.MetaEvent.TRACK_NAME,data:n.name})),n.encode(r,t.header)}),e.toBytes()}},{key:"toArray",value:function(){for(var t=this.encode(),e=new Array(t.length),n=0;n<t.length;n++)e[n]=t.charCodeAt(n);return e}},{key:"toJSON",value:function(){var t={header:this.header,startTime:this.startTime,duration:this.duration,tracks:(this.tracks||[]).map(function(t){return t.toJSON()})};return t.header.name||(t.header.name=""),t}},{key:"track",value:function(t){var e=new s.a(t);return this.tracks.push(e),e}},{key:"get",value:function(t){return o.c(t)?this.tracks[t]:this.tracks.find(function(e){return e.name===t})}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=new t;return r.header=this.header,r.tracks=this.tracks.map(function(t){return t.slice(e,n)}),r}},{key:"startTime",get:function(){var t=this.tracks.map(function(t){return t.startTime});return t.length?Math.min.apply(Math,t)||0:0}},{key:"bpm",get:function(){return this.header.bpm},set:function(t){var e=this.header.bpm;this.header.bpm=t;var n=e/t;this.tracks.forEach(function(t){return t.scale(n)})}},{key:"timeSignature",get:function(){return this.header.timeSignature},set:function(t){this.header.timeSignature=t}},{key:"duration",get:function(){var t=this.tracks.map(function(t){return t.duration});return t.length?Math.max.apply(Math,t)||0:0}}]),t}()},function(t,e,n){"use strict";function r(t,e){var n=0,r=t.length,i=r;if(r>0&&t[r-1].time<=e)return r-1;for(;n<i;){var a=Math.floor(n+(i-n)/2),o=t[a],s=t[a+1];if(o.time===e){for(var u=a;u<t.length;u++){t[u].time===e&&(a=u)}return a}if(o.time<e&&s.time>e)return a;o.time>e?i=a:o.time<e&&(n=a+1)}return-1}function i(t,e){if(t.length){var n=r(t,e.time);t.splice(n+1,0,e)}else t.push(e)}n.d(e,"a",function(){return i})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),a={1:"modulationWheel",2:"breath",4:"footController",5:"portamentoTime",7:"volume",8:"balance",10:"pan",64:"sustain",65:"portamentoTime",66:"sostenuto",67:"softPedal",68:"legatoFootswitch",84:"portamentoContro"},o=function(){function t(e,n,i){r(this,t),this.number=e,this.time=n,this.value=i}return i(t,[{key:"name",get:function(){if(a.hasOwnProperty(this.number))return a[this.number]}}]),t}()},function(t,e,n){"use strict";function r(t){for(var e={PPQ:t.header.ticksPerBeat},n=0;n<t.tracks.length;n++)for(var r=t.tracks[n],i=0;i<r.length;i++){var a=r[i];"meta"===a.type&&("timeSignature"===a.subtype?e.timeSignature=[a.numerator,a.denominator]:"setTempo"===a.subtype&&(e.bpm||(e.bpm=6e7/a.microsecondsPerBeat)))}return e.bpm=e.bpm||120,e}n.d(e,"a",function(){return r})},function(t,e,n){"use strict";function r(t,e){for(var n=0;n<t.length;n++){var r=t[n],i=e[n];if(r.length>i)return!0}return!1}function i(t,e,n){for(var r=0,i=1/0,a=0;a<t.length;a++){var o=t[a],s=e[a];o[s]&&o[s].time<i&&(r=a,i=o[s].time)}n[r](t[r][e[r]]),e[r]+=1}function a(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];for(var a=e.filter(function(t,e){return e%2==0}),o=new Uint32Array(a.length),s=e.filter(function(t,e){return e%2==1});r(a,o);)i(a,o,s)}n.d(e,"a",function(){return a})},function(t,e,n){"use strict";function r(t){return(new s.a).decode(t)}function i(t,e){var n=(new s.a).load(t);return e&&n.then(e),n}function a(){return new s.a}function o(t){return s.a.fromJSON(t)}Object.defineProperty(e,"__esModule",{value:!0}),e.parse=r,e.load=i,e.create=a,e.fromJSON=o;var s=n(2),u=n(0);n.d(e,"instrumentByPatchID",function(){return u.a}),n.d(e,"instrumentFamilyByID",function(){return u.b}),n.d(e,"drumKitByPatchID",function(){return u.c})},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return o});var i=n(1),a=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),o=function(){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1;if(r(this,t),i.c(e))this.midi=e;else{if(!i.d(e))throw new Error("the midi value must either be in Pitch Notation (e.g. C#4) or a midi value");this.name=e}this.time=n,this.duration=a,this.velocity=o}return a(t,null,[{key:"fromJSON",value:function(e){return new t(e.midi,e.time,e.duration,e.velocity)}}]),a(t,[{key:"match",value:function(t){return i.c(t)?this.midi===t:i.d(t)?this.name.toLowerCase()===t.toLowerCase():void 0}},{key:"toJSON",value:function(){return{name:this.name,midi:this.midi,time:this.time,velocity:this.velocity,duration:this.duration}}},{key:"name",get:function(){return i.e(this.midi)},set:function(t){this.midi=i.f(t)}},{key:"noteOn",get:function(){return this.time},set:function(t){this.time=t}},{key:"noteOff",get:function(){return this.time+this.duration},set:function(t){this.duration=t-this.time}}]),t}()},function(t,e,n){"use strict";function r(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}n.d(e,"a",function(){return h});var i=n(3),a=n(4),o=n(6),s=n(8),u=n(0),c=function(){function t(t,e){for(var n=0;n<e.length;n++){var r=e[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(t,r.key,r)}}return function(e,n,r){return n&&t(e.prototype,n),r&&t(e,r),e}}(),h=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:-1,i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:-1;r(this,t),this.name=e,this.channelNumber=i,this.notes=[],this.controlChanges={},this.instrumentNumber=n}return c(t,null,[{key:"fromJSON",value:function(e){var n=new t(e.name,e.instrumentNumber,e.channelNumber);return n.id=e.id,e.notes&&e.notes.forEach(function(t){var e=s.a.fromJSON(t);n.notes.push(e)}),e.controlChanges&&(n.controlChanges=e.controlChanges),n}}]),c(t,[{key:"note",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:0,a=arguments.length>3&&void 0!==arguments[3]?arguments[3]:1,o=new s.a(t,e,r,a);return n.i(i.a)(this.notes,o),this}},{key:"noteOn",value:function(t,e){var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:1,a=new s.a(t,e,0,r);return n.i(i.a)(this.notes,a),this}},{key:"noteOff",value:function(t,e){for(var n=0;n<this.notes.length;n++){var r=this.notes[n];if(r.match(t)&&0===r.duration){r.noteOff=e;break}}return this}},{key:"cc",value:function(t,e,r){this.controlChanges.hasOwnProperty(t)||(this.controlChanges[t]=[]);var o=new a.a(t,e,r);return n.i(i.a)(this.controlChanges[t],o),this}},{key:"patch",value:function(t){return this.instrumentNumber=t,this}},{key:"channel",value:function(t){return this.channelNumber=t,this}},{key:"scale",value:function(t){return this.notes.forEach(function(e){e.time*=t,e.duration*=t}),this}},{key:"slice",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.duration,r=Math.max(this.notes.findIndex(function(t){return t.time>=e}),0),i=this.notes.findIndex(function(t){return t.noteOff>=n})+1,a=new t(this.name);return a.notes=this.notes.slice(r,i),a.notes.forEach(function(t){return t.time=t.time-e}),a}},{key:"encode",value:function(t,e){function r(t){var e=Math.floor(i*t),n=Math.max(e-a,0);return a=e,n}var i=e.PPQ/(60/e.bpm),a=0,s=Math.max(0,this.channelNumber);-1!==this.instrumentNumber&&t.instrument(s,this.instrumentNumber),n.i(o.a)(this.noteOns.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOn(s,e.name,r(e.time),Math.floor(127*e.velocity))},this.noteOffs.sort(function(t,e){return t.time-e.time}),function(e){t.addNoteOff(s,e.name,r(e.time))})}},{key:"toJSON",value:function(){var t={startTime:this.startTime,duration:this.duration,length:this.length,notes:[],controlChanges:{}};return void 0!==this.id&&(t.id=this.id),t.name=this.name,-1!==this.instrumentNumber&&(t.instrumentNumber=this.instrumentNumber,t.instrument=this.instrument,t.instrumentFamily=this.instrumentFamily),-1!==this.channelNumber&&(t.channelNumber=this.channelNumber,t.isPercussion=this.isPercussion),this.notes.length&&(t.notes=this.notes.map(function(t){return t.toJSON()})),Object.keys(this.controlChanges).length&&(t.controlChanges=this.controlChanges),t}},{key:"noteOns",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOn,midi:e.midi,name:e.name,velocity:e.velocity})}),t}},{key:"noteOffs",get:function(){var t=[];return this.notes.forEach(function(e){t.push({time:e.noteOff,midi:e.midi,name:e.name})}),t}},{key:"length",get:function(){return this.notes.length}},{key:"startTime",get:function(){if(this.notes.length){return this.notes[0].noteOn}return 0}},{key:"duration",get:function(){if(this.notes.length){return this.notes[this.notes.length-1].noteOff}return 0}},{key:"instrument",get:function(){return this.isPercussion?u.c[this.instrumentNumber]:u.a[this.instrumentNumber]},set:function(t){var e=u.a.indexOf(t);-1!==e&&(this.instrumentNumber=e)}},{key:"isPercussion",get:function(){return[9,10].includes(this.channelNumber)}},{key:"instrumentFamily",get:function(){return this.isPercussion?"drums":u.b[Math.floor(this.instrumentNumber/8)]}}]),t}()},function(t,e,n){(function(t){var n={};!function(t){var e=t.DEFAULT_VOLUME=90,n=(t.DEFAULT_DURATION=128,t.DEFAULT_CHANNEL=0,{midi_letter_pitches:{a:21,b:23,c:12,d:14,e:16,f:17,g:19},midiPitchFromNote:function(t){var e=/([a-g])(#+|b+)?([0-9]+)$/i.exec(t),r=e[1].toLowerCase(),i=e[2]||"";return 12*parseInt(e[3],10)+n.midi_letter_pitches[r]+("#"==i.substr(0,1)?1:-1)*i.length},ensureMidiPitch:function(t){return"number"!=typeof t&&/[^0-9]/.test(t)?n.midiPitchFromNote(t):parseInt(t,10)},midi_pitches_letter:{12:"c",13:"c#",14:"d",15:"d#",16:"e",17:"f",18:"f#",19:"g",20:"g#",21:"a",22:"a#",23:"b"},midi_flattened_notes:{"a#":"bb","c#":"db","d#":"eb","f#":"gb","g#":"ab"},noteFromMidiPitch:function(t,e){var r,i=0,a=t,e=e||!1;return t>23&&(i=Math.floor(t/12)-1,a=t-12*i),r=n.midi_pitches_letter[a],e&&r.indexOf("#")>0&&(r=n.midi_flattened_notes[r]),r+i},mpqnFromBpm:function(t){var e=Math.floor(6e7/t),n=[];do{n.unshift(255&e),e>>=8}while(e);for(;n.length<3;)n.push(0);return n},bpmFromMpqn:function(t){var e=t;if(void 0!==t[0]){e=0;for(var n=0,r=t.length-1;r>=0;++n,--r)e|=t[n]<<r}return Math.floor(6e7/t)},codes2Str:function(t){return String.fromCharCode.apply(null,t)},str2Bytes:function(t,e){if(e)for(;t.length/2<e;)t="0"+t;for(var n=[],r=t.length-1;r>=0;r-=2){var i=0===r?t[r]:t[r-1]+t[r];n.unshift(parseInt(i,16))}return n},translateTickTime:function(t){for(var e=127&t;t>>=7;)e<<=8,e|=127&t|128;for(var n=[];;){if(n.push(255&e),!(128&e))break;e>>=8}return n}}),r=function(t){if(!this)return new r(t);!t||null===t.type&&void 0===t.type||null===t.channel&&void 0===t.channel||null===t.param1&&void 0===t.param1||(this.setTime(t.time),this.setType(t.type),this.setChannel(t.channel),this.setParam1(t.param1),this.setParam2(t.param2))};r.NOTE_OFF=128,r.NOTE_ON=144,r.AFTER_TOUCH=160,r.CONTROLLER=176,r.PROGRAM_CHANGE=192,r.CHANNEL_AFTERTOUCH=208,r.PITCH_BEND=224,r.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},r.prototype.setType=function(t){if(t<r.NOTE_OFF||t>r.PITCH_BEND)throw new Error("Trying to set an unknown event: "+t);this.type=t},r.prototype.setChannel=function(t){if(t<0||t>15)throw new Error("Channel is out of bounds.");this.channel=t},r.prototype.setParam1=function(t){this.param1=t},r.prototype.setParam2=function(t){this.param2=t},r.prototype.toBytes=function(){var t=[],e=this.type|15&this.channel;return t.push.apply(t,this.time),t.push(e),t.push(this.param1),void 0!==this.param2&&null!==this.param2&&t.push(this.param2),t};var i=function(t){if(!this)return new i(t);this.setTime(t.time),this.setType(t.type),this.setData(t.data)};i.SEQUENCE=0,i.TEXT=1,i.COPYRIGHT=2,i.TRACK_NAME=3,i.INSTRUMENT=4,i.LYRIC=5,i.MARKER=6,i.CUE_POINT=7,i.CHANNEL_PREFIX=32,i.END_OF_TRACK=47,i.TEMPO=81,i.SMPTE=84,i.TIME_SIG=88,i.KEY_SIG=89,i.SEQ_EVENT=127,i.prototype.setTime=function(t){this.time=n.translateTickTime(t||0)},i.prototype.setType=function(t){this.type=t},i.prototype.setData=function(t){this.data=t},i.prototype.toBytes=function(){if(!this.type)throw new Error("Type for meta-event not specified.");var t=[];if(t.push.apply(t,this.time),t.push(255,this.type),Array.isArray(this.data))t.push(this.data.length),t.push.apply(t,this.data);else if("number"==typeof this.data)t.push(1,this.data);else if(null!==this.data&&void 0!==this.data){t.push(this.data.length);var e=this.data.split("").map(function(t){return t.charCodeAt(0)});t.push.apply(t,e)}else t.push(0);return t};var a=function(t){if(!this)return new a(t);var e=t||{};this.events=e.events||[]};a.START_BYTES=[77,84,114,107],a.END_BYTES=[0,255,47,0],a.prototype.addEvent=function(t){return this.events.push(t),this},a.prototype.addNoteOn=a.prototype.noteOn=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_ON,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNoteOff=a.prototype.noteOff=function(t,i,a,o){return this.events.push(new r({type:r.NOTE_OFF,channel:t,param1:n.ensureMidiPitch(i),param2:o||e,time:a||0})),this},a.prototype.addNote=a.prototype.note=function(t,e,n,r,i){return this.noteOn(t,e,r,i),n&&this.noteOff(t,e,n,i),this},a.prototype.addChord=a.prototype.chord=function(t,e,n,r){if(!Array.isArray(e)&&!e.length)throw new Error("Chord must be an array of pitches");return e.forEach(function(e){this.noteOn(t,e,0,r)},this),e.forEach(function(e,r){0===r?this.noteOff(t,e,n):this.noteOff(t,e)},this),this},a.prototype.setInstrument=a.prototype.instrument=function(t,e,n){return this.events.push(new r({type:r.PROGRAM_CHANGE,channel:t,param1:e,time:n||0})),this},a.prototype.setTempo=a.prototype.tempo=function(t,e){return this.events.push(new i({type:i.TEMPO,data:n.mpqnFromBpm(t),time:e||0})),this},a.prototype.toBytes=function(){var t=0,e=[],r=a.START_BYTES,i=a.END_BYTES,o=function(n){var r=n.toBytes();t+=r.length,e.push.apply(e,r)};this.events.forEach(o),t+=i.length;var s=n.str2Bytes(t.toString(16),4);return r.concat(s,e,i)};var o=function(t){if(!this)return new o(t);var e=t||{};if(e.ticks){if("number"!=typeof e.ticks)throw new Error("Ticks per beat must be a number!");if(e.ticks<=0||e.ticks>=32768||e.ticks%1!=0)throw new Error("Ticks per beat must be an integer between 1 and 32767!")}this.ticks=e.ticks||128,this.tracks=e.tracks||[]};o.HDR_CHUNKID="MThd",o.HDR_CHUNK_SIZE="\0\0\0",o.HDR_TYPE0="\0\0",o.HDR_TYPE1="\0",o.prototype.addTrack=function(t){return t?(this.tracks.push(t),this):(t=new a,this.tracks.push(t),t)},o.prototype.toBytes=function(){var t=this.tracks.length.toString(16),e=o.HDR_CHUNKID+o.HDR_CHUNK_SIZE;return parseInt(t,16)>1?e+=o.HDR_TYPE1:e+=o.HDR_TYPE0,e+=n.codes2Str(n.str2Bytes(t,2)),e+=String.fromCharCode(this.ticks/256,this.ticks%256),this.tracks.forEach(function(t){e+=n.codes2Str(t.toBytes())}),e},t.Util=n,t.File=o,t.Track=a,t.Event=r,t.MetaEvent=i}(n),void 0!==t&&null!==t?t.exports=n:void 0!==e&&null!==e?e=n:this.Midi=n}).call(e,n(12)(t))},function(t,e){function n(t){function e(t){var e=t.read(4),n=t.readInt32();return{id:e,length:n,data:t.read(n)}}var n;stream=r(t);var i=e(stream);if("MThd"!=i.id||6!=i.length)throw"Bad .mid file - header not found";var a=r(i.data),o=a.readInt16(),s=a.readInt16(),u=a.readInt16();if(32768&u)throw"Expressing time division in SMTPE frames is not supported yet";ticksPerBeat=u;for(var c={formatType:o,trackCount:s,ticksPerBeat:ticksPerBeat},h=[],f=0;f<c.trackCount;f++){h[f]=[];var d=e(stream);if("MTrk"!=d.id)throw"Unexpected chunk - expected MTrk, got "+d.id;for(var l=r(d.data);!l.eof();){var p=function(t){var e={};e.deltaTime=t.readVarInt();var r=t.readInt8();if(240==(240&r)){if(255==r){e.type="meta";var i=t.readInt8(),a=t.readVarInt();switch(i){case 0:if(e.subtype="sequenceNumber",2!=a)throw"Expected length for sequenceNumber event is 2, got "+a;return e.number=t.readInt16(),e;case 1:return e.subtype="text",e.text=t.read(a),e;case 2:return e.subtype="copyrightNotice",e.text=t.read(a),e;case 3:return e.subtype="trackName",e.text=t.read(a),e;case 4:return e.subtype="instrumentName",e.text=t.read(a),e;case 5:return e.subtype="lyrics",e.text=t.read(a),e;case 6:return e.subtype="marker",e.text=t.read(a),e;case 7:return e.subtype="cuePoint",e.text=t.read(a),e;case 32:if(e.subtype="midiChannelPrefix",1!=a)throw"Expected length for midiChannelPrefix event is 1, got "+a;return e.channel=t.readInt8(),e;case 47:if(e.subtype="endOfTrack",0!=a)throw"Expected length for endOfTrack event is 0, got "+a;return e;case 81:if(e.subtype="setTempo",3!=a)throw"Expected length for setTempo event is 3, got "+a;return e.microsecondsPerBeat=(t.readInt8()<<16)+(t.readInt8()<<8)+t.readInt8(),e;case 84:if(e.subtype="smpteOffset",5!=a)throw"Expected length for smpteOffset event is 5, got "+a;var o=t.readInt8();return e.frameRate={0:24,32:25,64:29,96:30}[96&o],e.hour=31&o,e.min=t.readInt8(),e.sec=t.readInt8(),e.frame=t.readInt8(),e.subframe=t.readInt8(),e;case 88:if(e.subtype="timeSignature",4!=a)throw"Expected length for timeSignature event is 4, got "+a;return e.numerator=t.readInt8(),e.denominator=Math.pow(2,t.readInt8()),e.metronome=t.readInt8(),e.thirtyseconds=t.readInt8(),e;case 89:if(e.subtype="keySignature",2!=a)throw"Expected length for keySignature event is 2, got "+a;return e.key=t.readInt8(!0),e.scale=t.readInt8(),e;case 127:return e.subtype="sequencerSpecific",e.data=t.read(a),e;default:return e.subtype="unknown",e.data=t.read(a),e}return e.data=t.read(a),e}if(240==r){e.type="sysEx";var a=t.readVarInt();return e.data=t.read(a),e}if(247==r){e.type="dividedSysEx";var a=t.readVarInt();return e.data=t.read(a),e}throw"Unrecognised MIDI event type byte: "+r}var s;0==(128&r)?(s=r,r=n):(s=t.readInt8(),n=r);var u=r>>4;switch(e.channel=15&r,e.type="channel",u){case 8:return e.subtype="noteOff",e.noteNumber=s,e.velocity=t.readInt8(),e;case 9:return e.noteNumber=s,e.velocity=t.readInt8(),0==e.velocity?e.subtype="noteOff":e.subtype="noteOn",e;case 10:return e.subtype="noteAftertouch",e.noteNumber=s,e.amount=t.readInt8(),e;case 11:return e.subtype="controller",e.controllerType=s,e.value=t.readInt8(),e;case 12:return e.subtype="programChange",e.programNumber=s,e;case 13:return e.subtype="channelAftertouch",e.amount=s,e;case 14:return e.subtype="pitchBend",e.value=s+(t.readInt8()<<7),e;default:throw"Unrecognised MIDI event type: "+u}}(l);h[f].push(p)}}return{header:c,tracks:h}}function r(t){function e(e){var n=t.substr(s,e);return s+=e,n}function n(){var e=(t.charCodeAt(s)<<24)+(t.charCodeAt(s+1)<<16)+(t.charCodeAt(s+2)<<8)+t.charCodeAt(s+3);return s+=4,e}function r(){var e=(t.charCodeAt(s)<<8)+t.charCodeAt(s+1);return s+=2,e}function i(e){var n=t.charCodeAt(s);return e&&n>127&&(n-=256),s+=1,n}function a(){return s>=t.length}function o(){for(var t=0;;){var e=i();if(!(128&e))return t+e;t+=127&e,t<<=7}}var s=0;return{eof:a,read:e,readInt32:n,readInt16:r,readInt8:i,readVarInt:o}}t.exports=function(t){return n(t)}},function(t,e){t.exports=function(t){return t.webpackPolyfill||(t.deprecate=function(){},t.paths=[],t.children||(t.children=[]),Object.defineProperty(t,"loaded",{enumerable:!0,get:function(){return t.l}}),Object.defineProperty(t,"id",{enumerable:!0,get:function(){return t.i}}),t.webpackPolyfill=1),t}}])});
 
-},{}],263:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 'use strict'
 
 var ops = require('ndarray-ops')
@@ -41795,7 +44141,7 @@ function ndfft(dir, x, y) {
 }
 
 module.exports = ndfft
-},{"./lib/fft-matrix.js":264,"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],264:[function(require,module,exports){
+},{"./lib/fft-matrix.js":288,"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],288:[function(require,module,exports){
 var bits = require('bit-twiddle')
 
 function fft(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
@@ -42014,7 +44360,7 @@ function fftBluestein(dir, nrows, ncols, buffer, x_ptr, y_ptr, scratch_ptr) {
   }
 }
 
-},{"bit-twiddle":249}],265:[function(require,module,exports){
+},{"bit-twiddle":273}],289:[function(require,module,exports){
 "use strict"
 
 var compile = require("cwise-compiler")
@@ -42477,7 +44823,7 @@ exports.equals = compile({
 
 
 
-},{"cwise-compiler":252}],266:[function(require,module,exports){
+},{"cwise-compiler":276}],290:[function(require,module,exports){
 "use strict"
 
 var fft = require("ndarray-fft")
@@ -42581,7 +44927,7 @@ function resample(out, inp, clamp_lo, clamp_hi) {
 }
 
 module.exports = resample
-},{"cwise/lib/wrapper":255,"ndarray-fft":263,"ndarray-ops":265,"ndarray-scratch":267}],267:[function(require,module,exports){
+},{"cwise/lib/wrapper":279,"ndarray-fft":287,"ndarray-ops":289,"ndarray-scratch":291}],291:[function(require,module,exports){
 "use strict"
 
 var ndarray = require("ndarray")
@@ -42689,7 +45035,7 @@ function eye(shape, dtype) {
 }
 exports.eye = eye
 
-},{"ndarray":268,"ndarray-ops":265,"typedarray-pool":299}],268:[function(require,module,exports){
+},{"ndarray":292,"ndarray-ops":289,"typedarray-pool":323}],292:[function(require,module,exports){
 var iota = require("iota-array")
 var isBuffer = require("is-buffer")
 
@@ -43034,7 +45380,7 @@ function wrappedNDArrayCtor(data, shape, stride, offset) {
 
 module.exports = wrappedNDArrayCtor
 
-},{"iota-array":260,"is-buffer":261}],269:[function(require,module,exports){
+},{"iota-array":284,"is-buffer":285}],293:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -43220,9 +45566,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],270:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 arguments[4][50][0].apply(exports,arguments)
-},{"./src/index-minimal":271,"dup":50}],271:[function(require,module,exports){
+},{"./src/index-minimal":295,"dup":50}],295:[function(require,module,exports){
 "use strict";
 var protobuf = exports;
 
@@ -43260,7 +45606,7 @@ function configure() {
 protobuf.Writer._configure(protobuf.BufferWriter);
 configure();
 
-},{"./reader":272,"./reader_buffer":273,"./roots":274,"./rpc":275,"./util/minimal":278,"./writer":279,"./writer_buffer":280}],272:[function(require,module,exports){
+},{"./reader":296,"./reader_buffer":297,"./roots":298,"./rpc":299,"./util/minimal":302,"./writer":303,"./writer_buffer":304}],296:[function(require,module,exports){
 "use strict";
 module.exports = Reader;
 
@@ -43669,17 +46015,17 @@ Reader._configure = function(BufferReader_) {
     });
 };
 
-},{"./util/minimal":278}],273:[function(require,module,exports){
+},{"./util/minimal":302}],297:[function(require,module,exports){
 arguments[4][53][0].apply(exports,arguments)
-},{"./reader":272,"./util/minimal":278,"dup":53}],274:[function(require,module,exports){
+},{"./reader":296,"./util/minimal":302,"dup":53}],298:[function(require,module,exports){
 arguments[4][54][0].apply(exports,arguments)
-},{"dup":54}],275:[function(require,module,exports){
+},{"dup":54}],299:[function(require,module,exports){
 arguments[4][55][0].apply(exports,arguments)
-},{"./rpc/service":276,"dup":55}],276:[function(require,module,exports){
+},{"./rpc/service":300,"dup":55}],300:[function(require,module,exports){
 arguments[4][56][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":56}],277:[function(require,module,exports){
+},{"../util/minimal":302,"dup":56}],301:[function(require,module,exports){
 arguments[4][57][0].apply(exports,arguments)
-},{"../util/minimal":278,"dup":57}],278:[function(require,module,exports){
+},{"../util/minimal":302,"dup":57}],302:[function(require,module,exports){
 (function (global){
 "use strict";
 var util = exports;
@@ -44088,11 +46434,11 @@ util._configure = function() {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./longbits":277,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],279:[function(require,module,exports){
+},{"./longbits":301,"@protobufjs/aspromise":3,"@protobufjs/base64":4,"@protobufjs/eventemitter":5,"@protobufjs/float":6,"@protobufjs/inquire":7,"@protobufjs/pool":8,"@protobufjs/utf8":9}],303:[function(require,module,exports){
 arguments[4][59][0].apply(exports,arguments)
-},{"./util/minimal":278,"dup":59}],280:[function(require,module,exports){
+},{"./util/minimal":302,"dup":59}],304:[function(require,module,exports){
 arguments[4][60][0].apply(exports,arguments)
-},{"./util/minimal":278,"./writer":279,"dup":60}],281:[function(require,module,exports){
+},{"./util/minimal":302,"./writer":303,"dup":60}],305:[function(require,module,exports){
 // A library of seedable RNGs implemented in Javascript.
 //
 // Usage:
@@ -44154,7 +46500,7 @@ sr.tychei = tychei;
 
 module.exports = sr;
 
-},{"./lib/alea":282,"./lib/tychei":283,"./lib/xor128":284,"./lib/xor4096":285,"./lib/xorshift7":286,"./lib/xorwow":287,"./seedrandom":288}],282:[function(require,module,exports){
+},{"./lib/alea":306,"./lib/tychei":307,"./lib/xor128":308,"./lib/xor4096":309,"./lib/xorshift7":310,"./lib/xorwow":311,"./seedrandom":312}],306:[function(require,module,exports){
 // A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
 // http://baagoe.com/en/RandomMusings/javascript/
 // https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
@@ -44270,7 +46616,7 @@ if (module && module.exports) {
 
 
 
-},{}],283:[function(require,module,exports){
+},{}],307:[function(require,module,exports){
 // A Javascript implementaion of the "Tyche-i" prng algorithm by
 // Samuel Neves and Filipe Araujo.
 // See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
@@ -44375,7 +46721,7 @@ if (module && module.exports) {
 
 
 
-},{}],284:[function(require,module,exports){
+},{}],308:[function(require,module,exports){
 // A Javascript implementaion of the "xor128" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44458,7 +46804,7 @@ if (module && module.exports) {
 
 
 
-},{}],285:[function(require,module,exports){
+},{}],309:[function(require,module,exports){
 // A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
 //
 // This fast non-cryptographic random number generator is designed for
@@ -44606,7 +46952,7 @@ if (module && module.exports) {
   (typeof define) == 'function' && define   // present with an AMD loader
 );
 
-},{}],286:[function(require,module,exports){
+},{}],310:[function(require,module,exports){
 // A Javascript implementaion of the "xorshift7" algorithm by
 // François Panneton and Pierre L'ecuyer:
 // "On the Xorgshift Random Number Generators"
@@ -44705,7 +47051,7 @@ if (module && module.exports) {
 );
 
 
-},{}],287:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 // A Javascript implementaion of the "xorwow" prng algorithm by
 // George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
 
@@ -44793,7 +47139,7 @@ if (module && module.exports) {
 
 
 
-},{}],288:[function(require,module,exports){
+},{}],312:[function(require,module,exports){
 /*
 Copyright 2014 David Bau.
 
@@ -45042,7 +47388,7 @@ if ((typeof module) == 'object' && module.exports) {
   Math    // math: package containing random, pow, and seedrandom
 );
 
-},{"crypto":250}],289:[function(require,module,exports){
+},{"crypto":274}],313:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45198,7 +47544,7 @@ exports.unique = unique;
 exports.shuffle = shuffle;
 exports.permutations = permutations;
 
-},{"tonal-note":294}],290:[function(require,module,exports){
+},{"tonal-note":318}],314:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45390,7 +47736,7 @@ exports.supersets = supersets;
 exports.subsets = subsets;
 exports.tokenize = tokenize$1;
 
-},{"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],291:[function(require,module,exports){
+},{"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],315:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -45762,7 +48108,7 @@ exports.scale = scale;
 exports.chord = chord;
 exports.pcset = pcset;
 
-},{"tonal-pcset":295}],292:[function(require,module,exports){
+},{"tonal-pcset":319}],316:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46041,7 +48387,7 @@ exports.subtract = subtract;
 exports.interval = interval;
 exports.semitones = semitones;
 
-},{"tonal-interval":293,"tonal-note":294}],293:[function(require,module,exports){
+},{"tonal-interval":317,"tonal-note":318}],317:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46382,7 +48728,7 @@ exports.simplify = simplify;
 exports.invert = invert;
 exports.fromSemitones = fromSemitones;
 
-},{}],294:[function(require,module,exports){
+},{}],318:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -46797,7 +49143,7 @@ exports.fromMidi = fromMidi;
 exports.simplify = simplify;
 exports.enharmonic = enharmonic;
 
-},{}],295:[function(require,module,exports){
+},{}],319:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47026,7 +49372,7 @@ exports.isSupersetOf = isSupersetOf;
 exports.includes = includes;
 exports.filter = filter;
 
-},{"tonal-array":289,"tonal-interval":293,"tonal-note":294}],296:[function(require,module,exports){
+},{"tonal-array":313,"tonal-interval":317,"tonal-note":318}],320:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47263,7 +49609,7 @@ exports.toScale = toScale;
 exports.supersets = supersets;
 exports.subsets = subsets;
 
-},{"tonal-array":289,"tonal-dictionary":291,"tonal-distance":292,"tonal-note":294,"tonal-pcset":295}],297:[function(require,module,exports){
+},{"tonal-array":313,"tonal-dictionary":315,"tonal-distance":316,"tonal-note":318,"tonal-pcset":319}],321:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -47401,7 +49747,7 @@ exports.freq = freq$1;
 exports.chord = chord$1;
 exports.scale = scale$1;
 
-},{"tonal-array":289,"tonal-chord":290,"tonal-dictionary":291,"tonal-distance":292,"tonal-interval":293,"tonal-note":294,"tonal-pcset":295,"tonal-scale":296}],298:[function(require,module,exports){
+},{"tonal-array":313,"tonal-chord":314,"tonal-dictionary":315,"tonal-distance":316,"tonal-interval":317,"tonal-note":318,"tonal-pcset":319,"tonal-scale":320}],322:[function(require,module,exports){
 (function(root, factory){
 
 	//UMD
@@ -71784,7 +74130,7 @@ exports.scale = scale$1;
 	
 	return Tone;
 }));
-},{}],299:[function(require,module,exports){
+},{}],323:[function(require,module,exports){
 (function (global,Buffer){
 'use strict'
 
@@ -72001,7 +74347,7 @@ exports.clearCache = function clearCache() {
   }
 }
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"bit-twiddle":249,"buffer":251,"dup":256}],300:[function(require,module,exports){
+},{"bit-twiddle":273,"buffer":275,"dup":280}],324:[function(require,module,exports){
 "use strict"
 
 function unique_pred(list, compare) {
@@ -72060,7 +74406,7 @@ function unique(list, compare, sorted) {
 
 module.exports = unique
 
-},{}],301:[function(require,module,exports){
+},{}],325:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72108,7 +74454,7 @@ var BinaryCounter = (function (_super) {
 }(AuxiliaryInput));
 exports.BinaryCounter = BinaryCounter;
 
-},{"@tensorflow/tfjs-core":68}],302:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],326:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72302,7 +74648,7 @@ var PitchChordEncoder = (function (_super) {
 }(ChordEncoder));
 exports.PitchChordEncoder = PitchChordEncoder;
 
-},{"./constants":303,"@tensorflow/tfjs-core":68,"tonal":297}],303:[function(require,module,exports){
+},{"./constants":327,"@tensorflow/tfjs-core":68,"tonal":321}],327:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 null;
@@ -72330,7 +74676,7 @@ exports.HI_CLICK_PITCH = 90;
 exports.LO_CLICK_CLASS = 9;
 exports.HI_CLICK_CLASS = 10;
 
-},{}],304:[function(require,module,exports){
+},{}],328:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -72902,7 +75248,7 @@ var MultitrackConverter = (function (_super) {
 }(DataConverter));
 exports.MultitrackConverter = MultitrackConverter;
 
-},{"../protobuf/index":320,"./constants":303,"./performance":308,"./sequences":311,"@tensorflow/tfjs-core":68}],305:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./performance":332,"./sequences":335,"@tensorflow/tfjs-core":68}],329:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -72927,7 +75273,7 @@ __export(require("./player"));
 __export(require("./recorder"));
 __export(require("./visualizer"));
 
-},{"./aux_inputs":301,"./chords":302,"./constants":303,"./data":304,"./logging":306,"./midi_io":307,"./performance":308,"./player":309,"./recorder":310,"./sequences":311,"./visualizer":313}],306:[function(require,module,exports){
+},{"./aux_inputs":325,"./chords":326,"./constants":327,"./data":328,"./logging":330,"./midi_io":331,"./performance":332,"./player":333,"./recorder":334,"./sequences":335,"./visualizer":337}],330:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var Level;
@@ -72958,7 +75304,7 @@ function logWithDuration(msg, startTime, prefix, level) {
 }
 exports.logWithDuration = logWithDuration;
 
-},{}],307:[function(require,module,exports){
+},{}],331:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73104,7 +75450,7 @@ function sequenceProtoToMidi(ns) {
 }
 exports.sequenceProtoToMidi = sequenceProtoToMidi;
 
-},{"../protobuf":320,"./constants":303,"./sequences":311,"midiconvert":262}],308:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"./sequences":335,"midiconvert":286}],332:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var index_1 = require("../protobuf/index");
@@ -73307,7 +75653,7 @@ var Performance = (function () {
 }());
 exports.Performance = Performance;
 
-},{"../protobuf/index":320,"./constants":303,"./sequences":311}],309:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327,"./sequences":335}],333:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -73719,7 +76065,7 @@ var PlayerWithClick = (function (_super) {
 }(Player));
 exports.PlayerWithClick = PlayerWithClick;
 
-},{".":305,"./constants":303,"./data":304,"./soundfont":312,"tone":298}],310:[function(require,module,exports){
+},{".":329,"./constants":327,"./data":328,"./soundfont":336,"tone":322}],334:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -73945,7 +76291,7 @@ var Recorder = (function () {
 }());
 exports.Recorder = Recorder;
 
-},{"../protobuf":320,"./constants":303,"tone":298}],311:[function(require,module,exports){
+},{"../protobuf":344,"./constants":327,"tone":322}],335:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -74216,7 +76562,7 @@ function mergeInstruments(ns) {
 }
 exports.mergeInstruments = mergeInstruments;
 
-},{"../protobuf/index":320,"./constants":303}],312:[function(require,module,exports){
+},{"../protobuf/index":344,"./constants":327}],336:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74474,7 +76820,7 @@ var SoundFont = (function () {
 }());
 exports.SoundFont = SoundFont;
 
-},{"./constants":303,"tone":298}],313:[function(require,module,exports){
+},{"./constants":327,"tone":322}],337:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var _1 = require(".");
@@ -74566,7 +76912,7 @@ var Visualizer = (function () {
 }());
 exports.Visualizer = Visualizer;
 
-},{".":305,"./constants":303}],314:[function(require,module,exports){
+},{".":329,"./constants":327}],338:[function(require,module,exports){
 "use strict";
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -74580,7 +76926,7 @@ __export(require("./music_vae"));
 __export(require("./protobuf"));
 __export(require("./transcription"));
 
-},{"./core":305,"./music_rnn":316,"./music_vae":318,"./protobuf":320,"./transcription":324,"@tensorflow/tfjs":246}],315:[function(require,module,exports){
+},{"./core":329,"./music_rnn":340,"./music_vae":342,"./protobuf":344,"./transcription":348,"@tensorflow/tfjs":270}],339:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var tf = require("@tensorflow/tfjs-core");
@@ -74644,13 +76990,13 @@ var AttentionWrapper = (function () {
 }());
 exports.AttentionWrapper = AttentionWrapper;
 
-},{"@tensorflow/tfjs-core":68}],316:[function(require,module,exports){
+},{"@tensorflow/tfjs-core":68}],340:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.MusicRNN = model_1.MusicRNN;
 
-},{"./model":317}],317:[function(require,module,exports){
+},{"./model":341}],341:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -74949,7 +77295,7 @@ var MusicRNN = (function () {
 }());
 exports.MusicRNN = MusicRNN;
 
-},{"../core/aux_inputs":301,"../core/chords":302,"../core/data":304,"../core/logging":306,"../core/sequences":311,"./attention":315,"@tensorflow/tfjs-core":68}],318:[function(require,module,exports){
+},{"../core/aux_inputs":325,"../core/chords":326,"../core/data":328,"../core/logging":330,"../core/sequences":335,"./attention":339,"@tensorflow/tfjs-core":68}],342:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
@@ -74957,7 +77303,7 @@ exports.Decoder = model_1.Decoder;
 exports.Encoder = model_1.Encoder;
 exports.MusicVAE = model_1.MusicVAE;
 
-},{"./model":319}],319:[function(require,module,exports){
+},{"./model":343}],343:[function(require,module,exports){
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -75701,14 +78047,14 @@ var MusicVAE = (function () {
 }());
 exports.MusicVAE = MusicVAE;
 
-},{"../core/chords":302,"../core/constants":303,"../core/data":304,"../core/logging":306,"@tensorflow/tfjs-core":68}],320:[function(require,module,exports){
+},{"../core/chords":326,"../core/constants":327,"../core/data":328,"../core/logging":330,"@tensorflow/tfjs-core":68}],344:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var proto_1 = require("./proto");
 var NoteSequence = proto_1.tensorflow.magenta.NoteSequence;
 exports.NoteSequence = NoteSequence;
 
-},{"./proto":321}],321:[function(require,module,exports){
+},{"./proto":345}],345:[function(require,module,exports){
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
@@ -81419,7 +83765,7 @@ $root.tensorflow = (function() {
 
 module.exports = $root;
 
-},{"protobufjs/minimal":270}],322:[function(require,module,exports){
+},{"protobufjs/minimal":294}],346:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -81798,7 +84144,7 @@ function max(arr) {
     return arr.reduce(function (a, b) { return Math.max(a, b); });
 }
 
-},{"../core/logging":306,"./constants":323,"fft.js":257,"ndarray":268,"ndarray-resample":266}],323:[function(require,module,exports){
+},{"../core/logging":330,"./constants":347,"fft.js":281,"ndarray":292,"ndarray-resample":290}],347:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SAMPLE_RATE = 16000;
@@ -81809,13 +84155,13 @@ exports.MIN_MIDI_PITCH = 21;
 exports.MAX_MIDI_PITCH = 108;
 exports.MIDI_PITCHES = exports.MAX_MIDI_PITCH - exports.MIN_MIDI_PITCH + 1;
 
-},{}],324:[function(require,module,exports){
+},{}],348:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
 exports.OnsetsAndFrames = model_1.OnsetsAndFrames;
 
-},{"./model":325}],325:[function(require,module,exports){
+},{"./model":349}],349:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82181,7 +84527,7 @@ var Lstm = (function () {
     return Lstm;
 }());
 
-},{"../core/logging":306,"./audio_utils":322,"./constants":323,"./transcription_utils":326,"@tensorflow/tfjs":246}],326:[function(require,module,exports){
+},{"../core/logging":330,"./audio_utils":346,"./constants":347,"./transcription_utils":350,"@tensorflow/tfjs":270}],350:[function(require,module,exports){
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -82351,4 +84697,4 @@ function pianorollToNoteSequence(frameProbs, onsetProbs, velocityValues, onsetTh
 }
 exports.pianorollToNoteSequence = pianorollToNoteSequence;
 
-},{"../protobuf":320,"./constants":323,"@tensorflow/tfjs":246}]},{},[2]);
+},{"../protobuf":344,"./constants":347,"@tensorflow/tfjs":270}]},{},[2]);

--- a/music/yarn.lock
+++ b/music/yarn.lock
@@ -45,33 +45,33 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.5.9":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.5.9.tgz#76913bd916bbd940b6435e9e3ec63f963c786b95"
+"@tensorflow/tfjs-converter@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.5.tgz#71d28889e4236e8178d8cb849e741751011cb1f7"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.12.17":
-  version "0.12.17"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.17.tgz#133fef53272e4dc0819890e79153c8ee094400b6"
+"@tensorflow/tfjs-core@0.13.8":
+  version "0.13.8"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.8.tgz#90f73107df6ad7f1c13ff9d765a3d3d3997af1cb"
   dependencies:
-    "@types/seedrandom" "~2.4.27"
-    "@types/webgl-ext" "~0.0.29"
-    "@types/webgl2" "~0.0.4"
-    seedrandom "~2.4.3"
+    "@types/seedrandom" "2.4.27"
+    "@types/webgl-ext" "0.0.30"
+    "@types/webgl2" "0.0.4"
+    seedrandom "2.4.3"
 
-"@tensorflow/tfjs-layers@0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz#54241110e0a6e194eafbbd18babca0978788e930"
+"@tensorflow/tfjs-layers@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.3.tgz#b3995e668afecf37a1382deeea57e40eee6519b4"
 
-"@tensorflow/tfjs@^0.12.7":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.7.tgz#2fb643f503dada14b7f0ca43d2a41082b626f92a"
+"@tensorflow/tfjs@^0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.3.tgz#a44ce32ada34e464d8c596cee10695e0a0ebb5de"
   dependencies:
-    "@tensorflow/tfjs-converter" "0.5.9"
-    "@tensorflow/tfjs-core" "0.12.17"
-    "@tensorflow/tfjs-layers" "0.7.5"
+    "@tensorflow/tfjs-converter" "0.6.5"
+    "@tensorflow/tfjs-core" "0.13.8"
+    "@tensorflow/tfjs-layers" "0.8.3"
 
 "@types/clone@^0.1.30":
   version "0.1.30"
@@ -143,9 +143,9 @@
   version "8.10.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.9.tgz#b507a74a7d3eddc74a17dc35fd40d8f45dde0d6c"
 
-"@types/seedrandom@~2.4.27":
+"@types/seedrandom@2.4.27":
   version "2.4.27"
-  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"
+  resolved "http://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"
 
 "@types/shelljs@0.7.8":
   version "0.7.8"
@@ -160,11 +160,11 @@
   dependencies:
     "@types/node" "*"
 
-"@types/webgl-ext@~0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.29.tgz#4d479baf1124795f53d54bdc85b386e0f194d90a"
+"@types/webgl-ext@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
 
-"@types/webgl2@~0.0.4":
+"@types/webgl2@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.4.tgz#c3b0f9d6b465c66138e84e64cb3bdf8373c2c279"
 
@@ -1641,7 +1641,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, 
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-seedrandom@~2.4.3:
+seedrandom@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
 


### PR DESCRIPTION
Once more, with feeling.

(updates 1.2.3's hosted demos and yarn.lock file since it looked busted. I don't think we need to release this as 1.2.4)

Update: confirmed that these have the right (new) version of `tfjs`. In the bundle, `mm.tf.version` gives me:
```
tfjs: "0.13.3"
tfjs-converter: "0.6.5"
tfjs-core: "0.13.8"
tfjs-layers: "0.8.3"
```