### PR TITLE
documentation improvement, resolves #282

### DIFF
--- a/music/src/music_rnn/model.ts
+++ b/music/src/music_rnn/model.ts
@@ -200,9 +200,13 @@ export class MusicRNN {
    * @param sequence The sequence to continue. Must be quantized.
    * @param steps How many steps to continue.
    * @param temperature (Optional) The softmax temperature to use when sampling
-   * from the logits. Argmax is used if not provided.
+   * from the logits. Argmax is used if not provided. Temperature can be any
+   * number value above 0, however, anything above 1.5 will essentially result
+   * in random results.
    * @param chordProgression (Optional) Chord progression to use as
-   * conditioning.
+   * conditioning.  A chord progression param is an array of chords that are
+   * passed to the [tonal package](https://github.com/danigb/tonal) for parsing,
+   * so they're in that format. Example: ["G", "Em", "C", "D"]
    */
   async continueSequence(
       sequence: INoteSequence, steps: number, temperature?: number,


### PR DESCRIPTION
As per @notwaldorf suggestion, here is a PR adding some documentation on the format of the optional params of `continueSequence`. Resolves #282 
I added a link to the Tonal package's GitHub since I thought it was better than the npm link but let me know if that's not correct.
I also tested the documentation generation but noticed in the history of this project that the documentation is only generated when we reach a release milestone so I didn't commit the generated doc changes.