### PR TITLE
mm.Visualizer: calculate note offset correctly

### DIFF
--- a/music/package.json
+++ b/music/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magenta/music",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Make music with machine learning, in the browser.",
   "main": "es5/index.js",
   "types": "es5/index.d.ts",

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -141,11 +141,10 @@ export class Visualizer {
       const note = this.noteSequence.notes[i];
 
       // Size of this note.
-      const offset = this.config.noteSpacing * (i + 1);
-      const x = (this.getNoteStartTime(note) * this.config.pixelsPerTimeStep) +
-          offset;
-      const w = (this.getNoteEndTime(note) - this.getNoteStartTime(note)) *
-          this.config.pixelsPerTimeStep;
+      const x = (this.getNoteStartTime(note) * this.config.pixelsPerTimeStep);
+      const w = this.config.pixelsPerTimeStep *
+              (this.getNoteEndTime(note) - this.getNoteStartTime(note)) -
+          this.config.noteSpacing;
 
       // The canvas' y=0 is at the top, but a smaller pitch is actually
       // lower, so we're kind of painting backwards.


### PR DESCRIPTION
The way the note spacing was previously done only worked for monophonic melodies, and if several instruments had notes starting at time 0, then they would appear staggered (because the offset would apply to all the notes after 0, regardless of what their starting time was).

I've changed it so that now the note spacing is removed from the end of the note, so that consecutive notes appear spaced out but always start out correctly.