### PR TITLE
mm.Visualizer: use a better default for the pixels per unquantized step

### DIFF
--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -67,18 +67,21 @@ export class Visualizer {
   constructor(
       sequence: INoteSequence, canvas: HTMLCanvasElement,
       config: VisualizerConfig = {}) {
+    this.noteSequence = sequence;
+    this.sequenceIsQuantized = sequences.isQuantizedSequence(this.noteSequence);
+
+    // Quantized sequences appear "longer" because there's usually more
+    // quantized per note (vs seconds), so pick a better default.
+    const defaultPixelsPerTimeStep = this.sequenceIsQuantized ? 8 : 30;
     this.config = {
       noteHeight: config.noteHeight || 6,
       noteSpacing: config.noteSpacing || 1,
-      pixelsPerTimeStep: config.pixelsPerTimeStep || 30,
+      pixelsPerTimeStep: config.pixelsPerTimeStep || defaultPixelsPerTimeStep,
       noteRGB: config.noteRGB || '8, 41, 64',
       activeNoteRGB: config.activeNoteRGB || '240, 84, 119',
       minPitch: config.minPitch,
       maxPitch: config.maxPitch,
     };
-
-    this.noteSequence = sequence;
-    this.sequenceIsQuantized = sequences.isQuantizedSequence(this.noteSequence);
 
     // Initialize the canvas.
     this.ctx = canvas.getContext('2d');
@@ -154,8 +157,8 @@ export class Visualizer {
           `rgba(${isActive ? this.config.activeNoteRGB : this.config.noteRGB},
           ${opacity})`;
       // Round values to the nearest integer to avoid partially filled pixels.
-      this.ctx.fillRect(Math.round(x), Math.round(y), Math.round(w),
-          noteRenderHeight);
+      this.ctx.fillRect(
+          Math.round(x), Math.round(y), Math.round(w), noteRenderHeight);
       if (isActive) {
         activeNotePosition = x;
       }

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -72,7 +72,7 @@ export class Visualizer {
 
     // Quantized sequences appear "longer" because there's usually more
     // quantized per note (vs seconds), so pick a better default.
-    const defaultPixelsPerTimeStep = this.sequenceIsQuantized ? 8 : 30;
+    const defaultPixelsPerTimeStep = this.sequenceIsQuantized ? 7 : 30;
     this.config = {
       noteHeight: config.noteHeight || 6,
       noteSpacing: config.noteSpacing || 1,

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -71,8 +71,13 @@ export class Visualizer {
     this.sequenceIsQuantized = sequences.isQuantizedSequence(this.noteSequence);
 
     // Quantized sequences appear "longer" because there's usually more
-    // quantized per note (vs seconds), so pick a better default.
-    const defaultPixelsPerTimeStep = this.sequenceIsQuantized ? 7 : 30;
+    // quantized per note (vs seconds), so pick a better default by using
+    // the steps per quarter.
+    let defaultPixelsPerTimeStep = 30;
+    if (this.sequenceIsQuantized) {
+      const spq = sequence.quantizationInfo.stepsPerQuarter;
+      defaultPixelsPerTimeStep = spq ? defaultPixelsPerTimeStep / spq : 7;
+    }
     this.config = {
       noteHeight: config.noteHeight || 6,
       noteSpacing: config.noteSpacing || 1,


### PR DESCRIPTION
When using `mm.Visualizer`, quantized sequences looked way "wider", because the scale for quantized steps is different than seconds. Pick a better default to accommodate for that.
Note that this still doesn't mean all unquantized sequences will look the same as their quantized version (because sometimes `stepsPerQuarter` isn't actually the right value, we need `stepsPerSecond`, really). They're just a little bit better.

Before:
<img width="961" alt="screen shot 2019-01-30 at 2 45 32 pm" src="https://user-images.githubusercontent.com/1369170/52018010-e90e3a80-249d-11e9-9203-300730f3e052.png">

After:
<img width="912" alt="screen shot 2019-01-30 at 2 57 19 pm" src="https://user-images.githubusercontent.com/1369170/52018510-8c138400-249f-11e9-8f70-907521dc3321.png">
