### PR TITLE
Fix compilation error

### DIFF
--- a/music/tsconfig.json
+++ b/music/tsconfig.json
@@ -19,7 +19,8 @@
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
     "allowUnreachableCode": false,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "skipLibCheck": true
   },
   "include": [ "src/" ]
 }


### PR DESCRIPTION
When trying to `yarn build` inside music, we were getting a:

```
Interface 'NumericTensor<R>' incorrectly extends interface 'Tensor<R>'.
  Types of property 'data' are incompatible.
```

According to this [Issue](https://github.com/tensorflow/tfjs/issues/1645), the way to fix it is to add this typescript config.

Cheers