### PR TITLE
Fixes glitches/pops in the SoundFontPlayer

### DIFF
--- a/music/src/core/soundfont.ts
+++ b/music/src/core/soundfont.ts
@@ -217,12 +217,17 @@ export class Instrument {
           duration} > ${this.durationSeconds}`);
     }
 
-    const source = new Tone.BufferSource(buffer).connect(output);
+    const source = new Tone
+                       .BufferSource({
+                         buffer,
+                         fadeOut: this.FADE_SECONDS,
+                       })
+                       .connect(output);
     source.start(startTime, 0, undefined, 1, 0);
     if (!this.percussive && duration < this.durationSeconds) {
       // Fade to the note release.
       const releaseSource = new Tone.BufferSource(buffer).connect(output);
-      source.stop(startTime + duration + this.FADE_SECONDS, this.FADE_SECONDS);
+      source.stop(startTime + duration + this.FADE_SECONDS);
       releaseSource.start(
           startTime + duration, this.durationSeconds, undefined, 1,
           this.FADE_SECONDS);


### PR DESCRIPTION
https://github.com/tensorflow/magenta-js/issues/329

The `fadeOut` value was no longer being supplied correctly the to the `BufferSource` in the `SoundFontPlayer` after the upgrade to Tone.js 13. 

To repro, just run the `players` demo and play the soundfont players, particularly the multi-instrument version. This PR fixes all detectable pops/glitches