### PR TITLE
Export soundfont

### DIFF
--- a/music/src/core/index.ts
+++ b/music/src/core/index.ts
@@ -23,6 +23,7 @@ import * as logging from './logging';
 import * as melodies from './melodies';
 import * as performance from './performance';
 import * as sequences from './sequences';
+import * as soundfont from './soundfont';
 
 export {
   aux_inputs,
@@ -32,7 +33,8 @@ export {
   logging,
   melodies,
   performance,
-  sequences
+  sequences,
+  soundfont
 };
 
 export * from './metronome';


### PR DESCRIPTION
Make soundfond functionality accessible as `core.soundfont` (or `mm.soundfont`). This is useful when someone wants to create a player similiar to `SoundFontPlayer`.

Current workaround is to use the `SoundFontPlayer`, let it create the `SoundFont` instance and then use it in the derived class via the `soundfont` member.