### PR TITLE
Use a non-negative begin value for tf.slice() in MusicVAE Model.decode().

### DIFF
--- a/music/src/music_vae/model.ts
+++ b/music/src/music_vae/model.ts
@@ -494,9 +494,11 @@ class ConductorDecoder extends Decoder {
         }
         samples.push(tf.concat(currSamples, -1));
         initialInput = currSamples.map(
-            s => s.slice([0, -1, 0], [batchSize, 1, s.shape[s.rank - 1]])
-                     .squeeze([1])
-                     .toFloat() as tf.Tensor2D);
+          s => s.slice(
+                    [0, s.shape[1] - 1, 0],
+                    [batchSize, 1, s.shape[s.rank - 1]])
+                   .squeeze([1])
+                   .toFloat() as tf.Tensor2D);
       }
       return tf.concat(samples, 1);
     });


### PR DESCRIPTION
TensorFlow.js does not support negative start indexing (nor does TensorFlow python).

I'm going to make a change to tfjs-core to throw a better error message in this case.

Sorry about the weirdness!