### PR TITLE
remove docs generation from publishing step

### DIFF
--- a/music/package.json
+++ b/music/package.json
@@ -49,7 +49,7 @@
     "webpack-node-externals": "^1.7.2"
   },
   "scripts": {
-    "prepublish": "in-publish && yarn lint && yarn test && yarn build && yarn test-node-build && yarn docs || not-in-publish",
+    "prepublish": "in-publish && yarn lint && yarn test && yarn build && yarn test-node-build || not-in-publish",
     "build:es5": "webpack --config ./webpack/es5.lib.config.ts",
     "build:es6": "webpack --config webpack/es6.config.ts && cp src/protobuf/proto.* es6/protobuf",
     "build:node": "webpack --config webpack/node.config.ts && cp src/protobuf/proto.* node/protobuf",

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -85,7 +85,7 @@ mkdir -p $tmpDir/demos
 cp demos/*.{js,html,mid,css} $tmpDir/demos | true
 
 # Switch to gh-pages and update docs.
-git checkout gh-pages
+git checkout --track origin/gh-pages
 cd $baseDir
 git rm -fr $PKG_NAME
 # Use rsync instead of cp so that we don't clobber untracked files.


### PR DESCRIPTION
- script needs to check out the correct gh-page
- docs can't be in the publish pipeline because it's racy (publishing modifies the package.json file which means it can't then switch to the gh-pages branch for docs because it's got unstashed changes). also, docs shouldn't break publishing a release.