### PR TITLE
always play all notes, regardless of click sequence

### DIFF
--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -178,11 +178,8 @@ export abstract class BasePlayer {
         return;
       }
 
-      if (this.playClick ||
-          (n.pitch !== constants.LO_CLICK_PITCH &&
-           n.pitch !== constants.HI_CLICK_PITCH)) {
-        this.playNote(t, n);
-      }
+      this.playNote(t, n);
+      
       if (this.callbackObject) {
         Tone.Draw.schedule(() => {
           this.callbackObject.run(n, t);


### PR DESCRIPTION
Should fix #573.

I'm not sure what the conditional was supposed to do originally, but currently if we are *not* using a click track (which is most people), the player skips any pitches that are 89 or 90 (which we have reserved for the clicks). The clicks are only added to the sequence itself if it was originally created with a click (https://github.com/magenta/magenta-js/blob/master/music/src/core/player.ts#L160) so I think this should be ok and shouldn't break anything? Gahhhh.
