### PR TITLE
export the audio utils

### DIFF
--- a/music/src/core/audio_utils.ts
+++ b/music/src/core/audio_utils.ts
@@ -202,7 +202,7 @@ function magSpectrogram(
   return [spec, nFft];
 }
 
-function stft(y: Float32Array, params: SpecParams): Float32Array[] {
+export function stft(y: Float32Array, params: SpecParams): Float32Array[] {
   const nFft = params.nFft || 2048;
   const winLength = params.winLength || nFft;
   const hopLength = params.hopLength || Math.floor(winLength / 4);

--- a/music/src/core/index.ts
+++ b/music/src/core/index.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as audio_utils from './audio_utils';
 import * as aux_inputs from './aux_inputs';
 import * as chords from './chords';
 import * as constants from './constants';
@@ -23,7 +24,7 @@ import * as logging from './logging';
 import * as performance from './performance';
 import * as sequences from './sequences';
 
-export {aux_inputs, chords, constants, data, logging, performance, sequences};
+export {audio_utils, aux_inputs, chords, constants, data, logging, performance, sequences};
 
 export * from './metronome';
 export * from './midi_io';


### PR DESCRIPTION
Fixes https://github.com/tensorflow/magenta-js/issues/393

(I don't remember if there's a reason why we don't explicitly export the audio_utils btw)