### PR TITLE
Note data attributes in SVG piano roll

### DIFF
--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -324,10 +324,7 @@ export class Visualizer extends PianoRollCanvasVisualizer {
 /**
  * HTML data attribute key-value pair.
  */
-interface DataAttribute {
-  key: string;
-  value: any; // tslint:disable-line:no-any
-}
+type DataAttribute = [string, any]; // tslint:disable-line:no-any
 
 /**
  * Displays a pianoroll as an SVG. Pitches are the vertical axis and time is
@@ -430,12 +427,12 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
       const note = this.noteSequence.notes[i];
       const size = this.getNotePosition(note, i);
       const fill = this.getNoteFillColor(note, false);
-      const dataAttributes = [
-        {key: 'index', value: i},
-        {key: 'instrument', value: note.instrument},
-        {key: 'program', value: note.program},
-        {key: 'isDrum', value: note.isDrum === true},
-        {key: 'pitch', value: note.pitch},
+      const dataAttributes : DataAttribute[] = [
+        ['index', i],
+        ['instrument', note.instrument],
+        ['program', note.program],
+        ['isDrum', note.isDrum === true],
+        ['pitch', note.pitch],
       ];
 
       this.drawNote(size.x, size.y, size.w, size.h, fill, dataAttributes);
@@ -467,9 +464,9 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
     rect.setAttribute('y', `${Math.round(y)}`);
     rect.setAttribute('width', `${Math.round(w)}`);
     rect.setAttribute('height', `${Math.round(h)}`);
-    dataAttributes.forEach((attr: DataAttribute) => {
-      if (attr.value !== undefined) {
-        rect.dataset[attr.key] = `${attr.value}`;
+    dataAttributes.forEach(([key, value]: DataAttribute) => {
+      if (value !== undefined) {
+        rect.dataset[key] = `${value}`;
       }
     });
     this.svg.appendChild(rect);

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -320,6 +320,15 @@ export class Visualizer extends PianoRollCanvasVisualizer {
         'mm.Visualizer', logging.Level.WARN);
   }
 }
+
+/**
+ * HTML data attribute key-value pair.
+ */
+interface DataAttribute {
+  key: string;
+  value: any; // tslint:disable-line:no-any
+}
+
 /**
  * Displays a pianoroll as an SVG. Pitches are the vertical axis and time is
  * the horizontal. When connected to a player, the visualizer can also highlight
@@ -421,13 +430,13 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
       const note = this.noteSequence.notes[i];
       const size = this.getNotePosition(note, i);
       const fill = this.getNoteFillColor(note, false);
-      const dataAttributes = {
-        'index': i,
-        'instrument': note.instrument,
-        'program': note.program,
-        'is-drum': note.isDrum === true,
-        'pitch': note.pitch,
-      };
+      const dataAttributes = [
+        {key: 'index', value: i},
+        {key: 'instrument', value: note.instrument},
+        {key: 'program', value: note.program},
+        {key: 'isDrum', value: note.isDrum === true},
+        {key: 'pitch', value: note.pitch},
+      ];
 
       this.drawNote(size.x, size.y, size.w, size.h, fill, dataAttributes);
     }
@@ -445,7 +454,7 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
 
   private drawNote(
       x: number, y: number, w: number, h: number, fill: string,
-      dataAttributes: {[attr: string]: any}) { // tslint:disable-line:no-any
+      dataAttributes: DataAttribute[]) {
     if (!this.svg) {
       return;
     }
@@ -458,11 +467,11 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
     rect.setAttribute('y', `${Math.round(y)}`);
     rect.setAttribute('width', `${Math.round(w)}`);
     rect.setAttribute('height', `${Math.round(h)}`);
-    for (const attr in dataAttributes) {
-      if (dataAttributes[attr] !== undefined) {
-        rect.setAttribute('data-' + attr, dataAttributes[attr]);
+    dataAttributes.forEach((attr: DataAttribute) => {
+      if (attr.value !== undefined) {
+        rect.dataset[attr.key] = `${attr.value}`;
       }
-    }
+    });
     this.svg.appendChild(rect);
   }
 

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -421,8 +421,15 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
       const note = this.noteSequence.notes[i];
       const size = this.getNotePosition(note, i);
       const fill = this.getNoteFillColor(note, false);
+      const dataAttributes = {
+        'index': i,
+        'instrument': note.instrument,
+        'program': note.program,
+        'is-drum': note.isDrum === true,
+        'pitch': note.pitch,
+      };
 
-      this.drawNote(size.x, size.y, size.w, size.h, fill, i);
+      this.drawNote(size.x, size.y, size.w, size.h, fill, dataAttributes);
     }
     this.drawn = true;
   }
@@ -437,7 +444,8 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
   }
 
   private drawNote(
-      x: number, y: number, w: number, h: number, fill: string, index: number) {
+      x: number, y: number, w: number, h: number, fill: string,
+      dataAttributes: {[attr: string]: any}) { // tslint:disable-line:no-any
     if (!this.svg) {
       return;
     }
@@ -450,7 +458,11 @@ export class PianoRollSVGVisualizer extends BaseVisualizer {
     rect.setAttribute('y', `${Math.round(y)}`);
     rect.setAttribute('width', `${Math.round(w)}`);
     rect.setAttribute('height', `${Math.round(h)}`);
-    rect.setAttribute('data-index', `${index}`);
+    for (const attr in dataAttributes) {
+      if (dataAttributes[attr] !== undefined) {
+        rect.setAttribute('data-' + attr, dataAttributes[attr]);
+      }
+    }
     this.svg.appendChild(rect);
   }
 


### PR DESCRIPTION
Enhancing the `rect` elements in `PianoRollSVGVisualizer` with data attributes like `data-program`, `data-is-drum`, `data-instrument`.

Now we can style notes by instrument using CSS and have colorful piano rolls like this:
![image](https://user-images.githubusercontent.com/8046580/73880012-d7543580-485d-11ea-8a87-729b5e63f652.png)
