### PR TITLE
Remove quantized info from return of sequence.unquantizeSequence

### DIFF
--- a/music/src/core/sequences.ts
+++ b/music/src/core/sequences.ts
@@ -386,6 +386,10 @@ export function unquantizeSequence(qns: INoteSequence, qpm?: number) {
     n.endTime = stepToSeconds(n.quantizedEndStep);
     // Extend sequence if necessary.
     ns.totalTime = Math.max(ns.totalTime, n.endTime);
+
+    // Delete the quantized step information.
+    delete n.quantizedStartStep;
+    delete n.quantizedEndStep;
   });
 
   // Also quantize control changes and text annotations.
@@ -393,6 +397,8 @@ export function unquantizeSequence(qns: INoteSequence, qpm?: number) {
     // Quantize the event time, disallowing negative time.
     event.time = stepToSeconds(event.time);
   });
+  delete ns.totalQuantizedSteps;
+  delete ns.quantizationInfo;
   return ns;
 }
 

--- a/music/src/core/sequences_test.ts
+++ b/music/src/core/sequences_test.ts
@@ -458,12 +458,19 @@ function testUnQuantize(
 
   const ns = sequences.unquantizeSequence(qns, finalQpm);
 
-  const expectedSequence = sequences.clone(qns);
-  expectedSequence.notes.map((n, i) => {
-    n.startTime = expectedTimes[i][0];
-    n.endTime = expectedTimes[i][1];
+  const expectedSequence = NoteSequence.create();
+  expectedSequence.timeSignatures = ns.timeSignatures;
+  qns.notes.forEach((n, i) => {
+    expectedSequence.notes.push({
+      pitch: n.pitch,
+      instrument: n.instrument,
+      velocity: n.velocity,
+      startTime: expectedTimes[i][0],
+      endTime: expectedTimes[i][1]
+    });
   });
   expectedSequence.totalTime = expectedTotalTime;
+
   if (!finalQpm && !originalQpm) {
     expectedSequence.tempos = [];
   } else {
@@ -710,8 +717,7 @@ test(
           {stepsPerQuarter: STEPS_PER_QUARTER});
 
       addQuantizedTrackToSequence(expected, 0, [
-        [60, 100, 0, 4], [72, 100, 2, 6], [59, 100, 10, 14],
-        [71, 100, 11, 16]
+        [60, 100, 0, 4], [72, 100, 2, 6], [59, 100, 10, 14], [71, 100, 11, 16]
       ]);
       expected.quantizationInfo = NoteSequence.QuantizationInfo.create(
           {stepsPerQuarter: STEPS_PER_QUARTER});


### PR DESCRIPTION
The comment for `unquantizeSequence` says "quantization info and steps will be removed" but that wasn't actually true -- all the quantized steps and stuff remained, so the return of that function actually looked like a quantized sequence to everything in magenta.js.