### PR TITLE
Update tfjs to latest version

### DIFF
--- a/music/demos/groovae.ts
+++ b/music/demos/groovae.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 import * as mm from '../src/index';
 

--- a/music/demos/multitrack.ts
+++ b/music/demos/multitrack.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 import * as clone from 'clone';
 
 import * as mm from '../src/index';

--- a/music/demos/music_rnn.ts
+++ b/music/demos/music_rnn.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 import * as mm from '../src/index';
 

--- a/music/demos/music_vae.ts
+++ b/music/demos/music_vae.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 import * as clone from 'clone';
 
 import * as mm from '../src/index';

--- a/music/demos/transcription.ts
+++ b/music/demos/transcription.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 //@ts-ignore
 import * as MediaRecorder from 'audio-recorder-polyfill';
 

--- a/music/package.json
+++ b/music/package.json
@@ -7,7 +7,7 @@
   "jsdelivr": "dist/magentamusic.js",
   "unpkg": "dist/magentamusic.js",
   "dependencies": {
-    "@tensorflow/tfjs": "^0.15.2",
+    "@tensorflow/tfjs": "^0.15.3",
     "fft.js": "^4.0.3",
     "midiconvert": "^0.4.7",
     "ndarray-resample": "^1.0.1",

--- a/music/package.json
+++ b/music/package.json
@@ -7,7 +7,7 @@
   "jsdelivr": "dist/magentamusic.js",
   "unpkg": "dist/magentamusic.js",
   "dependencies": {
-    "@tensorflow/tfjs": "^0.13.3",
+    "@tensorflow/tfjs": "^0.15.2",
     "fft.js": "^4.0.3",
     "midiconvert": "^0.4.7",
     "ndarray-resample": "^1.0.1",
@@ -28,7 +28,6 @@
     "clone": "^1.0.4",
     "file-saver": "^1.3.8",
     "file-saver-typescript": "^1.0.1",
-    "fs": "^0.0.1-security",
     "http-server": "^0.11.1",
     "in-publish": "^2.0.0",
     "minimist": "^1.2.0",

--- a/music/package.json
+++ b/music/package.json
@@ -12,7 +12,6 @@
     "midiconvert": "^0.4.7",
     "ndarray-resample": "^1.0.1",
     "protobufjs": "^6.8.6",
-    "tfjs": "^0.6.0",
     "tonal": "^2.0.0",
     "tone": "^0.12.80"
   },

--- a/music/src/core/aux_inputs.ts
+++ b/music/src/core/aux_inputs.ts
@@ -22,7 +22,7 @@
 /**
  * Imports
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 export interface BinaryCounterSpec {
   type: 'BinaryCounter';

--- a/music/src/core/aux_inputs_test.ts
+++ b/music/src/core/aux_inputs_test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 import * as test from 'tape';
 import * as aux_inputs from './aux_inputs';
 

--- a/music/src/core/chords.ts
+++ b/music/src/core/chords.ts
@@ -21,7 +21,7 @@
 /**
  * Imports
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 import {Chord, Note} from 'tonal';
 import * as constants from './constants';
 

--- a/music/src/core/chords_test.ts
+++ b/music/src/core/chords_test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 import * as test from 'tape';
 import * as chords from './chords';
 

--- a/music/src/core/data.ts
+++ b/music/src/core/data.ts
@@ -23,7 +23,7 @@
 /**
  * Imports
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 import {INoteSequence, NoteSequence} from '../protobuf/index';
 
@@ -207,10 +207,11 @@ export class DrumsConverter extends DataConverter {
     this.depth = this.pitchClasses.length;
   }
 
-  toTensor(noteSequence: INoteSequence) {
+  toTensor(noteSequence: INoteSequence): tf.Tensor2D {
     sequences.assertIsQuantizedSequence(noteSequence);
     const numSteps = this.numSteps || noteSequence.totalQuantizedSteps;
-    const drumRoll = tf.buffer([numSteps, this.pitchClasses.length + 1]);
+    const drumRoll = tf.buffer([numSteps, this.pitchClasses.length + 1],
+        'int32');
     // Set final values to 1 and change to 0 later if the column gets a note.
     for (let i = 0; i < numSteps; ++i) {
       drumRoll.set(1, i, -1);
@@ -307,14 +308,15 @@ export class DrumsOneHotConverter extends DrumsConverter {
     this.depth = Math.pow(2, this.pitchClasses.length);
   }
 
-  toTensor(noteSequence: INoteSequence) {
+  toTensor(noteSequence: INoteSequence): tf.Tensor2D {
     sequences.assertIsRelativeQuantizedSequence(noteSequence);
     const numSteps = this.numSteps || noteSequence.totalQuantizedSteps;
     const labels = Array<number>(numSteps).fill(0);
     for (const {pitch, quantizedStartStep} of noteSequence.notes) {
       labels[quantizedStartStep] += Math.pow(2, this.pitchToClass.get(pitch));
     }
-    return tf.tidy(() => tf.oneHot(tf.tensor1d(labels, 'int32'), this.depth));
+    return tf.tidy(() =>
+        tf.oneHot(tf.tensor1d(labels, 'int32'), this.depth) as tf.Tensor2D);
   }
 }
 
@@ -369,7 +371,7 @@ export class MelodyConverter extends DataConverter {
     this.depth = args.maxPitch - args.minPitch + 1 + this.FIRST_PITCH;
   }
 
-  toTensor(noteSequence: INoteSequence) {
+  toTensor(noteSequence: INoteSequence): tf.Tensor2D {
     sequences.assertIsQuantizedSequence(noteSequence);
     const numSteps = this.numSteps || noteSequence.totalQuantizedSteps;
     // Sort by note start times, and secondarily by pitch descending.
@@ -402,7 +404,8 @@ export class MelodyConverter extends DataConverter {
       mel.set(this.NOTE_OFF, n.quantizedEndStep);
       lastStart = n.quantizedStartStep;
     });
-    return tf.tidy(() => tf.oneHot(mel.toTensor() as tf.Tensor1D, this.depth));
+    return tf.tidy(() =>
+        tf.oneHot(mel.toTensor() as tf.Tensor1D, this.depth) as tf.Tensor2D);
   }
 
   async toNoteSequence(
@@ -473,7 +476,7 @@ export class TrioConverter extends DataConverter {
          this.drumsConverter.depth);
   }
 
-  toTensor(noteSequence: INoteSequence) {
+  toTensor(noteSequence: INoteSequence): tf.Tensor2D {
     sequences.assertIsQuantizedSequence(noteSequence);
     const melSeq = sequences.clone(noteSequence);
     const bassSeq = sequences.clone(noteSequence);
@@ -615,7 +618,7 @@ export class MultitrackConverter extends DataConverter {
 
   private trackToTensor(track?: performance.Performance) {
     const maxEventsPerTrack = this.numSteps / this.numSegments;
-    let tokens: tf.TensorBuffer<tf.Rank.R1> = undefined;
+    let tokens: tf.TensorBuffer<tf.Rank.R1, 'int32'> = undefined;
 
     if (track) {
       // Drop events from track until we have the maximum number of events
@@ -670,7 +673,7 @@ export class MultitrackConverter extends DataConverter {
     });
   }
 
-  toTensor(noteSequence: INoteSequence) {
+  toTensor(noteSequence: INoteSequence): tf.Tensor2D {
     sequences.assertIsRelativeQuantizedSequence(noteSequence);
 
     if (noteSequence.quantizationInfo.stepsPerQuarter !==
@@ -710,9 +713,8 @@ export class MultitrackConverter extends DataConverter {
     }
 
     // Convert tracks to tensors then concatenate.
-    return tf.tidy(
-        () => tf.concat(
-            sortedTracks.map((track) => this.trackToTensor(track)), 0));
+    return tf.tidy(() => tf.concat(sortedTracks.map((track) =>
+        this.trackToTensor(track)), 0) as tf.Tensor2D);
   }
 
   private tokensToTrack(tokens: Int32Array) {
@@ -860,7 +862,7 @@ export class GrooveConverter extends DataConverter {
     this.depth = 3;
   }
 
-  toTensor(ns: INoteSequence) {
+  toTensor(ns: INoteSequence): tf.Tensor2D {
     const qns = sequences.isRelativeQuantizedSequence(ns) ?
         ns :
         sequences.quantizeNoteSequence(ns, this.stepsPerQuarter);
@@ -898,9 +900,9 @@ export class GrooveConverter extends DataConverter {
     // ([0, 1] velocity of hit, or 0 if not hit), and offset ([-1, 1] distance
     // from quantized start).
     const numDrums = this.pitchClasses.length;
-    const hitVectors = tf.buffer([numSteps, numDrums]);
-    const velocityVectors = tf.buffer([numSteps, numDrums]);
-    const offsetVectors = tf.buffer([numSteps, numDrums]);
+    const hitVectors = tf.buffer([numSteps, numDrums], 'int32');
+    const velocityVectors = tf.buffer([numSteps, numDrums], 'int32');
+    const offsetVectors = tf.buffer([numSteps, numDrums], 'int32');
 
     function getOffset(n: NoteSequence.INote) {
       if (n.startTime === undefined) {

--- a/music/src/core/data.ts
+++ b/music/src/core/data.ts
@@ -900,9 +900,9 @@ export class GrooveConverter extends DataConverter {
     // ([0, 1] velocity of hit, or 0 if not hit), and offset ([-1, 1] distance
     // from quantized start).
     const numDrums = this.pitchClasses.length;
-    const hitVectors = tf.buffer([numSteps, numDrums], 'int32');
-    const velocityVectors = tf.buffer([numSteps, numDrums], 'int32');
-    const offsetVectors = tf.buffer([numSteps, numDrums], 'int32');
+    const hitVectors = tf.buffer([numSteps, numDrums]);
+    const velocityVectors = tf.buffer([numSteps, numDrums]);
+    const offsetVectors = tf.buffer([numSteps, numDrums]);
 
     function getOffset(n: NoteSequence.INote) {
       if (n.startTime === undefined) {

--- a/music/src/core/data_test.ts
+++ b/music/src/core/data_test.ts
@@ -16,6 +16,9 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
+
+// To remove the warning that tf.get() is deprecated.
+tf.disableDeprecationWarnings();
 import * as test from 'tape';
 
 import {NoteSequence} from '../protobuf/index';

--- a/music/src/core/data_test.ts
+++ b/music/src/core/data_test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 import * as test from 'tape';
 
 import {NoteSequence} from '../protobuf/index';

--- a/music/src/core/data_test.ts
+++ b/music/src/core/data_test.ts
@@ -16,11 +16,6 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
-
-// TODO(notwaldorf): Added this to remove the warning that tf.get() is
-// deprecated. Remove it when https://github.com/tensorflow/tfjs/issues/1271 is
-// fixed.
-tf.disableDeprecationWarnings();
 import * as test from 'tape';
 
 import {NoteSequence} from '../protobuf/index';
@@ -234,11 +229,12 @@ test('Test DrumConverters', (t: test.Test) => {
 
   const drumOneHotTensor = drumsOneHotConverter.toTensor(DRUM_NS);
   t.deepEqual(drumOneHotTensor.shape, [32, 512]);
-  t.equal(
-      tf.tidy(
-          () =>
-              drumOneHotTensor.sum(1).equal(tf.scalar(1, 'int32')).sum().get()),
-      32);
+  const value = tf.tidy(
+      () => drumOneHotTensor.sum(1)
+                .equal(tf.scalar(1, 'int32'))
+                .sum()
+                .arraySync() as number);
+  t.equal(value, 32);
 
   const drumRollTensorOutput = drumRollTensor.slice([0, 0], [32, 9]);
   drumRollConverter.toNoteSequence(drumRollTensorOutput, 2)
@@ -264,9 +260,10 @@ test('Test TrioConverter', (t: test.Test) => {
 
   const trioTensor = trioConverter.toTensor(TRIO_NS);
   t.deepEqual(trioTensor.shape, [32, 90 + 90 + 512]);
-  t.equal(
-      tf.tidy(() => trioTensor.sum(1).equal(tf.scalar(3, 'int32')).sum().get()),
-      32);
+  const value = tf.tidy(
+      () => trioTensor.sum(1).equal(tf.scalar(3, 'int32')).sum().arraySync() as
+          number);
+  t.equal(value, 32);
 
   trioConverter.toNoteSequence(trioTensor, 2)
       .then(ns => t.deepEqual(ns.toJSON(), TRIO_NS.toJSON()));

--- a/music/src/core/data_test.ts
+++ b/music/src/core/data_test.ts
@@ -17,7 +17,9 @@
 
 import * as tf from '@tensorflow/tfjs';
 
-// To remove the warning that tf.get() is deprecated.
+// TODO(notwaldorf): Added this to remove the warning that tf.get() is
+// deprecated. Remove it when https://github.com/tensorflow/tfjs/issues/1271 is
+// fixed.
 tf.disableDeprecationWarnings();
 import * as test from 'tape';
 

--- a/music/src/music_rnn/attention.ts
+++ b/music/src/music_rnn/attention.ts
@@ -19,7 +19,7 @@
 /**
  * Imports
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 /**
  * @hidden

--- a/music/src/music_rnn/model.ts
+++ b/music/src/music_rnn/model.ts
@@ -20,7 +20,7 @@
 /**
  * Imports
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 import * as aux_inputs from '../core/aux_inputs';
 import * as chords from '../core/chords';
@@ -339,7 +339,8 @@ export class MusicRNN {
           probs.push(tf.softmax(logits));
         }
 
-        nextInput = tf.oneHot(sampledOutput, outputSize).toFloat();
+        nextInput =
+            tf.oneHot(sampledOutput, outputSize).toFloat() as tf.Tensor2D;
         // Save samples as bool to reduce data sync time.
         samples.push(nextInput.as1D());
       }

--- a/music/src/music_vae/model.ts
+++ b/music/src/music_vae/model.ts
@@ -20,7 +20,7 @@
 /**
  * Imports
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 import * as chords from '../core/chords';
 import * as constants from '../core/constants';
@@ -359,7 +359,7 @@ abstract class BaseDecoder extends Decoder {
  * Uses argmax if no temperature is provided.
  */
 class CategoricalDecoder extends BaseDecoder {
-  sample(lstmOutput: tf.Tensor2D, temperature?: number) {
+  sample(lstmOutput: tf.Tensor2D, temperature?: number): tf.Tensor2D {
     const logits = lstmOutput;
     const timeLabels =
         (temperature ?
@@ -367,7 +367,7 @@ class CategoricalDecoder extends BaseDecoder {
                    logits.div(tf.scalar(temperature)) as tf.Tensor2D, 1)
                  .as1D() :
              logits.argMax(1).as1D());
-    return tf.oneHot(timeLabels, this.outputDims).toFloat();
+    return tf.oneHot(timeLabels, this.outputDims).toFloat() as tf.Tensor2D;
   }
 }
 
@@ -386,7 +386,7 @@ class NadeDecoder extends BaseDecoder {
     this.nade = nade;
   }
 
-  sample(lstmOutput: tf.Tensor2D, temperature?: number) {
+  sample(lstmOutput: tf.Tensor2D, temperature?: number): tf.Tensor2D {
     const [encBias, decBias] =
         tf.split(lstmOutput, [this.nade.numHidden, this.nade.numDims], 1);
     return this.nade.sample(encBias as tf.Tensor2D, decBias as tf.Tensor2D);
@@ -401,7 +401,7 @@ class NadeDecoder extends BaseDecoder {
 // TODO(adarob): Remove ts-ignore once are using this.
 // @ts-ignore
 class GrooveDecoder extends BaseDecoder {
-  sample(lstmOutput: tf.Tensor2D, temperature?: number) {
+  sample(lstmOutput: tf.Tensor2D, temperature?: number): tf.Tensor2D {
     let [hits, velocities, offsets] = tf.split(lstmOutput, 3, 1);
 
     velocities = tf.sigmoid(velocities);
@@ -540,7 +540,7 @@ class Nade {
    * @param decBias A batch of biases to use when decoding, sized
    * `[batchSize, numDims]`.
    */
-  sample(encBias: tf.Tensor2D, decBias: tf.Tensor2D) {
+  sample(encBias: tf.Tensor2D, decBias: tf.Tensor2D): tf.Tensor2D {
     const batchSize = encBias.shape[0];
     return tf.tidy(() => {
       const samples: tf.Tensor1D[] = [];

--- a/music/src/piano_genie/model_test.ts
+++ b/music/src/piano_genie/model_test.ts
@@ -6,7 +6,7 @@
  * https://storage.googleapis.com/magentadata/js/checkpoints/piano_genie/testdata.zip
  * And unzip them to src/piano_genie/testdata/*.json.
  * Then run yarn test from magenta-js/musis directory.
- * 
+ *
  * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
@@ -26,7 +26,7 @@
 
 import * as fs from 'fs';
 import * as test from 'tape';
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 
 import {PianoGenie} from './model';
 

--- a/music/src/transcription/model.ts
+++ b/music/src/transcription/model.ts
@@ -257,7 +257,10 @@ class AcousticCnn {
   readonly outputShape: number[];
   private readonly nn = tf.sequential();
 
-  constructor(finalDenseActivation?: string) {
+  // Activation types come from here, which isn't exported:
+  // tfjs-layers/blob/master/src/keras_format/activation_config.ts#L16
+  constructor(finalDenseActivation?:'elu'|'hardSigmoid'|'linear'|'relu'
+      |'relu6'|'selu'|'sigmoid'|'softmax'|'softplus'|'softsign'|'tanh') {
     // tslint:disable-next-line:no-any
     const convConfig: any = {
       filters: 48,

--- a/music/src/transcription/transcription_utils_test.ts
+++ b/music/src/transcription/transcription_utils_test.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as tf from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
 import * as test from 'tape';
 
 import {NoteSequence} from '../protobuf';

--- a/music/webpack/base.config.ts
+++ b/music/webpack/base.config.ts
@@ -6,6 +6,9 @@ export const baseConfig = {
       use: 'ts-loader',
     }],
   },
+  node: {
+    fs: 'empty'
+  },
   resolve: {
     extensions: ['.ts', '.js'],
   },

--- a/music/yarn.lock
+++ b/music/yarn.lock
@@ -1888,10 +1888,6 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-protobuf@^3.2.0-rc.2:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
-
 graceful-fs@^4.1.11:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
@@ -2490,10 +2486,6 @@ lodash.debounce@^4.0.8:
 lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
-
-lodash@^4.17.4:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 lodash@^4.17.5:
   version "4.17.10"
@@ -4123,13 +4115,6 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tensorjs@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/tensorjs/-/tensorjs-0.2.0.tgz#ce348937a0a3fa3e8ce885bb4b412b5054f969bb"
-  dependencies:
-    google-protobuf "^3.2.0-rc.2"
-    lodash "^4.17.4"
-
 terser-webpack-plugin@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz#cf7c25a1eee25bf121f4a587bb9e004e3f80e528"
@@ -4150,12 +4135,6 @@ terser@^3.8.1:
     commander "~2.17.1"
     source-map "~0.6.1"
     source-map-support "~0.5.6"
-
-tfjs@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tfjs/-/tfjs-0.6.0.tgz#370ee5d2112f573e63bbb70cd350b90677e119cc"
-  dependencies:
-    tensorjs "^0.2.0"
 
 through2@^2.0.0:
   version "2.0.3"

--- a/music/yarn.lock
+++ b/music/yarn.lock
@@ -45,42 +45,42 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.8.3.tgz#7a559664e751add832e44f9d817693fabe9c2bef"
+"@tensorflow/tfjs-converter@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.8.4.tgz#7c1326e9858c6c3a6d23947e31a73e9458450a9b"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.2.tgz#e2868be35d5455b1be540739f1d0968db49b034c"
+"@tensorflow/tfjs-core@0.15.4":
+  version "0.15.4"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.4.tgz#aaf52acd209476ebde7bd9a37a7c60ec9d067b65"
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-data@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.2.2.tgz#18a1828c559b79a4d163a9c76037f2763a9d1693"
+"@tensorflow/tfjs-data@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.2.3.tgz#67c0cd505485c9b0b6a83cb1c8a24559c5adfa68"
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.10.2.tgz#634429ced43793544afa797d633592fb4bedac5f"
+"@tensorflow/tfjs-layers@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.10.3.tgz#cf4001b5b7566b1526e65e615439e85070a1012c"
 
-"@tensorflow/tfjs@^0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.15.2.tgz#f7574e03f97fe4b6f5eaf2253c01b2732337cbce"
+"@tensorflow/tfjs@^0.15.3":
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.15.3.tgz#6608833952858c8984f20962eb86624f99196f06"
   dependencies:
-    "@tensorflow/tfjs-converter" "0.8.3"
-    "@tensorflow/tfjs-core" "0.15.2"
-    "@tensorflow/tfjs-data" "0.2.2"
-    "@tensorflow/tfjs-layers" "0.10.2"
+    "@tensorflow/tfjs-converter" "0.8.4"
+    "@tensorflow/tfjs-core" "0.15.4"
+    "@tensorflow/tfjs-data" "0.2.3"
+    "@tensorflow/tfjs-layers" "0.10.3"
 
 "@types/clone@^0.1.30":
   version "0.1.30"

--- a/music/yarn.lock
+++ b/music/yarn.lock
@@ -45,33 +45,42 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.5.tgz#71d28889e4236e8178d8cb849e741751011cb1f7"
+"@tensorflow/tfjs-converter@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.8.3.tgz#7a559664e751add832e44f9d817693fabe9c2bef"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.8.tgz#90f73107df6ad7f1c13ff9d765a3d3d3997af1cb"
+"@tensorflow/tfjs-core@0.15.2":
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.2.tgz#e2868be35d5455b1be540739f1d0968db49b034c"
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-layers@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.3.tgz#b3995e668afecf37a1382deeea57e40eee6519b4"
-
-"@tensorflow/tfjs@^0.13.3":
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.3.tgz#a44ce32ada34e464d8c596cee10695e0a0ebb5de"
+"@tensorflow/tfjs-data@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.2.2.tgz#18a1828c559b79a4d163a9c76037f2763a9d1693"
   dependencies:
-    "@tensorflow/tfjs-converter" "0.6.5"
-    "@tensorflow/tfjs-core" "0.13.8"
-    "@tensorflow/tfjs-layers" "0.8.3"
+    "@types/node-fetch" "^2.1.2"
+    node-fetch "~2.1.2"
+    seedrandom "~2.4.3"
+
+"@tensorflow/tfjs-layers@0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.10.2.tgz#634429ced43793544afa797d633592fb4bedac5f"
+
+"@tensorflow/tfjs@^0.15.2":
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.15.2.tgz#f7574e03f97fe4b6f5eaf2253c01b2732337cbce"
+  dependencies:
+    "@tensorflow/tfjs-converter" "0.8.3"
+    "@tensorflow/tfjs-core" "0.15.2"
+    "@tensorflow/tfjs-data" "0.2.2"
+    "@tensorflow/tfjs-layers" "0.10.2"
 
 "@types/clone@^0.1.30":
   version "0.1.30"
@@ -130,6 +139,12 @@
 "@types/ndarray@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/ndarray/-/ndarray-1.0.6.tgz#47d716dce58b51bf26496f042df2d22a3a860fb7"
+
+"@types/node-fetch@^2.1.2":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.1.6.tgz#4326288b49f352a142f03c63526ebce0f4c50877"
+  dependencies:
+    "@types/node" "*"
 
 "@types/node@*":
   version "9.6.1"
@@ -1794,10 +1809,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-
 fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
@@ -2830,6 +2841,10 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
+node-fetch@~2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
@@ -3604,6 +3619,10 @@ schema-utils@^1.0.0:
 seedrandom@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
+
+seedrandom@~2.4.3:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.4.tgz#b25ea98632c73e45f58b77cfaa931678df01f9ba"
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Updates `tfjs` to the latest version. This was a bit of a pain and involved:
- fixing a bunch of TypeScript errors.
- ~*adding a p dubious `tf.disableDeprecationWarnings();` to the tests, to supress a warning that says "Tensor.get() is deprecated. Use Tensor.array() and native array indexing instead.". I'd love to fix it, but I don't understand who is generating that warning. I've added it to a test file that has two `.get()` calls, but if I comment out those tests then the errors still get generated. *~

I've also changed the demos to import `tfjs` instead of `tfjs-core`, for consistency. I don't know if it makes a difference, and I can revert this change if there was a good reason to have it there.

I've also cleaned up the `package.json` a bit while I was there:
- we were depending on a `fs` package that doesn't exist
- we were depending on an old `tfjs` package that didn't seem to be used