### PR TITLE
Make recorder timing more accurate

### DIFF
--- a/music/src/core/recorder.ts
+++ b/music/src/core/recorder.ts
@@ -28,7 +28,7 @@ import {DEFAULT_QUARTERS_PER_MINUTE} from './constants';
  * @param playCountIn Whether to play a count-in click at the beginning of
  * the recording.
  * @param startRecordingAtFirstNote Whether to start the note time offset at
- * the first note received instead of the start of the recording.  Defaults to 
+ * the first note received instead of the start of the recording.  Defaults to
  * false.
  */
 interface RecorderConfig {
@@ -163,13 +163,13 @@ export class Recorder {
 
   private initClickLoop() {
     let clickStep = 0;
-    this.clickLoop = new Tone.Loop((_:number) => {
+    this.clickLoop = new Tone.Loop((time:number) => {
       // TODO(notwaldorf): It would be nice if this took into account a
       // time signature.
       if (clickStep % 4 === 0) {
-        this.loClick.triggerAttack('G5');
+        this.loClick.triggerAttack('G5', time);
       } else {
-        this.hiClick.triggerAttack('C6');
+        this.hiClick.triggerAttack('C6', time);
       }
       clickStep++;
       if (this.config.playCountIn && clickStep === 4) {
@@ -217,7 +217,7 @@ export class Recorder {
     this.firstNoteTimestamp = undefined;
     this.notes = [];
     this.onNotes = new Map<number, NoteSequence.Note>();
-    
+
    if (!this.startRecordingAtFirstNote) {
     const timeStamp: number = Date.now();
     this.firstNoteTimestamp = timeStamp;


### PR DESCRIPTION
Good news, I finally understood what @tambien meant in [this comment](https://github.com/tensorflow/magenta-js/pull/181#discussion_r224963796), so here's that change.