### PR TITLE
Fixed erroneous dispose

### DIFF
--- a/music/src/gansynth/model.ts
+++ b/music/src/gansynth/model.ts
@@ -68,8 +68,8 @@ class GANSynth {
         if (v.includes('kernel')) {
           const fanIn = vars[v].shape[0] * vars[v].shape[1] * vars[v].shape[2];
           const tmp = vars[v];
-          vars[v].dispose();
           vars[v] = tf.mul(tmp, tf.sqrt(2 / fanIn));
+          tmp.dispose();
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/tensorflow/magenta-js/issues/324

Dispose was being called on a tensor before it was used. Moved the dispose to after. `demos/gansynth.ts` works now and leaks 0 bytes of memory.