### PR TITLE
don't panic when notes can't be played

### DIFF
--- a/music/src/core/soundfont.ts
+++ b/music/src/core/soundfont.ts
@@ -216,6 +216,9 @@ export class Instrument {
       pitch: number, velocity: number, startTime: number, duration: number,
       output: any) {  // tslint:disable-line:no-any
     const buffer = this.getBuffer(pitch, velocity);
+    if (!buffer) {
+      return;
+    }
 
     if (duration > this.durationSeconds) {
       logging.log(
@@ -258,6 +261,9 @@ export class Instrument {
       pitch: number, velocity: number,
       output: any) {  // tslint:disable-line:no-any
     const buffer = this.getBuffer(pitch, velocity);
+    if (!buffer) {
+      return;
+    }
     const source = new Tone.ToneBufferSource(buffer).connect(output);
     source.start(0, 0, undefined, 1);
     if (this.sourceMap.has(pitch)) {
@@ -284,6 +290,9 @@ export class Instrument {
       return;
     }
     const buffer = this.getBuffer(pitch, velocity);
+    if (!buffer) {
+      return;
+    }
 
     // Fade to the note release.
     const releaseSource = new Tone


### PR DESCRIPTION
Fixes #581

If a note is out of range we already log it but return a null buffer, which we still try to pass to Tone.js to play, and we really shouldn't since we know it's not going to work (and in particular, Tone throwing the error we're causing messes up other notes at that time)