### PR TITLE
Fix blurry notes when using the Visualizer

### DIFF
--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -127,6 +127,7 @@ export class Visualizer {
     // active notes instead.
     this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
     let activeNotePosition;
+    const noteRenderHeight = Math.round(this.config.noteHeight);
 
     for (let i = 0; i < this.noteSequence.notes.length; i++) {
       const note = this.noteSequence.notes[i];
@@ -154,7 +155,7 @@ export class Visualizer {
           ${opacity})`;
       // Round values to the nearest integer to avoid partially filled pixels.
       this.ctx.fillRect(Math.round(x), Math.round(y), Math.round(w),
-        Math.round(this.config.noteHeight));
+          noteRenderHeight);
       if (isActive) {
         activeNotePosition = x;
       }

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -152,7 +152,7 @@ export class Visualizer {
       this.ctx.fillStyle =
           `rgba(${isActive ? this.config.activeNoteRGB : this.config.noteRGB},
           ${opacity})`;
-      // Round all values to the nearest integer to avoid partially colored pixels.
+      // Round values to the nearest integer to avoid partially filled pixels.
       this.ctx.fillRect(Math.round(x), Math.round(y), Math.round(w),
         Math.round(this.config.noteHeight));
       if (isActive) {

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -66,7 +66,7 @@ export class Visualizer {
    */
   constructor(
       sequence: INoteSequence, canvas: HTMLCanvasElement,
-      config = {} as VisualizerConfig) {
+      config: VisualizerConfig = {}) {
     this.config = {
       noteHeight: config.noteHeight || 6,
       noteSpacing: config.noteSpacing || 1,
@@ -152,7 +152,9 @@ export class Visualizer {
       this.ctx.fillStyle =
           `rgba(${isActive ? this.config.activeNoteRGB : this.config.noteRGB},
           ${opacity})`;
-      this.ctx.fillRect(x, y, w, this.config.noteHeight);
+      // Round all values to the nearest integer to avoid partially colored pixels.
+      this.ctx.fillRect(Math.round(x), Math.round(y), Math.round(w),
+        Math.round(this.config.noteHeight));
       if (isActive) {
         activeNotePosition = x;
       }


### PR DESCRIPTION
The calculated position of notes aren't always integers, which results in a blurry visualization. 

See https://stackoverflow.com/q/53918770/7186598 for more details.